### PR TITLE
Remove vtk exports from deal.II tutorials

### DIFF
--- a/FSI/cylinderFlap/OpenFOAM-deal.II/precice-config.xml
+++ b/FSI/cylinderFlap/OpenFOAM-deal.II/precice-config.xml
@@ -29,7 +29,6 @@
         <use-mesh name="Solid_mesh" from="Solid"/>
 	<read-data name="Displacement" mesh="Fluid-Mesh-Nodes"/>
         <write-data name="Stress" mesh="Fluid-Mesh-Centers"/>
-        <!--export:vtk directory="coupling_data" /-->
         <mapping:rbf-thin-plate-splines direction="read" from="Solid_mesh" to="Fluid-Mesh-Nodes" constraint="consistent"/>
     </participant>
 

--- a/FSI/cylinderFlap_2D/OpenFOAM-deal.II/precice-config.xml
+++ b/FSI/cylinderFlap_2D/OpenFOAM-deal.II/precice-config.xml
@@ -29,7 +29,6 @@
         <use-mesh name="Solid_mesh" from="Solid"/>
 	<read-data name="Displacement" mesh="Fluid-Mesh-Nodes"/>
         <write-data name="Stress" mesh="Fluid-Mesh-Centers"/>
-        <!--export:vtk directory="coupling_data" /-->
         <mapping:rbf-thin-plate-splines direction="read" from="Solid_mesh" to="Fluid-Mesh-Nodes" constraint="consistent"/>
     </participant>
 

--- a/FSI/flap_perp/OpenFOAM-deal.II/precice-config.xml
+++ b/FSI/flap_perp/OpenFOAM-deal.II/precice-config.xml
@@ -29,7 +29,6 @@
         <use-mesh name="Solid_mesh" from="Solid"/>
 	<read-data name="Displacement" mesh="Fluid-Mesh-Nodes"/>
         <write-data name="Stress" mesh="Fluid-Mesh-Centers"/>
-        <export:vtk directory="coupling_data" />
 	<mapping:rbf-thin-plate-splines direction="read" from="Solid_mesh" to="Fluid-Mesh-Nodes" constraint="consistent"/>
 
     </participant>
@@ -41,7 +40,6 @@
 	<read-data name="Stress"  mesh="Solid_mesh"/>
   	<write-data name="Displacement" mesh="Solid_mesh"/>
         <watch-point mesh="Solid_mesh" name="flap_tip" coordinate="-0.05;1;0" />
-        <export:vtk directory="coupling_data" />
 	<mapping:rbf-thin-plate-splines direction="read" from="Fluid-Mesh-Centers" to="Solid_mesh" constraint="consistent" z-dead="true" />
     </participant>
 

--- a/FSI/flap_perp_2D/OpenFOAM-deal.II/precice-config.xml
+++ b/FSI/flap_perp_2D/OpenFOAM-deal.II/precice-config.xml
@@ -29,7 +29,6 @@
         <use-mesh name="Solid_mesh" from="Solid"/>
 	<read-data name="Displacement" mesh="Fluid-Mesh-Nodes"/>
         <write-data name="Stress" mesh="Fluid-Mesh-Centers"/>
-        <export:vtk directory="coupling_data" />
         <mapping:rbf-thin-plate-splines direction="read" from="Solid_mesh" to="Fluid-Mesh-Nodes" constraint="consistent"/>
     </participant>
 


### PR DESCRIPTION
This removes the `<export:vtk directory="coupling_data" />` from the deal.II FSI tutorials.

@DavidSCN I would just remove them, but maybe you have reasons to keep them that I oversee. If you agree, please merge.