### PR TITLE
cylinderFlap OpenFOAM: Remove residualControl, version-specific

### DIFF
--- a/FSI/3D_Tube/OpenFOAM-CalculiX/Fluid/system/fvSolution
+++ b/FSI/3D_Tube/OpenFOAM-CalculiX/Fluid/system/fvSolution
@@ -7,206 +7,214 @@ FoamFile
     object fvSolution;
 }
 
-    PISO
+PISO
+{
+    nCorrectors 3;
+    nNonOrthogonalCorrectors 2;
+    tolerance 1e-8;
+    relTol 0;
+    maxIter 30;
+    minIter 1;
+    pisoTol 1e-1;
+}
+
+PIMPLE
+{
+    nCorrectors 3;
+    nNonOrthogonalCorrectors 2;
+    tolerance 1e-5;
+    relTol 0;
+    maxIter 30;
+    minIter 1;
+    pisoTol 1e-1;
+}
+
+SIMPLE
+{
+    nCorrectors 3;
+    nNonOrthogonalCorrectors 2;
+    tolerance 1e-5;
+    relTol 0;
+    maxIter 30;
+    minIter 1;
+    pisoTol 1e-1;
+}
+
+blockSolver
+{
+    nCorrectors 3;
+    nNonOrthogonalCorrectors 2;
+    tolerance 1e-5;
+    relTol 0;
+    maxIter 50;
+    nOuterCorrectors 50;
+    minIter 1;
+    pisoTol 1e-1;
+    convergenceTolerance 1e-6;
+}
+
+solvers
+{
+    p
     {
-        nCorrectors 3;
-        nNonOrthogonalCorrectors 2;
-    	tolerance 1e-8;
-    	relTol 0;
-    	maxIter 30;
-    	minIter 1;
-    	pisoTol 1e-1;
+        solver GAMG;
+        agglomerator faceAreaPair;
+        mergeLevels 1;
+        cacheAgglomeration true;
+        nCellsInCoarsestLevel 500;
+        tolerance 1e-7;
+        relTol 1e-1;
+        smoother GaussSeidel;
+        nPreSweeps 1;
+        nPostSweeps 2;
+        nFinestSweeps 2;
+        minIter 1;
+        maxIter 5;
     }
 
-    PIMPLE
+    cellMotionU
     {
-        nCorrectors 3;
-        nNonOrthogonalCorrectors 2;
-    	tolerance 1e-5;
-    	relTol 0;
-    	maxIter 30;
-    	minIter 1;
-    	pisoTol 1e-1;
+        solver           GAMG;
+        tolerance        1e-6;
+        relTol           1e-3;
+        minIter          1;
+        maxIter          1000;
+
+        smoother         GaussSeidel;
+        nPreSweeps       0;
+        nPostSweeps      2;
+        nFinestSweeps    2;
+
+        scaleCorrection true;
+        directSolveCoarsest false;
+
+        cacheAgglomeration true;
+
+        nCellsInCoarsestLevel 20;
+        agglomerator     faceAreaPair;
+        mergeLevels      1;
     }
 
-    SIMPLE
+    Phi
     {
-        nCorrectors 3;
-        nNonOrthogonalCorrectors 2;
-    	tolerance 1e-5;
-    	relTol 0;
-    	maxIter 30;
-    	minIter 1;
-    	pisoTol 1e-1;
+        $p;
     }
 
-    blockSolver
+    "(U|cellDisplacement)"
     {
-        nCorrectors 3;
-        nNonOrthogonalCorrectors 2;
-    	tolerance 1e-5;
-    	relTol 0;
-    	maxIter 50;
-	nOuterCorrectors 50;
-    	minIter 1;
-    	pisoTol 1e-1;
-	convergenceTolerance 1e-6;
+        solver          smoothSolver;
+        smoother        symGaussSeidel;
+        tolerance       1e-10;
+        relTol          1e-6;
     }
 
-    solvers
+    "(U|cellDisplacement)Final"
     {
-        p
-        {
-            solver GAMG;
-            agglomerator faceAreaPair;
-            mergeLevels 1;
-            cacheAgglomeration true;
-            nCellsInCoarsestLevel 500;
-            tolerance 1e-7;
-            relTol 1e-1;
-            smoother GaussSeidel;
-            nPreSweeps 1;
-            nPostSweeps 2;
-            nFinestSweeps 2;
-            minIter 1;
-	    maxIter 5;
-        }
-
-	cellMotionU
-	{
-		solver          GAMG;
-		tolerance        1e-6;
-		relTol           1e-3;
-		minIter          1;
-		maxIter          1000;
-
-		smoother         GaussSeidel;
-		nPreSweeps       0;
-		nPostSweeps      2;
-		nFinestSweeps    2;
-
-		scaleCorrection true;
-		directSolveCoarsest false;
-
-		 cacheAgglomeration true;
-
-		 nCellsInCoarsestLevel 20;
-		 agglomerator     faceAreaPair;
-		 mergeLevels      1;
-	}
-
-     	Phi
-     	{
-     	   $p;
-     	}
-
-     	"(U|cellDisplacement)"
-     	{
-        	solver          smoothSolver;
-        	smoother        symGaussSeidel;
-        	tolerance       1e-10;
-        	relTol          1e-6;
-     	}
-
-     	"(U|cellDisplacement)Final"
-     	{
-        	$U;
-        	relTol          0;
-     	}
-
-	Up
-        {
-            solver BiCGStab;
-	    preconditioner Cholesky;
-	    tolerance 1e-8;
-	    relTol 1e-2;
-            minIter 1;
-	    maxIter 100;
-        }
-
-	"pcorr.*"
-        {
-            solver GAMG;
-            agglomerator faceAreaPair;
-            mergeLevels 1;
-            cacheAgglomeration true;
-            nCellsInCoarsestLevel 500;
-            tolerance 1e-10;
-            relTol 1e-1;
-            smoother GaussSeidel;
-            nPreSweeps 1;
-            nPostSweeps 2;
-            nFinestSweeps 2;
-            minIter 1;
-	    maxIter 5;
-        }
-    
-        pFinal
-        {
-            solver GAMG;
-            agglomerator faceAreaPair;
-            mergeLevels 1;
-            cacheAgglomeration true;
-            nCellsInCoarsestLevel 500;
-            tolerance 1e-10;
-            relTol 1e-1;
-            smoother GaussSeidel;
-            nPreSweeps 1;
-            nPostSweeps 2;
-            nFinestSweeps 2;
-            minIter 1;
-	    maxIter 5;
-        }
-
-        
-        U
-        {
-            solver smoothSolver;
-            smoother GaussSeidel;
-            tolerance 1e-8;
-            relTol 1e-2;
-            minIter 1;
-        }
-
-        
-
-        UFinal
-        {
-            solver smoothSolver;
-            smoother GaussSeidel;
-            tolerance 1e-10;
-            relTol 0;
-            minIter 1;
-        }
-
+        $U;
+        relTol          0;
     }
 
-    residualControl
+    Up
     {
-        U
-        {
-            relTol          0;
-            tolerance       0.0001;
-        }
-        p
-        {
-            relTol          0;
-            tolerance       0.0001;
-        }
-        // possibly check turbulence fields
-        "(k|epsilon|omega)"        {
-            relTol          0;
-            tolerance       0.0001;
-        }
-        
+        solver BiCGStab;
+        preconditioner Cholesky;
+        tolerance 1e-8;
+        relTol 1e-2;
+        minIter 1;
+        maxIter 100;
     }
 
-    relaxationFactors
+    "pcorr.*"
     {
-	U 0.5;
-	UFinal 0.5;
-        p 0.2;
-	pFinal 0.2;
-	Up 0.2;
+        solver GAMG;
+        agglomerator faceAreaPair;
+        mergeLevels 1;
+        cacheAgglomeration true;
+        nCellsInCoarsestLevel 500;
+        tolerance 1e-10;
+        relTol 1e-1;
+        smoother GaussSeidel;
+        nPreSweeps 1;
+        nPostSweeps 2;
+        nFinestSweeps 2;
+        minIter 1;
+        maxIter 5;
     }
+
+    pFinal
+    {
+        solver GAMG;
+        agglomerator faceAreaPair;
+        mergeLevels 1;
+        cacheAgglomeration true;
+        nCellsInCoarsestLevel 500;
+        tolerance 1e-10;
+        relTol 1e-1;
+        smoother GaussSeidel;
+        nPreSweeps 1;
+        nPostSweeps 2;
+        nFinestSweeps 2;
+        minIter 1;
+        maxIter 5;
+    }
+
+    U
+    {
+        solver smoothSolver;
+        smoother GaussSeidel;
+        tolerance 1e-8;
+        relTol 1e-2;
+        minIter 1;
+    }
+
+    UFinal
+    {
+        solver smoothSolver;
+        smoother GaussSeidel;
+        tolerance 1e-10;
+        relTol 0;
+        minIter 1;
+    }
+}
+
+// OpenFOAM (.com), OpenFOAM 5 or older (.org)
+/*
+residualControl
+{
+    U
+    {
+        relTol          0;
+        tolerance       0.0001;
+    }
+    p
+    {
+        relTol          0;
+        tolerance       0.0001;
+    }
+    "(k|epsilon|omega)"
+    {
+        relTol          0;
+        tolerance       0.0001;
+    }
+}
+*/
+
+// OpenFOAM 6 (.org) or newer
+/*
+residualControl
+{
+    U 0.0001;
+    p 0.0001;
+    "(k|epsilon|omega)" 0.0001;
+}
+*/
+
+relaxationFactors
+{
+    U       0.5;
+    UFinal  0.5;
+    p       0.2;
+    pFinal  0.2;
+    Up      0.2;
+}
 

--- a/FSI/cylinderFlap/OpenFOAM-CalculiX/Fluid/system/fvSolution
+++ b/FSI/cylinderFlap/OpenFOAM-CalculiX/Fluid/system/fvSolution
@@ -61,6 +61,8 @@ PIMPLE
 
     nOuterCorrectors 50;
 
+    // OpenFOAM (.com), OpenFOAM 5 or older (.org)
+    /*
     residualControl
     {
 	    U
@@ -74,6 +76,16 @@ PIMPLE
     		relTol	  0;
     	}
     }
+    */
+    
+    // OpenFOAM 6 (.org) or newer
+    /*
+    residualControl
+    {
+        U 5e-5;
+        p 5e-4;
+    }
+    */
 }
 
 potentialFlow

--- a/FSI/cylinderFlap/OpenFOAM-CalculiX/Fluid/system/fvSolution
+++ b/FSI/cylinderFlap/OpenFOAM-CalculiX/Fluid/system/fvSolution
@@ -65,19 +65,19 @@ PIMPLE
     /*
     residualControl
     {
-	    U
-    	{
-    		tolerance 5e-5;
-    		relTol	  0;
-    	}
-	    p
-    	{
-    		tolerance 5e-4;
-    		relTol	  0;
-    	}
+        U
+        {
+            tolerance 5e-5;
+            relTol      0;
+        }
+        p
+        {
+            tolerance 5e-4;
+            relTol      0;
+        }
     }
     */
-    
+
     // OpenFOAM 6 (.org) or newer
     /*
     residualControl

--- a/FSI/cylinderFlap/OpenFOAM-FEniCS/Fluid/system/fvSolution
+++ b/FSI/cylinderFlap/OpenFOAM-FEniCS/Fluid/system/fvSolution
@@ -61,19 +61,31 @@ PIMPLE
 
     nOuterCorrectors 50;
 
-    // residualControl
-    // {
-    //	    U
-    //	{
-    //		tolerance 5e-5;
-    //		relTol	  0;
-    //	}
-    //      p
-    //	{
-    // 		tolerance 5e-4;
-    // 		relTol	  0;
-    // 	}
-    // }
+    // OpenFOAM (.com), OpenFOAM 5 or older (.org)
+    /*
+    residualControl
+    {
+        U
+        {
+            tolerance 5e-5;
+            relTol      0;
+        }
+        p
+        {
+            tolerance 5e-4;
+            relTol      0;
+        }
+    }
+    */
+
+    // OpenFOAM 6 (.org) or newer
+    /*
+    residualControl
+    {
+        U 5e-5;
+        p 5e-4;
+    }
+    */
 }
 
 potentialFlow

--- a/FSI/cylinderFlap/OpenFOAM-deal.II/Fluid/system/fvSolution
+++ b/FSI/cylinderFlap/OpenFOAM-deal.II/Fluid/system/fvSolution
@@ -61,6 +61,8 @@ PIMPLE
 
     nOuterCorrectors 50;
 
+    // OpenFOAM (.com), OpenFOAM 5 or older (.org)
+    /*
     residualControl
     {
 	    U
@@ -74,6 +76,16 @@ PIMPLE
     		relTol	  0;
     	}
     }
+    */
+    
+    // OpenFOAM 6 (.org) or newer
+    /*
+    residualControl
+    {
+        U 5e-5;
+        p 5e-4;
+    }
+    */
 }
 
 potentialFlow

--- a/FSI/cylinderFlap_2D/OpenFOAM-deal.II/Fluid/system/fvSolution
+++ b/FSI/cylinderFlap_2D/OpenFOAM-deal.II/Fluid/system/fvSolution
@@ -61,19 +61,31 @@ PIMPLE
 
     nOuterCorrectors 50;
 
+    // OpenFOAM (.com), OpenFOAM 5 or older (.org)
+    /*
     residualControl
     {
-	    U
-    	{
-    		tolerance 5e-5;
-    		relTol	  0;
-    	}
-	    p
-    	{
-    		tolerance 5e-4;
-    		relTol	  0;
-    	}
+        U
+        {
+            tolerance 5e-5;
+            relTol      0;
+        }
+        p
+        {
+            tolerance 5e-4;
+            relTol      0;
+        }
     }
+    */
+
+    // OpenFOAM 6 (.org) or newer
+    /*
+    residualControl
+    {
+        U 5e-5;
+        p 5e-4;
+    }
+    */
 }
 
 potentialFlow


### PR DESCRIPTION
Instead, offer commented-out ways to get the residualControl in the various OpenFOAM versions, with the current values.

This may affect convergence, but the purpose of the tutorial is to demonstrate how to configure preCICE and the adapters.

This fixes #40.