### PR TITLE
Fix runFluid -parallel error

### DIFF
--- a/FSI/flap_perp/OpenFOAM-CalculiX/runFluid
+++ b/FSI/flap_perp/OpenFOAM-CalculiX/runFluid
@@ -35,14 +35,12 @@ checkMesh -case Fluid
 # Run
 cd Fluid
 	solver=$(getApplication)
+	procs=$(getNumberOfProcessors)
 cd ..
 if [ $parallel -eq 1 ]; then
     decomposePar -force -case Fluid
-    mpirun -np $(getNumberOfProcessors) $solver -parallel -case Fluid
+    mpirun -np $procs $solver -parallel -case Fluid
     reconstructPar -case Fluid
 else
     $solver -case Fluid
 fi
-
-# Workaround for issue #26
-./removeObsoleteFolders.sh

--- a/FSI/flap_perp/OpenFOAM-CalculiX/runFluid
+++ b/FSI/flap_perp/OpenFOAM-CalculiX/runFluid
@@ -44,3 +44,6 @@ if [ $parallel -eq 1 ]; then
 else
     $solver -case Fluid
 fi
+
+# Workaround for issue #26
+./removeObsoleteFolders.sh


### PR DESCRIPTION
The function getNumberOfProcessors needs to be called in the Fluid directory to work properly. I am running the script with openfoam 5 (.org version). Can you confirm this? Is it different for .com version?