### PR TITLE
Update FEniCS cases data initialization

### DIFF
--- a/FSI/cylinderFlap/OpenFOAM-FEniCS/Solid/cyl-flap.py
+++ b/FSI/cylinderFlap/OpenFOAM-FEniCS/Solid/cyl-flap.py
@@ -88,7 +88,7 @@ clamped_boundary_domain = AutoSubDomain(left_boundary)
 force_boundary = AutoSubDomain(remaining_boundary)
 
 # Initialize the coupling interface
-precice_dt = precice.initialize(coupling_boundary, mesh, V, dim)
+precice_dt = precice.initialize(coupling_boundary, mesh, V, dim, fixed_boundary=clamped_boundary_domain)
 
 fenics_dt = precice_dt  # if fenics_dt == precice_dt, no subcycling is applied
 # fenics_dt = 0.02  # if fenics_dt < precice_dt, subcycling is applied
@@ -171,8 +171,6 @@ v_np1 = update_velocity(a_np1, u_n, v_n, a_n, ufl=True)
 
 res = m(avg(a_n, a_np1, alpha_m), v) + k(avg(u_n, du, alpha_f), v)
 
-Forces_x, Forces_y = precice.create_point_sources(clamped_boundary_domain)
-
 a_form = lhs(res)
 L_form = rhs(res)
 
@@ -201,7 +199,7 @@ while precice.is_coupling_ongoing():
     read_data = precice.read_data()
 
     # Update the point sources on the coupling boundary with the new read data
-    Forces_x, Forces_y = precice.update_point_sources(read_data)
+    Forces_x, Forces_y = precice.get_point_sources(read_data)
 
     A, b = assemble_system(a_form, L_form, bc)
 

--- a/FSI/flap_perp/OpenFOAM-FEniCS/Solid/perp-flap.py
+++ b/FSI/flap_perp/OpenFOAM-FEniCS/Solid/perp-flap.py
@@ -72,7 +72,7 @@ clamped_boundary_domain = AutoSubDomain(clamped_boundary)
 force_boundary = AutoSubDomain(neumann_boundary)
 
 # Initialize the coupling interface
-precice_dt = precice.initialize(coupling_boundary, mesh, V, dim)
+precice_dt = precice.initialize(coupling_boundary, mesh, V, dim, fixed_boundary=clamped_boundary_domain)
 
 fenics_dt = precice_dt  # if fenics_dt == precice_dt, no subcycling is applied
 # fenics_dt = 0.02  # if fenics_dt < precice_dt, subcycling is applied
@@ -165,8 +165,6 @@ v_np1 = update_v(a_np1, u_n, v_n, a_n, ufl=True)
 
 res = m(avg(a_n, a_np1, alpha_m), v) + k(avg(u_n, du, alpha_f), v)
 
-Forces_x, Forces_y = precice.create_point_sources(clamped_boundary_domain)
-
 a_form = lhs(res)
 L_form = rhs(res)
 
@@ -194,7 +192,7 @@ while precice.is_coupling_ongoing():
     read_data = precice.read_data()
 
     # Update the point sources on the coupling boundary with the new read data
-    Forces_x, Forces_y = precice.update_point_sources(read_data)
+    Forces_x, Forces_y = precice.get_point_sources(read_data)
 
     A, b = assemble_system(a_form, L_form, bc)
 

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -124,16 +124,12 @@ precice, precice_dt, initial_data = None, 0.0, None
 # Initialize the adapter according to the specific participant
 if problem is ProblemType.DIRICHLET:
     precice = Adapter(adapter_config_filename="precice-adapter-config-D.json")
-    precice_dt = precice.initialize(coupling_boundary, mesh, V)
-    initial_data = precice.initialize_data(f_N_function)
+    precice_dt = precice.initialize(coupling_boundary, mesh, V, write_function=f_N_function)
 elif problem is ProblemType.NEUMANN:
     precice = Adapter(adapter_config_filename="precice-adapter-config-N.json")
-    precice_dt = precice.initialize(coupling_boundary, mesh, V_g)
-    initial_data = precice.initialize_data(u_D_function)
+    precice_dt = precice.initialize(coupling_boundary, mesh, V_g, write_function=u_D_function)
 
 boundary_marker = False
-
-coupling_expression = precice.create_coupling_expression(initial_data)
 
 dt = Constant(0)
 dt.assign(np.min([fenics_dt, precice_dt]))
@@ -148,6 +144,7 @@ F = u * v / dt * dx + dot(grad(u), grad(v)) * dx - (u_n / dt + f) * v * dx
 bcs = [DirichletBC(V, u_D, remaining_boundary)]
 
 # Set boundary conditions at coupling interface once wrt to the coupling expression
+coupling_expression = precice.create_coupling_expression()
 if problem is ProblemType.DIRICHLET:
     # modify Dirichlet boundary condition on coupling interface
     bcs.append(DirichletBC(V, coupling_expression, coupling_boundary))


### PR DESCRIPTION
Ensures compatibility with changes introduced in https://github.com/precice/fenics-adapter/pull/81.

# Update

- [x] `heat.py` Note: Other tutorials do not use data initialization
- [x] `cyl-flap.py` uses `PointSources`
- [x] `perp-flap.py` uses `PointSources`

# Check for regressions

- [x] `heat.py`
- [x] `flap_perp`
- [x] `cylinderFlap`
- [x] `flow-over-plate`