### PR TITLE
Restrict logger to rank 0 to cope with preCICE v2.0

### DIFF
--- a/CHT/flow-over-plate/buoyantPimpleFoam-fenics/precice-config.xml
+++ b/CHT/flow-over-plate/buoyantPimpleFoam-fenics/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/CHT/flow-over-plate/buoyantPimpleFoam-nutils/precice-config.xml
+++ b/CHT/flow-over-plate/buoyantPimpleFoam-nutils/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
   <log>
-    <sink filter= "%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true" />	
+    <sink filter= "%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true" />	
   </log>
 
   <solver-interface dimensions="3">

--- a/CHT/heat_exchanger/buoyantSimpleFoam-CalculiX/precice-config.xml
+++ b/CHT/heat_exchanger/buoyantSimpleFoam-CalculiX/precice-config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <precice-configuration>
   <log>
-      <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+      <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
   </log>
   <solver-interface dimensions="3">
     <data:scalar name="Heat-Transfer-Coefficient-Solid"/>

--- a/FSI/3D_Tube/OpenFOAM-CalculiX/precice-config.xml
+++ b/FSI/3D_Tube/OpenFOAM-CalculiX/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
    <solver-interface dimensions="3">

--- a/FSI/cylinderFlap/OpenFOAM-CalculiX/precice-config.xml
+++ b/FSI/cylinderFlap/OpenFOAM-CalculiX/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/cylinderFlap/OpenFOAM-FEniCS/precice-config.xml
+++ b/FSI/cylinderFlap/OpenFOAM-FEniCS/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/cylinderFlap/OpenFOAM-deal.II/precice-config.xml
+++ b/FSI/cylinderFlap/OpenFOAM-deal.II/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/cylinderFlap_2D/OpenFOAM-deal.II/precice-config.xml
+++ b/FSI/cylinderFlap_2D/OpenFOAM-deal.II/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="2">

--- a/FSI/flap_perp/OpenFOAM-CalculiX/precice-config.xml
+++ b/FSI/flap_perp/OpenFOAM-CalculiX/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/flap_perp/OpenFOAM-FEniCS/precice-config.xml
+++ b/FSI/flap_perp/OpenFOAM-FEniCS/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/flap_perp/OpenFOAM-deal.II/precice-config.xml
+++ b/FSI/flap_perp/OpenFOAM-deal.II/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="3">

--- a/FSI/flap_perp/SU2-CalculiX/precice-config.xml
+++ b/FSI/flap_perp/SU2-CalculiX/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
    <solver-interface dimensions="3">

--- a/FSI/flap_perp_2D/OpenFOAM-deal.II/precice-config.xml
+++ b/FSI/flap_perp_2D/OpenFOAM-deal.II/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
 
     <solver-interface dimensions="2">

--- a/HT/partitioned-heat/fenics-fenics/precice-config.xml
+++ b/HT/partitioned-heat/fenics-fenics/precice-config.xml
@@ -3,7 +3,7 @@
 <precice-configuration>
 
     <log>
-        <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+        <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
     </log>
   
   <solver-interface dimensions="2">

--- a/SSI/loaded_beam/CalculiX-CalculiX/precice-config.xml
+++ b/SSI/loaded_beam/CalculiX-CalculiX/precice-config.xml
@@ -2,7 +2,7 @@
 
 <precice-configuration>
    <log>
-       <sink filter="%Severity% > debug" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
+       <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
    </log>
    <solver-interface dimensions="3">
       <data:vector name="Forces0"/>


### PR DESCRIPTION
Previously, we explicitly printed INFO statements only for rank 0. This changed with v2.0. Now, instead we set the default of the logger to rank 0. The default gets however overwritten as soon as you set a different logger. So, the logger here also needs to restrict to rank 0 to not have INFO statements for every rank. 

Reviewer: FYI, please try with any arbitrary tutorial (I ran OpenFOAM-Nutils), and merge.