### PR TITLE
Adding complex interface case in HT fenics-fenics tutorial

### DIFF
--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -51,17 +51,13 @@ def determine_gradient(V_g, u, flux):
     solve(a == L, flux)
 
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(description='Solving heat equation for simple or complex interface case')
 parser.add_argument("-d", "--dirichlet", help="create a dirichlet problem", dest='dirichlet', action='store_true')
 parser.add_argument("-n", "--neumann", help="create a neumann problem", dest='neumann', action='store_true')
 parser.add_argument("-g", "--gamma", help="parameter gamma to set temporal dependence of heat flux", default=0.0, type=float)
 parser.add_argument("-a", "--arbitrary-coupling-interface", help="uses more general, but less exact method for interpolation on coupling interface, see https://github.com/precice/fenics-adapter/milestone/1", dest='arbitrary_coupling_interface', action='store_true')
-parser.add_argument("-dl", "--domain-left", help="right part of the domain is being computed", dest='domain_left', action='store_true')
-parser.add_argument("-dr", "--domain-right", help="left part of the domain is being computed", dest='domain_right', action='store_true')
-parser.add_argument("-is", "--simple_interface", help="Interface defined is a straight line", dest='simple_interface', action='store_true')
-parser.add_argument("-ic", "--complex_interface", help="Interface defined is circular", dest='complex_interface', action='store_true')
-parser.add_argument("-dc", "--domain_circular", help="domain inside circular part is being computed", dest='domain_circular', action='store_true')
-parser.add_argument("-dnc", "--domain_rest", help="domain excluding circular part is being computed", dest='domain_rest', action='store_true')
+parser.add_argument("-interface", metavar="interface_type string", type=str, nargs=1, help="Type of geometric interface to be solved: simple or complex", dest='interface')
+parser.add_argument("-domain", metavar='domain_type string', type=str, nargs=1, help="Part of domain being solved. For simple interface the options are left and right, for complex interface the options are circular and rest", dest='domain')
 
 args = parser.parse_args()
 

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -32,7 +32,6 @@ from errorcomputation import compute_errors
 from my_enums import ProblemType, DomainPart, Subcyling
 import argparse
 import numpy as np
-import mshr
 from problem_setup import OuterBoundary, CouplingBoundary, get_geometry, get_problem_setup
 
 
@@ -79,9 +78,6 @@ if not (args.dirichlet or args.neumann):
     raise Exception("you have to choose either a dirichlet problem (option -d) or a neumann problem (option -n)")
 
 
-# coupling parameters
-
-
 # Create mesh and define function space
 if problem is ProblemType.DIRICHLET:
     adapter_config_filename = "precice-adapter-config-D.json"
@@ -113,7 +109,9 @@ alpha = 3  # parameter alpha
 beta = 1.3  # parameter beta
 gamma = args.gamma  # parameter gamma, dependence of heat flux on time
 
+print("problem = {}".format(problem))
 domain_part = get_problem_setup(args, problem)
+print("domain_part = {}".format(domain_part))
 mesh = get_geometry(args, domain_part)
 
 V = FunctionSpace(mesh, 'P', 2)

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -124,7 +124,10 @@ f_N = Expression('2 * gamma*t*x[0] + 2 * (1-gamma)*x[0] ', degree=1, gamma=gamma
 f_N_function = interpolate(f_N, V)
 
 coupling_boundary = CouplingBoundary()
+coupling_boundary.get_user_input_args(args)
+
 remaining_boundary = OuterBoundary()
+remaining_boundary.get_user_input_args(args)
 
 bcs = [DirichletBC(V, u_D, remaining_boundary)]
 # Define initial value

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -55,9 +55,9 @@ parser = argparse.ArgumentParser(description='Solving heat equation for simple o
 parser.add_argument("-d", "--dirichlet", help="create a dirichlet problem", dest='dirichlet', action='store_true')
 parser.add_argument("-n", "--neumann", help="create a neumann problem", dest='neumann', action='store_true')
 parser.add_argument("-g", "--gamma", help="parameter gamma to set temporal dependence of heat flux", default=0.0, type=float)
-parser.add_argument("-a", "--arbitrary-coupling-interface", help="uses more general, but less exact method for interpolation on coupling interface, see https://github.com/precice/fenics-adapter/milestone/1", dest='arbitrary_coupling_interface', action='store_true')
-parser.add_argument("-interface", metavar="interface_type string", type=str, nargs=1, choices=['simple', 'complex'], help="Type of coupling interface case to be solved. Options: simple, complex", dest='interface')
-parser.add_argument("-domain", metavar='domain_type string', type=str, nargs=1, choices=['left', 'right', 'circular', 'rectangle'], help="Specifying part of the domain being solved. For simple interface the options are left, right, for complex interface the options are circular, rest", dest='domain')
+parser.add_argument("-a", "--arbitrary-coupling-interface", help="uses more general, but less exact method for interpolation on coupling interface, see https://github.com/precice/fenics-adapter/milestone/1", action='store_true')
+parser.add_argument("-i", "--interface", metavar="interface_type string", type=str, choices=['simple', 'complex'], help="Type of coupling interface case to be solved. Options: simple, complex", default="simple")
+parser.add_argument("-dom", "--domain", metavar='domain_type string', type=str, choices=['left', 'right', 'circular', 'rectangle'], help="Specifying part of the domain being solved. For simple interface the options are left, right, for complex interface the options are circular, rest")
 
 args = parser.parse_args()
 

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -89,16 +89,13 @@ beta = 1.3  # parameter beta
 gamma = args.gamma  # parameter gamma, dependence of heat flux on time
 
 domain_part, problem = get_problem_setup(args)
-# print("problem = {}".format(problem))
+mesh, coupling_boundary, remaining_boundary = get_geometry(domain_part)
 
 # Create mesh and define function space
 if problem is ProblemType.DIRICHLET:
     adapter_config_filename = "precice-adapter-config-D.json"
 elif problem is ProblemType.NEUMANN:
     adapter_config_filename = "precice-adapter-config-N.json"
-
-# print("domain_part = {}".format(domain_part))
-mesh, coupling_boundary, remaining_boundary = get_geometry(args, domain_part)
 
 V = FunctionSpace(mesh, 'P', 2)
 

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -56,29 +56,12 @@ parser.add_argument("-d", "--dirichlet", help="create a dirichlet problem", dest
 parser.add_argument("-n", "--neumann", help="create a neumann problem", dest='neumann', action='store_true')
 parser.add_argument("-g", "--gamma", help="parameter gamma to set temporal dependence of heat flux", default=0.0, type=float)
 parser.add_argument("-a", "--arbitrary-coupling-interface", help="uses more general, but less exact method for interpolation on coupling interface, see https://github.com/precice/fenics-adapter/milestone/1", dest='arbitrary_coupling_interface', action='store_true')
-parser.add_argument("-interface", metavar="interface_type string", type=str, nargs=1, help="Type of geometric interface to be solved: simple or complex", dest='interface')
-parser.add_argument("-domain", metavar='domain_type string', type=str, nargs=1, help="Part of domain being solved. For simple interface the options are left and right, for complex interface the options are circular and rest", dest='domain')
+parser.add_argument("-interface", metavar="interface_type string", type=str, nargs=1, help="Type of coupling interface case to be solved. Options: simple, complex", dest='interface')
+parser.add_argument("-domain", metavar='domain_type string', type=str, nargs=1, help="Specifying part of the domain being solved. For simple interface the options are left, right, for complex interface the options are circular, rest", dest='domain')
 
 args = parser.parse_args()
 
 config_file_name = "precice-config.xml"  # TODO should be moved into config, see https://github.com/precice/fenics-adapter/issues/5 , in case file doesnt not exsist open will fail
-
-# coupling parameters
-if args.dirichlet:
-    problem = ProblemType.DIRICHLET
-if args.neumann:
-    problem = ProblemType.NEUMANN
-if args.dirichlet and args.neumann:
-    raise Exception("you can only choose either a dirichlet problem (option -d) or a neumann problem (option -n)")
-if not (args.dirichlet or args.neumann):
-    raise Exception("you have to choose either a dirichlet problem (option -d) or a neumann problem (option -n)")
-
-
-# Create mesh and define function space
-if problem is ProblemType.DIRICHLET:
-    adapter_config_filename = "precice-adapter-config-D.json"
-elif problem is ProblemType.NEUMANN:
-    adapter_config_filename = "precice-adapter-config-N.json"
 
 subcycle = Subcyling.NONE
 
@@ -105,8 +88,15 @@ alpha = 3  # parameter alpha
 beta = 1.3  # parameter beta
 gamma = args.gamma  # parameter gamma, dependence of heat flux on time
 
+domain_part, problem = get_problem_setup(args)
 print("problem = {}".format(problem))
-domain_part = get_problem_setup(args, problem)
+
+# Create mesh and define function space
+if problem is ProblemType.DIRICHLET:
+    adapter_config_filename = "precice-adapter-config-D.json"
+elif problem is ProblemType.NEUMANN:
+    adapter_config_filename = "precice-adapter-config-N.json"
+
 print("domain_part = {}".format(domain_part))
 mesh = get_geometry(args, domain_part)
 

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -68,8 +68,9 @@ subcycle = Subcyling.NONE
 # for all scenarios, we assume precice_dt == .1
 if subcycle is Subcyling.NONE and not args.arbitrary_coupling_interface:
     fenics_dt = .1  # time step size
-    error_tol = 10 ** -7  # Error is bounded by coupling accuracy. In theory we would obtain the analytical solution.
-    interpolation_strategy = ExactInterpolationExpression
+    error_tol = 10 ** -2  # Error is bounded by coupling accuracy. In theory we would obtain the analytical solution.
+    # interpolation_strategy = ExactInterpolationExpression
+    interpolation_strategy = GeneralInterpolationExpression
 elif subcycle is Subcyling.NONE and args.arbitrary_coupling_interface:
     fenics_dt = .1  # time step size
     error_tol = 10 ** -1  # error low, if we do not subcycle. In theory we would obtain the analytical solution.

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -68,12 +68,12 @@ subcycle = Subcyling.NONE
 # for all scenarios, we assume precice_dt == .1
 if subcycle is Subcyling.NONE and not args.arbitrary_coupling_interface:
     fenics_dt = .1  # time step size
-    error_tol = 10 ** -2  # Error is bounded by coupling accuracy. In theory we would obtain the analytical solution.
+    error_tol = 10 ** -7  # Error is bounded by coupling accuracy. In theory we would obtain the analytical solution.
     # interpolation_strategy = ExactInterpolationExpression
     interpolation_strategy = ExactInterpolationExpression
 elif subcycle is Subcyling.NONE and args.arbitrary_coupling_interface:
     fenics_dt = .1  # time step size
-    error_tol = 10 ** -1  # error low, if we do not subcycle. In theory we would obtain the analytical solution.
+    error_tol = 10 ** -3  # error low, if we do not subcycle. In theory we would obtain the analytical solution.
     interpolation_strategy = GeneralInterpolationExpression
     # TODO For reasons, why we currently still have a relatively high error, see milestone https://github.com/precice/fenics-adapter/milestone/1
 elif subcycle is Subcyling.MATCHING:

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -93,7 +93,7 @@ if subcycle is Subcyling.NONE and not args.arbitrary_coupling_interface:
     interpolation_strategy = ExactInterpolationExpression
 elif subcycle is Subcyling.NONE and args.arbitrary_coupling_interface:
     fenics_dt = .1  # time step size
-    error_tol = 10 ** -3 # error low, if we do not subcycle. In theory we would obtain the analytical solution.
+    error_tol = 10 ** -3  # error low, if we do not subcycle. In theory we would obtain the analytical solution.
     interpolation_strategy = GeneralInterpolationExpression
     # TODO For reasons, why we currently still have a relatively high error, see milestone https://github.com/precice/fenics-adapter/milestone/1
 elif subcycle is Subcyling.MATCHING:

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -25,63 +25,15 @@ Heat equation with mixed boundary conditions. (Neumann problem)
 """
 
 from __future__ import print_function, division
-from fenics import Function, SubDomain, RectangleMesh, FunctionSpace, Point, Expression, Constant, DirichletBC, \
-    TrialFunction, TestFunction, File, solve, lhs, rhs, grad, inner, dot, dx, ds, interpolate, near, \
-    VectorFunctionSpace
-from enum import Enum
+from fenics import Function, FunctionSpace, Expression, Constant, DirichletBC, TrialFunction, TestFunction, \
+    File, solve, lhs, rhs, grad, inner, dot, dx, ds, interpolate, VectorFunctionSpace
 from fenicsadapter import Adapter, ExactInterpolationExpression, GeneralInterpolationExpression
 from errorcomputation import compute_errors
+from my_enums import ProblemType, DomainPart, Subcyling
 import argparse
 import numpy as np
 import mshr
-
-
-class ProblemType(Enum):
-    """
-    Enum defines problem type. Details see above.
-    """
-    DIRICHLET = 1  # Dirichlet problem
-    NEUMANN = 2  # Neumann problem
-
-
-class DomainPart(Enum):
-    """
-    Enum defines which part of the domain [x_left, x_right] x [y_bottom, y_top] we compute.
-    """
-    LEFT = 1  # left part of domain in simple interface case
-    RIGHT = 2  # right part of domain in simple interface case
-    CIRCULAR = 3 # circular part of domain in complex interface case
-    REST = 4 # domain excluding circular part of complex interface case
-
-
-class Subcyling(Enum):
-    """
-    Enum defines which kind of subcycling is used
-    """
-    NONE = 0  # no subcycling, precice_dt == fenics_dt
-    MATCHING = 1  # subcycling, where fenics_dt fits into precice_dt, mod(precice_dt, fenics_dt) == 0
-    NONMATCHING = 2  # subcycling, where fenics_dt does not fit into precice_dt, mod(precice_dt, fenics_dt) != 0
-
-    # note: the modulo expressions above should be understood in an exact way (no floating point round off problems. For
-    # details, see https://stackoverflow.com/questions/14763722/python-modulo-on-floats)
-
-
-class OuterBoundary(SubDomain):
-    def inside(self, x, on_boundary):
-        tol = 1E-14
-        if on_boundary and not near(x[0], x_coupling, tol) or near(x[1], y_top, tol) or near(x[1], y_bottom, tol):
-            return True
-        else:
-            return False
-
-
-class CouplingBoundary(SubDomain):
-    def inside(self, x, on_boundary):
-        tol = 1E-14
-        if on_boundary and near(x[0], x_coupling, tol):
-            return True
-        else:
-            return False
+from problem_setup import OuterBoundary, CouplingBoundary, get_geometry, get_problem_setup
 
 
 def determine_gradient(V_g, u, flux):
@@ -128,39 +80,9 @@ if not (args.dirichlet or args.neumann):
 
 
 # coupling parameters
-domain_part = ''
 
-if args.simple_interface:
-    if args.domain_left:
-        domain_part = DomainPart.LEFT
-    if args.domain_right:
-        domain_part = DomainPart.RIGHT
-    if args.dirichlet and args.neumann:
-        raise Exception("you can only choose to either compute the left part of the domain (option -dl) or the right part (option -dr)")
-    if not (args.domain_left or args.domain_right):
-        print("Default domain partitioning for simple interface is used: Left part of domain is a Dirichlet-type problem; right part is a Neumann-type problem")
-        if problem is ProblemType.DIRICHLET:
-            domain_part = DomainPart.LEFT
-        elif problem is ProblemType.NEUMANN:
-            domain_part = DomainPart.RIGHT
-
-if args.complex_interface:
-    if args.domain_circular:
-        domain_part = DomainPart.CIRCULAR
-    if args.domain_rest:
-        domain_part = DomainPart.REST
-    if args.dirichlet and args.neumann:
-        raise Exception("you can only choose to either compute the circular part of the domain (option -dc) or the residual part (option -dnc)")
-    if not (args.domain_circular or args.domain_rest):
-        print("Default domain partitioning for complex interface is used: Circular part of domain is a Dirichlet-type problem; Rest of the domain is a Neumann-type problem")
-        if problem is ProblemType.DIRICHLET:
-            domain_part = DomainPart.CIRCULAR
-        elif problem is ProblemType.NEUMANN:
-            domain_part = DomainPart.REST
 
 # Create mesh and define function space
-mesh = ''
-
 if problem is ProblemType.DIRICHLET:
     adapter_config_filename = "precice-adapter-config-D.json"
 elif problem is ProblemType.NEUMANN:
@@ -187,49 +109,12 @@ elif subcycle is Subcyling.NONMATCHING:
     error_tol = 10 ** -1  # error increases. If we use subcycling, we cannot assume that we still get the exact solution.
     # TODO Using waveform relaxation, we should be able to obtain the exact solution here, as well.
 
-nx = 5
-ny = 10
 alpha = 3  # parameter alpha
 beta = 1.3  # parameter beta
 gamma = args.gamma  # parameter gamma, dependence of heat flux on time
-y_bottom, y_top = 0, 1
-x_left, x_right = 0, 2
-x_coupling = 1.5  # x coordinate of coupling interface
-radius = 0.05
-midpoint = Point(0.5, 0.5)
-low_resolution = 2
-high_resolution = 10
-n_vertices = 10
 
-if domain_part is DomainPart.LEFT:
-    nx = nx*3
-elif domain_part is DomainPart.RIGHT:
-    ny = 20
-
-if domain_part is DomainPart.CIRCULAR:
-    n_vertices = n_vertices*3
-elif domain_part is DomainPart.REST:
-    n_vertices = 20
-
-if args.simple_interface:
-    if domain_part is DomainPart.LEFT:
-        p0 = Point(x_left, y_bottom)
-        p1 = Point(x_coupling, y_top)
-    elif domain_part is DomainPart.RIGHT:
-        p0 = Point(x_coupling, y_bottom)
-        p1 = Point(x_right, y_top)
-    mesh = RectangleMesh(p0, p1, nx, ny)
-
-if args.complex_interface:
-    p0 = Point(x_left, y_bottom)
-    p1 = Point(x_right, y_top)
-    whole_domain = mshr.Rectangle(p0, p1)
-    if domain_part is DomainPart.CIRCULAR:
-        circular_domain = mshr.Circle(midpoint, radius, n_vertices)
-        mesh = mshr.generate_mesh(circular_domain, high_resolution, "cgal")
-    elif domain_part is DomainPart.REST:
-        circular_domain = mshr.Circle(midpoint, radius, n_vertices)
-        mesh = mshr.generate_mesh(whole_domain - circular_domain, low_resolution, "cgal")
+domain_part = get_problem_setup(args, problem)
+mesh = get_geometry(args, domain_part)
 
 V = FunctionSpace(mesh, 'P', 2)
 

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -70,7 +70,7 @@ if subcycle is Subcyling.NONE and not args.arbitrary_coupling_interface:
     fenics_dt = .1  # time step size
     error_tol = 10 ** -2  # Error is bounded by coupling accuracy. In theory we would obtain the analytical solution.
     # interpolation_strategy = ExactInterpolationExpression
-    interpolation_strategy = GeneralInterpolationExpression
+    interpolation_strategy = ExactInterpolationExpression
 elif subcycle is Subcyling.NONE and args.arbitrary_coupling_interface:
     fenics_dt = .1  # time step size
     error_tol = 10 ** -1  # error low, if we do not subcycle. In theory we would obtain the analytical solution.

--- a/HT/partitioned-heat/fenics-fenics/my_enums.py
+++ b/HT/partitioned-heat/fenics-fenics/my_enums.py
@@ -15,7 +15,7 @@ class DomainPart(Enum):
     LEFT = 1  # left part of domain in simple interface case
     RIGHT = 2  # right part of domain in simple interface case
     CIRCULAR = 3  # circular part of domain in complex interface case
-    REST = 4  # domain excluding circular part of complex interface case
+    RECTANGLE = 4  # domain excluding circular part of complex interface case
 
 
 class Subcyling(Enum):

--- a/HT/partitioned-heat/fenics-fenics/my_enums.py
+++ b/HT/partitioned-heat/fenics-fenics/my_enums.py
@@ -1,0 +1,30 @@
+from enum import Enum
+
+class ProblemType(Enum):
+    """
+    Enum defines problem type. Details see above.
+    """
+    DIRICHLET = 1  # Dirichlet problem
+    NEUMANN = 2  # Neumann problem
+
+
+class DomainPart(Enum):
+    """
+    Enum defines which part of the domain [x_left, x_right] x [y_bottom, y_top] we compute.
+    """
+    LEFT = 1  # left part of domain in simple interface case
+    RIGHT = 2  # right part of domain in simple interface case
+    CIRCULAR = 3  # circular part of domain in complex interface case
+    REST = 4  # domain excluding circular part of complex interface case
+
+
+class Subcyling(Enum):
+    """
+    Enum defines which kind of subcycling is used
+    """
+    NONE = 0  # no subcycling, precice_dt == fenics_dt
+    MATCHING = 1  # subcycling, where fenics_dt fits into precice_dt, mod(precice_dt, fenics_dt) == 0
+    NONMATCHING = 2  # subcycling, where fenics_dt does not fit into precice_dt, mod(precice_dt, fenics_dt) != 0
+
+    # note: the modulo expressions above should be understood in an exact way (no floating point round off problems. For
+    # details, see https://stackoverflow.com/questions/14763722/python-modulo-on-floats)

--- a/HT/partitioned-heat/fenics-fenics/precice-config.xml
+++ b/HT/partitioned-heat/fenics-fenics/precice-config.xml
@@ -10,7 +10,7 @@
     
     <!-- Data fields that are exchanged between the solvers -->
     <data:scalar name="Temperature"/>
-    <data:scalar name="Flux"/>
+    <data:vector name="Flux"/>
 
     <!-- A common mesh that uses these data fields -->
     <mesh name="DirichletNodes">

--- a/HT/partitioned-heat/fenics-fenics/precice-config.xml
+++ b/HT/partitioned-heat/fenics-fenics/precice-config.xml
@@ -54,8 +54,8 @@
          <max-iterations value="100"/>
          <exchange data="Flux"        mesh="NeumannNodes" from="HeatDirichlet" to="HeatNeumann" />
          <exchange data="Temperature" mesh="NeumannNodes" from="HeatNeumann"   to="HeatDirichlet" initialize="true"/>
-         <relative-convergence-measure data="Flux"        mesh="NeumannNodes" limit="1e-12"/>
-         <relative-convergence-measure data="Temperature" mesh="NeumannNodes" limit="1e-12"/>
+         <relative-convergence-measure data="Flux"        mesh="NeumannNodes" limit="1e-5"/>
+         <relative-convergence-measure data="Temperature" mesh="NeumannNodes" limit="1e-5"/>
          <extrapolation-order value="0"/>
          <post-processing:IQN-ILS> 
 	    <!--PostProc always done on the second participant-->

--- a/HT/partitioned-heat/fenics-fenics/precice-config.xml
+++ b/HT/partitioned-heat/fenics-fenics/precice-config.xml
@@ -54,8 +54,8 @@
          <max-iterations value="100"/>
          <exchange data="Flux"        mesh="NeumannNodes" from="HeatDirichlet" to="HeatNeumann" />
          <exchange data="Temperature" mesh="NeumannNodes" from="HeatNeumann"   to="HeatDirichlet" initialize="true"/>
-         <relative-convergence-measure data="Flux"        mesh="NeumannNodes" limit="1e-5"/>
-         <relative-convergence-measure data="Temperature" mesh="NeumannNodes" limit="1e-5"/>
+         <relative-convergence-measure data="Flux"        mesh="NeumannNodes" limit="1e-12"/>
+         <relative-convergence-measure data="Temperature" mesh="NeumannNodes" limit="1e-12"/>
          <extrapolation-order value="0"/>
          <post-processing:IQN-ILS> 
 	    <!--PostProc always done on the second participant-->

--- a/HT/partitioned-heat/fenics-fenics/problem_setup.py
+++ b/HT/partitioned-heat/fenics-fenics/problem_setup.py
@@ -151,38 +151,3 @@ def get_geometry(domain_part):
         raise Exception("invalid control flow!")
 
     return mesh, coupling_boundary, remaining_boundary
-
-
-def get_facet_normal(mesh):
-    """
-    Manually calculate FacetNormal function
-    :param mesh: fenics mesh
-    :return: vector of facet normals of mesh
-    """
-    """
-    if not mesh.type().dim() == 1:
-        raise ValueError('Only works for 2-D mesh')
-    """
-    vertices = mesh.coordinates()
-    cells = mesh.cells()
-
-    vec1 = vertices[cells[:, 1]] - vertices[cells[:, 0]]
-    normals = vec1[:, [1, 0]] * np.array([1, -1])
-    normals /= np.sqrt((normals**2).sum(axis=1))[:, np.newaxis]
-
-    # Ensure outward pointing normal
-    mesh.init_cell_orientations(Expression(('x[0]', 'x[1]'), degree=1))
-    normals[mesh.cell_orientations() == 1] *= -1
-
-    V = VectorFunctionSpace(mesh, 'DG', 0)
-    norm = Function(V)
-    nv = norm.vector()
-
-    for n in (0, 1):
-        dofmap = V.sub(n).dofmap()
-        for i in range(dofmap.global_dimension()):
-            dof_indices = dofmap.cell_dofs(i)
-            assert len(dof_indices) == 1
-            nv[dof_indices[0]] = normals[i, n]
-
-    return norm

--- a/HT/partitioned-heat/fenics-fenics/problem_setup.py
+++ b/HT/partitioned-heat/fenics-fenics/problem_setup.py
@@ -107,7 +107,7 @@ def get_geometry(args, domain_part):
     elif domain_part is DomainPart.RECTANGLE:
         n_vertices = n_vertices
 
-    if args.interface == ['simple']:
+    if domain_part is DomainPart.LEFT or domain_part is DomainPart.RIGHT:
         if domain_part is DomainPart.LEFT:
             p0 = Point(x_left, y_bottom)
             p1 = Point(x_coupling, y_top)
@@ -116,7 +116,7 @@ def get_geometry(args, domain_part):
             p1 = Point(x_right, y_top)
         mesh = RectangleMesh(p0, p1, nx, ny)
 
-    if args.interface == ['complex']:
+    if domain_part is DomainPart.CIRCULAR or domain_part is DomainPart.RECTANGLE:
         p0 = Point(x_left, y_bottom)
         p1 = Point(x_right, y_top)
         whole_domain = mshr.Rectangle(p0, p1)

--- a/HT/partitioned-heat/fenics-fenics/problem_setup.py
+++ b/HT/partitioned-heat/fenics-fenics/problem_setup.py
@@ -25,6 +25,7 @@ class CouplingBoundary(SubDomain):
     def inside(self, x, on_boundary):
         tol = 1E-14
         if on_boundary and near(x[0], x_coupling, tol):
+            print("Returning True from CouplingBoundary")
             return True
         else:
             return False
@@ -33,33 +34,31 @@ class CouplingBoundary(SubDomain):
 def get_problem_setup(args, problem):
     if args.simple_interface:
         if args.domain_left:
-            domain_part = DomainPart.LEFT
+            return DomainPart.LEFT
         if args.domain_right:
-            domain_part = DomainPart.RIGHT
+            return DomainPart.RIGHT
         if args.dirichlet and args.neumann:
             raise Exception("you can only choose to either compute the left part of the domain (option -dl) or the right part (option -dr)")
         if not (args.domain_left or args.domain_right):
             print("Default domain partitioning for simple interface is used: Left part of domain is a Dirichlet-type problem; right part is a Neumann-type problem")
             if problem is ProblemType.DIRICHLET:
-                domain_part = DomainPart.LEFT
+                return DomainPart.LEFT
             elif problem is ProblemType.NEUMANN:
-                domain_part = DomainPart.RIGHT
+                return DomainPart.RIGHT
 
     if args.complex_interface:
         if args.domain_circular:
-            domain_part = DomainPart.CIRCULAR
+            return DomainPart.CIRCULAR
         if args.domain_rest:
-            domain_part = DomainPart.REST
+            return DomainPart.REST
         if args.dirichlet and args.neumann:
             raise Exception("you can only choose to either compute the circular part of the domain (option -dc) or the residual part (option -dnc)")
         if not (args.domain_circular or args.domain_rest):
             print("Default domain partitioning for complex interface is used: Circular part of domain is a Dirichlet-type problem; Rest of the domain is a Neumann-type problem")
             if problem is ProblemType.DIRICHLET:
-                domain_part = DomainPart.CIRCULAR
+                return DomainPart.CIRCULAR
             elif problem is ProblemType.NEUMANN:
-                domain_part = DomainPart.REST
-
-    return domain_part
+                return DomainPart.REST
 
 
 def get_geometry(args, domain_part):
@@ -88,7 +87,7 @@ def get_geometry(args, domain_part):
         elif domain_part is DomainPart.RIGHT:
             p0 = Point(x_coupling, y_bottom)
             p1 = Point(x_right, y_top)
-        mesh = RectangleMesh(p0, p1, nx, ny)
+        return RectangleMesh(p0, p1, nx, ny)
 
     if args.complex_interface:
         p0 = Point(x_left, y_bottom)
@@ -96,9 +95,8 @@ def get_geometry(args, domain_part):
         whole_domain = mshr.Rectangle(p0, p1)
         if domain_part is DomainPart.CIRCULAR:
             circular_domain = mshr.Circle(midpoint, radius, n_vertices)
-            mesh = mshr.generate_mesh(circular_domain, high_resolution, "cgal")
+            return mshr.generate_mesh(circular_domain, high_resolution, "cgal")
         elif domain_part is DomainPart.REST:
             circular_domain = mshr.Circle(midpoint, radius, n_vertices)
-            mesh = mshr.generate_mesh(whole_domain - circular_domain, low_resolution, "cgal")
+            return mshr.generate_mesh(whole_domain - circular_domain, low_resolution, "cgal")
 
-    return mesh

--- a/HT/partitioned-heat/fenics-fenics/problem_setup.py
+++ b/HT/partitioned-heat/fenics-fenics/problem_setup.py
@@ -1,0 +1,104 @@
+"""
+Problem setup for HT fenics-fenics tutorial
+"""
+
+import numpy as np
+from fenics import SubDomain, Point, RectangleMesh, near
+from my_enums import DomainPart, ProblemType
+import mshr
+
+y_bottom, y_top = 0, 1
+x_left, x_right = 0, 2
+x_coupling = 1.5  # x coordinate of coupling interface
+
+
+class OuterBoundary(SubDomain):
+    def inside(self, x, on_boundary):
+        tol = 1E-14
+        if on_boundary and not near(x[0], x_coupling, tol) or near(x[1], y_top, tol) or near(x[1], y_bottom, tol):
+            return True
+        else:
+            return False
+
+
+class CouplingBoundary(SubDomain):
+    def inside(self, x, on_boundary):
+        tol = 1E-14
+        if on_boundary and near(x[0], x_coupling, tol):
+            return True
+        else:
+            return False
+
+
+def get_problem_setup(args, problem):
+    if args.simple_interface:
+        if args.domain_left:
+            domain_part = DomainPart.LEFT
+        if args.domain_right:
+            domain_part = DomainPart.RIGHT
+        if args.dirichlet and args.neumann:
+            raise Exception("you can only choose to either compute the left part of the domain (option -dl) or the right part (option -dr)")
+        if not (args.domain_left or args.domain_right):
+            print("Default domain partitioning for simple interface is used: Left part of domain is a Dirichlet-type problem; right part is a Neumann-type problem")
+            if problem is ProblemType.DIRICHLET:
+                domain_part = DomainPart.LEFT
+            elif problem is ProblemType.NEUMANN:
+                domain_part = DomainPart.RIGHT
+
+    if args.complex_interface:
+        if args.domain_circular:
+            domain_part = DomainPart.CIRCULAR
+        if args.domain_rest:
+            domain_part = DomainPart.REST
+        if args.dirichlet and args.neumann:
+            raise Exception("you can only choose to either compute the circular part of the domain (option -dc) or the residual part (option -dnc)")
+        if not (args.domain_circular or args.domain_rest):
+            print("Default domain partitioning for complex interface is used: Circular part of domain is a Dirichlet-type problem; Rest of the domain is a Neumann-type problem")
+            if problem is ProblemType.DIRICHLET:
+                domain_part = DomainPart.CIRCULAR
+            elif problem is ProblemType.NEUMANN:
+                domain_part = DomainPart.REST
+
+    return domain_part
+
+
+def get_geometry(args, domain_part):
+    nx = 5
+    ny = 10
+    radius = 0.05
+    midpoint = Point(0.5, 0.5)
+    low_resolution = 2
+    high_resolution = 10
+    n_vertices = 10
+
+    if domain_part is DomainPart.LEFT:
+        nx = nx*3
+    elif domain_part is DomainPart.RIGHT:
+        ny = 20
+
+    if domain_part is DomainPart.CIRCULAR:
+        n_vertices = n_vertices*3
+    elif domain_part is DomainPart.REST:
+        n_vertices = 20
+
+    if args.simple_interface:
+        if domain_part is DomainPart.LEFT:
+            p0 = Point(x_left, y_bottom)
+            p1 = Point(x_coupling, y_top)
+        elif domain_part is DomainPart.RIGHT:
+            p0 = Point(x_coupling, y_bottom)
+            p1 = Point(x_right, y_top)
+        mesh = RectangleMesh(p0, p1, nx, ny)
+
+    if args.complex_interface:
+        p0 = Point(x_left, y_bottom)
+        p1 = Point(x_right, y_top)
+        whole_domain = mshr.Rectangle(p0, p1)
+        if domain_part is DomainPart.CIRCULAR:
+            circular_domain = mshr.Circle(midpoint, radius, n_vertices)
+            mesh = mshr.generate_mesh(circular_domain, high_resolution, "cgal")
+        elif domain_part is DomainPart.REST:
+            circular_domain = mshr.Circle(midpoint, radius, n_vertices)
+            mesh = mshr.generate_mesh(whole_domain - circular_domain, low_resolution, "cgal")
+
+    return mesh

--- a/HT/partitioned-heat/fenics-fenics/problem_setup.py
+++ b/HT/partitioned-heat/fenics-fenics/problem_setup.py
@@ -2,7 +2,7 @@
 Problem setup for HT fenics-fenics tutorial
 """
 
-from fenics import SubDomain, Point, RectangleMesh, near
+from fenics import SubDomain, Point, RectangleMesh, near, Function, VectorFunctionSpace, Expression
 from my_enums import DomainPart, ProblemType
 import mshr
 
@@ -135,3 +135,37 @@ def get_geometry(args, domain_part):
 
     return mesh, coupling_boundary, remaining_boundary
 
+
+def get_facet_normal(mesh):
+    """
+    Manually calculate FacetNormal function
+    :param mesh: fenics mesh
+    :return: vector of facet normals of mesh
+    """
+    """
+    if not mesh.type().dim() == 1:
+        raise ValueError('Only works for 2-D mesh')
+    """
+    vertices = mesh.coordinates()
+    cells = mesh.cells()
+
+    vec1 = vertices[cells[:, 1]] - vertices[cells[:, 0]]
+    normals = vec1[:, [1, 0]] * np.array([1, -1])
+    normals /= np.sqrt((normals**2).sum(axis=1))[:, np.newaxis]
+
+    # Ensure outward pointing normal
+    mesh.init_cell_orientations(Expression(('x[0]', 'x[1]'), degree=1))
+    normals[mesh.cell_orientations() == 1] *= -1
+
+    V = VectorFunctionSpace(mesh, 'DG', 0)
+    norm = Function(V)
+    nv = norm.vector()
+
+    for n in (0, 1):
+        dofmap = V.sub(n).dofmap()
+        for i in range(dofmap.global_dimension()):
+            dof_indices = dofmap.cell_dofs(i)
+            assert len(dof_indices) == 1
+            nv[dof_indices[0]] = normals[i, n]
+
+    return norm

--- a/HT/partitioned-heat/fenics-fenics/problem_setup.py
+++ b/HT/partitioned-heat/fenics-fenics/problem_setup.py
@@ -27,7 +27,7 @@ class OuterBoundary(SubDomain):
                 return False
         elif self._interface == 'complex':
             point = Point(x[0], x[1])
-            if on_boundary and point.distance(midpoint)**2 - radius**2 > tol or near(x[1], y_top, tol) or near(x[1], y_bottom, tol):
+            if on_boundary and not point.distance(midpoint)**2 - radius**2 < tol:
                 return True
             else:
                 return False

--- a/HT/partitioned-heat/fenics-fenics/problem_setup.py
+++ b/HT/partitioned-heat/fenics-fenics/problem_setup.py
@@ -9,7 +9,7 @@ import mshr
 y_bottom, y_top = 0, 1
 x_left, x_right = 0, 2
 x_coupling = 1.5  # x coordinate of coupling interface
-radius = 0.05
+radius = 0.2
 midpoint = Point(0.5, 0.5)
 
 
@@ -26,7 +26,8 @@ class OuterBoundary(SubDomain):
             else:
                 return False
         if self._complex_interface:
-            if on_boundary and not x[0]**2 + x[1]**2 - radius**2 < tol:
+            point = Point(x[0], x[1])
+            if on_boundary and point.distance(midpoint)**2 - radius**2 > tol or near(x[1], y_top, tol) or near(x[1], y_bottom, tol):
                 return True
             else:
                 return False

--- a/HT/partitioned-heat/fenics-fenics/problem_setup.py
+++ b/HT/partitioned-heat/fenics-fenics/problem_setup.py
@@ -51,35 +51,44 @@ class CouplingBoundary(SubDomain):
                 return False
 
 
-def get_problem_setup(args, problem):
+def get_problem_setup(args):
+    if args.dirichlet:
+        problem = ProblemType.DIRICHLET
+    if args.neumann:
+        problem = ProblemType.NEUMANN
+    if args.dirichlet and args.neumann:
+        raise Exception("you can only choose either a dirichlet problem (option -d) or a neumann problem (option -n)")
+    if not (args.dirichlet or args.neumann):
+        raise Exception("you have to choose either a dirichlet problem (option -d) or a neumann problem (option -n)")
+
     if args.interface == ['simple']:
         if args.domain == ['left']:
             print("Reaching command return DomainPart.LEFT")
-            return DomainPart.LEFT
+            return DomainPart.LEFT, problem
         if args.domain == ['right']:
-            return DomainPart.RIGHT
+            return DomainPart.RIGHT, problem
         if args.dirichlet and args.neumann:
             raise Exception("you can only choose to either compute the left part of the domain (option -dl) or the right part (option -dr)")
         if not (args.domain == ['left'] or args.domain == ['right']):
             print("Default domain partitioning for simple interface is used: Left part of domain is a Dirichlet-type problem; right part is a Neumann-type problem")
             if problem is ProblemType.DIRICHLET:
-                return DomainPart.LEFT
+                return DomainPart.LEFT, problem
             elif problem is ProblemType.NEUMANN:
-                return DomainPart.RIGHT
+                return DomainPart.RIGHT, problem
 
     if args.interface == ['complex']:
         if args.domain == ['circular']:
-            return DomainPart.CIRCULAR
+            return DomainPart.CIRCULAR, problem
         if args.domain == ['rest']:
-            return DomainPart.REST
+            return DomainPart.RECTANGLE, problem
         if args.dirichlet and args.neumann:
             raise Exception("you can only choose to either compute the circular part of the domain (option -dc) or the residual part (option -dnc)")
         if not (args.domain == ['circular'] or args.domain == ['rest']):
             print("Default domain partitioning for complex interface is used: Circular part of domain is a Dirichlet-type problem; Rest of the domain is a Neumann-type problem")
             if problem is ProblemType.DIRICHLET:
-                return DomainPart.CIRCULAR
+                return DomainPart.CIRCULAR, problem
             elif problem is ProblemType.NEUMANN:
-                return DomainPart.REST
+                return DomainPart.RECTANGLE, problem
 
 
 def get_geometry(args, domain_part):
@@ -96,7 +105,7 @@ def get_geometry(args, domain_part):
 
     if domain_part is DomainPart.CIRCULAR:
         n_vertices = n_vertices
-    elif domain_part is DomainPart.REST:
+    elif domain_part is DomainPart.RECTANGLE:
         n_vertices = n_vertices
 
     if args.interface == ['simple']:
@@ -115,7 +124,7 @@ def get_geometry(args, domain_part):
         if domain_part is DomainPart.CIRCULAR:
             circular_domain = mshr.Circle(midpoint, radius, n_vertices)
             return mshr.generate_mesh(circular_domain, high_resolution, "cgal")
-        elif domain_part is DomainPart.REST:
+        elif domain_part is DomainPart.RECTANGLE:
             circular_domain = mshr.Circle(midpoint, radius, n_vertices)
             return mshr.generate_mesh(whole_domain - circular_domain, low_resolution, "cgal")
 

--- a/HT/partitioned-heat/fenics-fenics/problem_setup.py
+++ b/HT/partitioned-heat/fenics-fenics/problem_setup.py
@@ -106,7 +106,7 @@ def get_geometry(domain_part):
     ny = 10
     low_resolution = 5
     high_resolution = 5
-    n_vertices = 3
+    n_vertices = 20
 
     if domain_part is DomainPart.LEFT:
         nx = nx*3

--- a/HT/partitioned-heat/fenics-fenics/problem_setup.py
+++ b/HT/partitioned-heat/fenics-fenics/problem_setup.py
@@ -92,10 +92,10 @@ def get_problem_setup(args):
         elif args.dirichlet and args.neumann:
             raise Exception("you can only choose to either compute the circular part of the domain (option -dc) or the residual part (option -dnc)")
         elif not (args.domain == 'circular' or args.domain == 'rectangle'):
-            print("Default domain partitioning for complex interface is used: Circular part of domain is a Dirichlet-type problem; Rest of the domain is a Neumann-type problem")
-            if problem is ProblemType.DIRICHLET:
+            print("Default domain partitioning for complex interface is used: Circular part of domain is a Neumann-type problem; Rest of the domain is a Dirichlet-type problem")
+            if problem is ProblemType.NEUMANN:
                 return DomainPart.CIRCULAR, problem
-            elif problem is ProblemType.NEUMANN:
+            elif problem is ProblemType.DIRICHLET:
                 return DomainPart.RECTANGLE, problem
     else:
         raise Exception("invalid interface provided: args.interface = {}".format(args.interface))
@@ -111,7 +111,7 @@ def get_geometry(domain_part):
     if domain_part is DomainPart.LEFT:
         nx = nx*3
     elif domain_part is DomainPart.RIGHT:
-        ny = 20
+        ny = ny*2
     elif domain_part is DomainPart.CIRCULAR:
         n_vertices = n_vertices
     elif domain_part is DomainPart.RECTANGLE:

--- a/HT/partitioned-heat/fenics-fenics/problem_setup.py
+++ b/HT/partitioned-heat/fenics-fenics/problem_setup.py
@@ -5,6 +5,7 @@ Problem setup for HT fenics-fenics tutorial
 from fenics import SubDomain, Point, RectangleMesh, near, Function, VectorFunctionSpace, Expression
 from my_enums import DomainPart, ProblemType
 import mshr
+import numpy as np
 
 y_bottom, y_top = 0, 1
 x_left, x_right = 0, 2
@@ -19,17 +20,19 @@ class OuterBoundary(SubDomain):
 
     def inside(self, x, on_boundary):
         tol = 1E-14
-        if self._interface == ['simple']:
+        if self._interface == 'simple':
             if on_boundary and not near(x[0], x_coupling, tol) or near(x[1], y_top, tol) or near(x[1], y_bottom, tol):
                 return True
             else:
                 return False
-        if self._interface == ['complex']:
+        elif self._interface == 'complex':
             point = Point(x[0], x[1])
             if on_boundary and point.distance(midpoint)**2 - radius**2 > tol or near(x[1], y_top, tol) or near(x[1], y_bottom, tol):
                 return True
             else:
                 return False
+        else:
+            raise Exception("invalid!")
 
 
 class CouplingBoundary(SubDomain):
@@ -38,56 +41,65 @@ class CouplingBoundary(SubDomain):
 
     def inside(self, x, on_boundary):
         tol = 1E-14
-        if self._interface == ['simple']:
+        if self._interface == 'simple':
             if on_boundary and near(x[0], x_coupling, tol):
                 return True
             else:
                 return False
-        if self._interface == ['complex']:
+        elif self._interface == 'complex':
             point = Point(x[0], x[1])
             if on_boundary and point.distance(midpoint)**2 - radius**2 < tol:
                 return True
             else:
                 return False
+        else:
+            raise Exception("invalid!")
 
 
 def get_problem_setup(args):
-    if args.dirichlet:
+    if args.dirichlet and not args.neumann:
         problem = ProblemType.DIRICHLET
-    if args.neumann:
+    elif args.neumann and not args.dirichlet:
         problem = ProblemType.NEUMANN
-    if args.dirichlet and args.neumann:
+    elif args.dirichlet and args.neumann:
         raise Exception("you can only choose either a dirichlet problem (option -d) or a neumann problem (option -n)")
-    if not (args.dirichlet or args.neumann):
+    elif not (args.dirichlet or args.neumann):
         raise Exception("you have to choose either a dirichlet problem (option -d) or a neumann problem (option -n)")
+    else:
+        raise Exception("invalid control flow.")
 
-    if args.interface == ['simple']:
-        if args.domain == ['left']:
+    if args.interface == 'simple':
+        if args.domain == 'circular' or args.domain == 'rectangle':
+            raise Exception("Only --domain left or --domain right is supported for --interface {}. Invalid --domain {} provided.".format(args.interface, args.domain))
+        elif args.domain == 'left':
             return DomainPart.LEFT, problem
-        if args.domain == ['right']:
+        elif args.domain == 'right':
             return DomainPart.RIGHT, problem
-        if args.dirichlet and args.neumann:
+        elif args.dirichlet and args.neumann:
             raise Exception("you can only choose to either compute the left part of the domain (option -dl) or the right part (option -dr)")
-        if not (args.domain == ['left'] or args.domain == ['right']):
+        elif not (args.domain == 'left' or args.domain == 'right'):
             print("Default domain partitioning for simple interface is used: Left part of domain is a Dirichlet-type problem; right part is a Neumann-type problem")
             if problem is ProblemType.DIRICHLET:
                 return DomainPart.LEFT, problem
             elif problem is ProblemType.NEUMANN:
                 return DomainPart.RIGHT, problem
-
-    if args.interface == ['complex']:
-        if args.domain == ['circular']:
+    elif args.interface == 'complex':
+        if args.domain == 'left' or args.domain == 'right':
+            raise Exception("Only --domain circular or --domain rectangle is supported for --interface {}. Invalid --domain {} provided.".format(args.interface, args.domain))
+        elif args.domain == 'circular':
             return DomainPart.CIRCULAR, problem
-        if args.domain == ['rectangle']:
+        elif args.domain == 'rectangle':
             return DomainPart.RECTANGLE, problem
-        if args.dirichlet and args.neumann:
+        elif args.dirichlet and args.neumann:
             raise Exception("you can only choose to either compute the circular part of the domain (option -dc) or the residual part (option -dnc)")
-        if not (args.domain == ['circular'] or args.domain == ['rectangle']):
+        elif not (args.domain == 'circular' or args.domain == 'rectangle'):
             print("Default domain partitioning for complex interface is used: Circular part of domain is a Dirichlet-type problem; Rest of the domain is a Neumann-type problem")
             if problem is ProblemType.DIRICHLET:
                 return DomainPart.CIRCULAR, problem
             elif problem is ProblemType.NEUMANN:
                 return DomainPart.RECTANGLE, problem
+    else:
+        raise Exception("invalid interface provided: args.interface = {}".format(args.interface))
 
 
 def get_geometry(args, domain_part):
@@ -101,11 +113,12 @@ def get_geometry(args, domain_part):
         nx = nx*3
     elif domain_part is DomainPart.RIGHT:
         ny = 20
-
-    if domain_part is DomainPart.CIRCULAR:
+    elif domain_part is DomainPart.CIRCULAR:
         n_vertices = n_vertices
     elif domain_part is DomainPart.RECTANGLE:
         n_vertices = n_vertices
+    else:
+        raise Exception("invalid domain_part: {}".format(domain_part))
 
     if domain_part is DomainPart.LEFT or domain_part is DomainPart.RIGHT:
         if domain_part is DomainPart.LEFT:
@@ -114,9 +127,10 @@ def get_geometry(args, domain_part):
         elif domain_part is DomainPart.RIGHT:
             p0 = Point(x_coupling, y_bottom)
             p1 = Point(x_right, y_top)
+        else:
+            raise Exception("invalid control flow!")
         mesh = RectangleMesh(p0, p1, nx, ny)
-
-    if domain_part is DomainPart.CIRCULAR or domain_part is DomainPart.RECTANGLE:
+    elif domain_part is DomainPart.CIRCULAR or domain_part is DomainPart.RECTANGLE:
         p0 = Point(x_left, y_bottom)
         p1 = Point(x_right, y_top)
         whole_domain = mshr.Rectangle(p0, p1)
@@ -126,6 +140,10 @@ def get_geometry(args, domain_part):
         elif domain_part is DomainPart.RECTANGLE:
             circular_domain = mshr.Circle(midpoint, radius, n_vertices)
             mesh = mshr.generate_mesh(whole_domain - circular_domain, low_resolution, "cgal")
+        else:
+            raise Exception("invalid control flow!")
+    else:
+        raise Exception("invalid control flow!")
 
     coupling_boundary = CouplingBoundary()
     coupling_boundary.get_user_input_args(args)


### PR DESCRIPTION
The current heat transfer fenics-fenics tutorial consists of one case in which the interface is a straight edge parallel to the y-axis. A more generalised case of an interface of circular shape is being added in the same tutorial. User can select between two options `simple-interface` and `complex-interface` to compute the respective cases. The aim of this PR is also to verify the nearest_projection mapping implemented in this PR: https://github.com/precice/fenics-adapter/pull/42