### PR TITLE
Change FEniCS tutorials to handle new initialization signature of FEniCS-Adapter

### DIFF
--- a/CHT/flow-over-plate/buoyantPimpleFoam-fenics/Solid/heat.py
+++ b/CHT/flow-over-plate/buoyantPimpleFoam-fenics/Solid/heat.py
@@ -116,7 +116,7 @@ u_n.rename("T", "")
 # Adapter definition and initialization
 precice = Adapter(adapter_config_filename="precice-adapter-config.json")
 
-precice_dt = precice.initialize(coupling_boundary, V, V_g, write_function=f_N_function)
+precice_dt = precice.initialize(coupling_boundary, V, f_N_function)
 
 # Create a FEniCS Expression to define and control the coupling boundary values
 coupling_expression = precice.create_coupling_expression()

--- a/CHT/flow-over-plate/buoyantPimpleFoam-fenics/Solid/heat.py
+++ b/CHT/flow-over-plate/buoyantPimpleFoam-fenics/Solid/heat.py
@@ -116,7 +116,7 @@ u_n.rename("T", "")
 # Adapter definition and initialization
 precice = Adapter(adapter_config_filename="precice-adapter-config.json")
 
-precice_dt = precice.initialize(coupling_boundary, V, f_N_function)
+precice_dt = precice.initialize(coupling_boundary, read_function_space=V, write_object=f_N_function)
 
 # Create a FEniCS Expression to define and control the coupling boundary values
 coupling_expression = precice.create_coupling_expression()

--- a/CHT/flow-over-plate/buoyantPimpleFoam-fenics/Solid/heat.py
+++ b/CHT/flow-over-plate/buoyantPimpleFoam-fenics/Solid/heat.py
@@ -116,7 +116,7 @@ u_n.rename("T", "")
 # Adapter definition and initialization
 precice = Adapter(adapter_config_filename="precice-adapter-config.json")
 
-precice_dt = precice.initialize(coupling_boundary, mesh, V, write_function=f_N_function)
+precice_dt = precice.initialize(coupling_boundary, V, V_g, write_function=f_N_function)
 
 # Create a FEniCS Expression to define and control the coupling boundary values
 coupling_expression = precice.create_coupling_expression()

--- a/FSI/cylinderFlap/OpenFOAM-FEniCS/Solid/cyl-flap.py
+++ b/FSI/cylinderFlap/OpenFOAM-FEniCS/Solid/cyl-flap.py
@@ -88,6 +88,7 @@ clamped_boundary_domain = AutoSubDomain(left_boundary)
 force_boundary = AutoSubDomain(remaining_boundary)
 
 # Initialize the coupling interface
+# Function space V is passed twice as both read and write functions are defined using the same space
 precice_dt = precice.initialize(coupling_boundary, read_function_space=V, write_object=V,
                                 fixed_boundary=clamped_boundary_domain)
 

--- a/FSI/cylinderFlap/OpenFOAM-FEniCS/Solid/cyl-flap.py
+++ b/FSI/cylinderFlap/OpenFOAM-FEniCS/Solid/cyl-flap.py
@@ -88,7 +88,7 @@ clamped_boundary_domain = AutoSubDomain(left_boundary)
 force_boundary = AutoSubDomain(remaining_boundary)
 
 # Initialize the coupling interface
-precice_dt = precice.initialize(coupling_boundary, mesh, V, dim, fixed_boundary=clamped_boundary_domain)
+precice_dt = precice.initialize(coupling_boundary, V, V, clamped_boundary_domain)
 
 fenics_dt = precice_dt  # if fenics_dt == precice_dt, no subcycling is applied
 # fenics_dt = 0.02  # if fenics_dt < precice_dt, subcycling is applied

--- a/FSI/cylinderFlap/OpenFOAM-FEniCS/Solid/cyl-flap.py
+++ b/FSI/cylinderFlap/OpenFOAM-FEniCS/Solid/cyl-flap.py
@@ -88,7 +88,8 @@ clamped_boundary_domain = AutoSubDomain(left_boundary)
 force_boundary = AutoSubDomain(remaining_boundary)
 
 # Initialize the coupling interface
-precice_dt = precice.initialize(coupling_boundary, V, V, clamped_boundary_domain)
+precice_dt = precice.initialize(coupling_boundary, read_function_space=V, write_object=V,
+                                fixed_boundary=clamped_boundary_domain)
 
 fenics_dt = precice_dt  # if fenics_dt == precice_dt, no subcycling is applied
 # fenics_dt = 0.02  # if fenics_dt < precice_dt, subcycling is applied

--- a/FSI/flap_perp/OpenFOAM-FEniCS/Solid/perp-flap.py
+++ b/FSI/flap_perp/OpenFOAM-FEniCS/Solid/perp-flap.py
@@ -72,7 +72,8 @@ clamped_boundary_domain = AutoSubDomain(clamped_boundary)
 force_boundary = AutoSubDomain(neumann_boundary)
 
 # Initialize the coupling interface
-precice_dt = precice.initialize(coupling_boundary, V, V, fixed_boundary=clamped_boundary_domain)
+precice_dt = precice.initialize(coupling_boundary, read_function_space=V, write_object=V,
+                                fixed_boundary=clamped_boundary_domain)
 
 fenics_dt = precice_dt  # if fenics_dt == precice_dt, no subcycling is applied
 # fenics_dt = 0.02  # if fenics_dt < precice_dt, subcycling is applied

--- a/FSI/flap_perp/OpenFOAM-FEniCS/Solid/perp-flap.py
+++ b/FSI/flap_perp/OpenFOAM-FEniCS/Solid/perp-flap.py
@@ -72,7 +72,7 @@ clamped_boundary_domain = AutoSubDomain(clamped_boundary)
 force_boundary = AutoSubDomain(neumann_boundary)
 
 # Initialize the coupling interface
-precice_dt = precice.initialize(coupling_boundary, mesh, V, dim, fixed_boundary=clamped_boundary_domain)
+precice_dt = precice.initialize(coupling_boundary, V, V, fixed_boundary=clamped_boundary_domain)
 
 fenics_dt = precice_dt  # if fenics_dt == precice_dt, no subcycling is applied
 # fenics_dt = 0.02  # if fenics_dt < precice_dt, subcycling is applied

--- a/FSI/flap_perp/OpenFOAM-FEniCS/Solid/perp-flap.py
+++ b/FSI/flap_perp/OpenFOAM-FEniCS/Solid/perp-flap.py
@@ -72,6 +72,7 @@ clamped_boundary_domain = AutoSubDomain(clamped_boundary)
 force_boundary = AutoSubDomain(neumann_boundary)
 
 # Initialize the coupling interface
+# Function space V is passed twice as both read and write functions are defined using the same space
 precice_dt = precice.initialize(coupling_boundary, read_function_space=V, write_object=V,
                                 fixed_boundary=clamped_boundary_domain)
 

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -124,10 +124,10 @@ precice, precice_dt, initial_data = None, 0.0, None
 # Initialize the adapter according to the specific participant
 if problem is ProblemType.DIRICHLET:
     precice = Adapter(adapter_config_filename="precice-adapter-config-D.json")
-    precice_dt = precice.initialize(coupling_boundary, V, V_g, write_function=f_N_function)
+    precice_dt = precice.initialize(coupling_boundary, V, f_N_function)
 elif problem is ProblemType.NEUMANN:
     precice = Adapter(adapter_config_filename="precice-adapter-config-N.json")
-    precice_dt = precice.initialize(coupling_boundary, V_g, V, write_function=u_D_function)
+    precice_dt = precice.initialize(coupling_boundary, V_g, u_D_function)
 
 boundary_marker = False
 

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -124,10 +124,10 @@ precice, precice_dt, initial_data = None, 0.0, None
 # Initialize the adapter according to the specific participant
 if problem is ProblemType.DIRICHLET:
     precice = Adapter(adapter_config_filename="precice-adapter-config-D.json")
-    precice_dt = precice.initialize(coupling_boundary, V, f_N_function)
+    precice_dt = precice.initialize(coupling_boundary, read_function_space=V, write_object=f_N_function)
 elif problem is ProblemType.NEUMANN:
     precice = Adapter(adapter_config_filename="precice-adapter-config-N.json")
-    precice_dt = precice.initialize(coupling_boundary, V_g, u_D_function)
+    precice_dt = precice.initialize(coupling_boundary, read_function_space=V_g, write_object=u_D_function)
 
 boundary_marker = False
 

--- a/HT/partitioned-heat/fenics-fenics/heat.py
+++ b/HT/partitioned-heat/fenics-fenics/heat.py
@@ -124,10 +124,10 @@ precice, precice_dt, initial_data = None, 0.0, None
 # Initialize the adapter according to the specific participant
 if problem is ProblemType.DIRICHLET:
     precice = Adapter(adapter_config_filename="precice-adapter-config-D.json")
-    precice_dt = precice.initialize(coupling_boundary, mesh, V, write_function=f_N_function)
+    precice_dt = precice.initialize(coupling_boundary, V, V_g, write_function=f_N_function)
 elif problem is ProblemType.NEUMANN:
     precice = Adapter(adapter_config_filename="precice-adapter-config-N.json")
-    precice_dt = precice.initialize(coupling_boundary, mesh, V_g, write_function=u_D_function)
+    precice_dt = precice.initialize(coupling_boundary, V_g, V, write_function=u_D_function)
 
 boundary_marker = False
 


### PR DESCRIPTION
The initialization signature of the FEniCS-Adapter is changed in https://github.com/precice/fenics-adapter/pull/101. Correspondingly all FEniCS tutorials need to use the new initialization.

Not to be merged before https://github.com/precice/fenics-adapter/pull/101