### PR TITLE
Fix wrong visualization in nutils cht.py

### DIFF
--- a/CHT/flow-over-plate/buoyantPimpleFoam-nutils/Nutils/cht.py
+++ b/CHT/flow-over-plate/buoyantPimpleFoam-nutils/Nutils/cht.py
@@ -118,7 +118,7 @@ def main(elemsize: 'mesh width in x and y direction' = 0.05,
       lhs0 = lhscheckpoint
     else: # go to next timestep and visualize
       bezier = domain.sample('bezier', 2)
-      x, u = bezier.eval(['x_i', 'u'] @ ns, lhs=lhs0)
+      x, u = bezier.eval(['x_i', 'u'] @ ns, lhs=lhs)
       with treelog.add(treelog.DataLog()):
         if timestep % 20 == 0:
           nutils.export.vtk('Solid_' + str(timestep), bezier.tri, x, T=u)


### PR DESCRIPTION
If the system tests only use the coupling vtks this should have no effect. It's a pure visualization problem ... results were just lagging by one timestep. 
@Eder-K  Anything we need to adjust in the system tests or can I just merge?