### PR TITLE
Update 2D tutorials to define 2D watchpoint

### DIFF
--- a/FSI/cylinderFlap_2D/OpenFOAM-deal.II/precice-config.xml
+++ b/FSI/cylinderFlap_2D/OpenFOAM-deal.II/precice-config.xml
@@ -38,7 +38,7 @@
         <use-mesh name="Fluid-Mesh-Nodes" from="Fluid"/>
 	<read-data name="Stress"  mesh="Solid_mesh"/>
 	<write-data name="Displacement" mesh="Solid_mesh"/>
-        <watch-point mesh="Solid_mesh" name="flap_tip" coordinate="0.6;0.2;0" />
+        <watch-point mesh="Solid_mesh" name="flap_tip" coordinate="0.6;0.2" />
 	<mapping:rbf-thin-plate-splines direction="read" from="Fluid-Mesh-Centers" to="Solid_mesh" constraint="consistent" />
     </participant>
 

--- a/FSI/flap_perp_2D/OpenFOAM-deal.II/precice-config.xml
+++ b/FSI/flap_perp_2D/OpenFOAM-deal.II/precice-config.xml
@@ -38,7 +38,7 @@
         <use-mesh name="Fluid-Mesh-Nodes" from="Fluid"/>
 	<read-data name="Stress"  mesh="Solid_mesh"/>
   	<write-data name="Displacement" mesh="Solid_mesh"/>
-        <watch-point mesh="Solid_mesh" name="flap_tip" coordinate="-0.05;1;0" />
+        <watch-point mesh="Solid_mesh" name="flap_tip" coordinate="-0.05;1" />
 	<mapping:rbf-thin-plate-splines direction="read" from="Fluid-Mesh-Centers" to="Solid_mesh" constraint="consistent" />
     </participant>
 


### PR DESCRIPTION
preCICE v2.1.0 is now stricter in checking that everything has the same dimensions. Our current 2D tutorials are, therefore, failing by definition.

This removes the z-component of the watchpoint in the OpenFOAM-deal.II 2D tutorials.

@DavidSCN @Eder-K maybe this is interesting for you.