### PR TITLE
Removes interpolation_type from all fenics adapter config files.

### DIFF
--- a/FSI/cylinderFlap/OpenFOAM-FEniCS/Solid/precice-adapter-config-fsi-s.json
+++ b/FSI/cylinderFlap/OpenFOAM-FEniCS/Solid/precice-adapter-config-fsi-s.json
@@ -4,7 +4,6 @@
   "interface": {
       "coupling_mesh_name": "Solid",
       "write_data_name": "Displacements0",
-      "read_data_name": "Forces0",
-      "interpolation_type": "rbf"
+      "read_data_name": "Forces0"
     }
 }

--- a/FSI/flap_perp/OpenFOAM-FEniCS/Solid/precice-adapter-config-fsi-s.json
+++ b/FSI/flap_perp/OpenFOAM-FEniCS/Solid/precice-adapter-config-fsi-s.json
@@ -4,7 +4,6 @@
   "interface": {
       "coupling_mesh_name": "Solid",
       "write_data_name": "Displacements0",
-      "read_data_name": "Forces0",
-      "interpolation_type": "rbf"
+      "read_data_name": "Forces0"
     }
 }

--- a/HT/partitioned-heat/fenics-fenics/precice-adapter-config-D.json
+++ b/HT/partitioned-heat/fenics-fenics/precice-adapter-config-D.json
@@ -4,7 +4,6 @@
   "interface": {
       "coupling_mesh_name": "DirichletNodes",
       "write_data_name": "Flux",
-      "read_data_name": "Temperature",
-      "interpolation_type": "rbf_segregated"
+      "read_data_name": "Temperature"
     }
 }

--- a/HT/partitioned-heat/fenics-fenics/precice-adapter-config-N.json
+++ b/HT/partitioned-heat/fenics-fenics/precice-adapter-config-N.json
@@ -4,7 +4,6 @@
   "interface": {
       "coupling_mesh_name": "NeumannNodes",
       "write_data_name": "Temperature",
-      "read_data_name": "Flux",
-      "interpolation_type": "rbf_segregated"
+      "read_data_name": "Flux"
     }
 }


### PR DESCRIPTION
Ensures compatibility with changes introduced in https://github.com/precice/fenics-adapter/pull/86.