### PR TITLE
Consistent log config and format for all cases

### DIFF
--- a/CHT/flow-over-plate/buoyantPimpleFoam-fenics/precice-config_serial.xml
+++ b/CHT/flow-over-plate/buoyantPimpleFoam-fenics/precice-config_serial.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true"/>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/CHT/flow-over-plate/buoyantPimpleFoam-nutils/precice-config.xml
+++ b/CHT/flow-over-plate/buoyantPimpleFoam-nutils/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
   <log>
-    <sink type="stream" output="stdout"  filter= "%Severity% > debug" format="preCICE:%ColorizedSeverity% %Message%" enabled="true" />	
+    <sink filter= "%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true" />	
   </log>
 
   <solver-interface dimensions="3">

--- a/CHT/heat_exchanger/buoyantSimpleFoam-CalculiX/precice-config_parallel.xml
+++ b/CHT/heat_exchanger/buoyantSimpleFoam-CalculiX/precice-config_parallel.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <precice-configuration>
   <log>
-    <sink enabled="true" output="stdout" type="stream"/>
+      <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
   </log>
   <solver-interface dimensions="3">
     <data:scalar name="Heat-Transfer-Coefficient-Solid"/>

--- a/CHT/heat_exchanger/buoyantSimpleFoam-CalculiX/precice-config_serial.xml
+++ b/CHT/heat_exchanger/buoyantSimpleFoam-CalculiX/precice-config_serial.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <precice-configuration>
     <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true"/>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
     <solver-interface dimensions="3">
         <data:scalar name="Heat-Transfer-Coefficient-Solid"/>

--- a/FSI/3D_Tube/OpenFOAM-CalculiX/precice-config_parallel.xml
+++ b/FSI/3D_Tube/OpenFOAM-CalculiX/precice-config_parallel.xml
@@ -2,9 +2,9 @@
 
 <precice-configuration>
 
-    <!-- <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true"/>
-    </log>	-->	
+    <log>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+    </log>
 
    <solver-interface dimensions="3">
 

--- a/FSI/3D_Tube/OpenFOAM-CalculiX/precice-config_serial.xml
+++ b/FSI/3D_Tube/OpenFOAM-CalculiX/precice-config_serial.xml
@@ -2,9 +2,9 @@
 
 <precice-configuration>
 
-    <!-- <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true"/>
-    </log>	-->	
+    <log>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+    </log>
 
    <solver-interface dimensions="3">
 

--- a/FSI/cylinderFlap/OpenFOAM-CalculiX/precice-config_parallel.xml
+++ b/FSI/cylinderFlap/OpenFOAM-CalculiX/precice-config_parallel.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true"/>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/cylinderFlap/OpenFOAM-CalculiX/precice-config_serial.xml
+++ b/FSI/cylinderFlap/OpenFOAM-CalculiX/precice-config_serial.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true"/>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/cylinderFlap/OpenFOAM-FEniCS/precice-config_serial.xml
+++ b/FSI/cylinderFlap/OpenFOAM-FEniCS/precice-config_serial.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true"/>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/cylinderFlap/OpenFOAM-deal.II/precice-config_parallel.xml
+++ b/FSI/cylinderFlap/OpenFOAM-deal.II/precice-config_parallel.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout"  filter= "(%Severity% > debug)" enabled="true" />	
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/cylinderFlap/OpenFOAM-deal.II/precice-config_serial.xml
+++ b/FSI/cylinderFlap/OpenFOAM-deal.II/precice-config_serial.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout"  filter= "(%Severity% > debug)" enabled="true" />	
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/cylinderFlap_2D/OpenFOAM-deal.II/precice-config_parallel.xml
+++ b/FSI/cylinderFlap_2D/OpenFOAM-deal.II/precice-config_parallel.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout"  filter= "(%Severity% > debug)" enabled="true" />	
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="2">

--- a/FSI/cylinderFlap_2D/OpenFOAM-deal.II/precice-config_serial.xml
+++ b/FSI/cylinderFlap_2D/OpenFOAM-deal.II/precice-config_serial.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout"  filter= "(%Severity% > debug)" enabled="true" />	
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="2">

--- a/FSI/flap_perp/OpenFOAM-CalculiX/precice-config_parallel.xml
+++ b/FSI/flap_perp/OpenFOAM-CalculiX/precice-config_parallel.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true"/>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/flap_perp/OpenFOAM-CalculiX/precice-config_serial.xml
+++ b/FSI/flap_perp/OpenFOAM-CalculiX/precice-config_serial.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true"/>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/flap_perp/OpenFOAM-FEniCS/precice-config_serial.xml
+++ b/FSI/flap_perp/OpenFOAM-FEniCS/precice-config_serial.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true"/>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/flap_perp/OpenFOAM-deal.II/precice-config_parallel.xml
+++ b/FSI/flap_perp/OpenFOAM-deal.II/precice-config_parallel.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout"  filter= "(%Severity% > debug)" enabled="true" />	
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/flap_perp/OpenFOAM-deal.II/precice-config_serial.xml
+++ b/FSI/flap_perp/OpenFOAM-deal.II/precice-config_serial.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout"  filter= "(%Severity% > debug)" enabled="true" />	
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/flap_perp/SU2-CalculiX/precice-config_parallel.xml
+++ b/FSI/flap_perp/SU2-CalculiX/precice-config_parallel.xml
@@ -2,6 +2,10 @@
 
 <precice-configuration>
 
+    <log>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+    </log>
+
    <solver-interface dimensions="3">
       <data:vector name="Forces0"/>
       <data:vector name="DisplacementDeltas0"/>

--- a/FSI/flap_perp/SU2-CalculiX/precice-config_serial.xml
+++ b/FSI/flap_perp/SU2-CalculiX/precice-config_serial.xml
@@ -2,6 +2,10 @@
 
 <precice-configuration>
 
+    <log>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+    </log>
+
    <solver-interface dimensions="3">
       <data:vector name="Forces0"/>
       <data:vector name="DisplacementDeltas0"/>

--- a/FSI/flap_perp_2D/OpenFOAM-deal.II/precice-config_parallel.xml
+++ b/FSI/flap_perp_2D/OpenFOAM-deal.II/precice-config_parallel.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout"  filter= "(%Severity% > debug)" enabled="true" />	
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="2">

--- a/FSI/flap_perp_2D/OpenFOAM-deal.II/precice-config_serial.xml
+++ b/FSI/flap_perp_2D/OpenFOAM-deal.II/precice-config_serial.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink type="stream" output="stdout"  filter= "(%Severity% > debug)" enabled="true" />	
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="2">

--- a/HT/partitioned-heat/fenics-fenics/precice-config.xml
+++ b/HT/partitioned-heat/fenics-fenics/precice-config.xml
@@ -2,9 +2,9 @@
 
 <precice-configuration>
 
-  <log enabled="1">
-    <sink filter="%Severity% > debug" />
-  </log>
+    <log>
+        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+    </log>
   
   <solver-interface dimensions="2">
     

--- a/SSI/loaded_beam/CalculiX-CalculiX/precice-config.xml
+++ b/SSI/loaded_beam/CalculiX-CalculiX/precice-config.xml
@@ -2,7 +2,7 @@
 
 <precice-configuration>
    <log>
-      <sink type="stream" output="stdout" filter="(%Severity% > debug)" enabled="true"/>-->
+       <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
    </log>
    <solver-interface dimensions="3">
       <data:vector name="Forces0"/>

--- a/Structure/precice-config.xml
+++ b/Structure/precice-config.xml
@@ -2,8 +2,8 @@
 
 <precice-configuration>
 
-  <log enabled="1">
-    <sink filter="%Severity% > debug" />
+  <log>
+      <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
   </log>
 
   <solver-interface dimensions="2">


### PR DESCRIPTION
This PR applies the same logging configuration and format to all tutorials:

```xml
<log>
    <sink filter= "%Severity% >= debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true" />
</log>
```

Notes:
- Now the preCICE messages will be prepended by `---[precice] `, making them easier to identify. The same style is already used in the OpenFOAM adapter and should be extended to the rest of the adapters (see #41).
- I did not set the (default) `type="stream"` and `output="stdout"` to make the scripts user-fliendlier.

Closes #41.