### PR TITLE
Add the flow-over-heated-plate for nearest-projection

### DIFF
--- a/flow-over-heated-plate-nearest-projection/README.md
+++ b/flow-over-heated-plate-nearest-projection/README.md
@@ -1,0 +1,122 @@
+---
+title: Flow over heated plate nearest projection
+permalink: tutorials-flow-over-heated-plate-nearest-projection.html
+keywords: OpenFOAM, nearest-projection, CHT
+summary: This tutorial introduces an example simulation setup for nearest-projection mapping with the OpenFOAM adapter. The demonstrated "flow over a heated plate" scenario is exactly the same as in the `buoyantPimpleFoam-laplacianFoam` tutorial (with a thinner plate). The following text explains the _general functionality_ of the adapter, the _current capability_ of the adapter and the necessary _changes in the tutorials_ for your own simulation.
+---
+
+## Setup
+
+The setup is exactly the same as described in our [flow-over-heated-plate tutorial](tutorials-flow-over-heated-plate.html). Since the physical setup is not the main concern of this tutorial, we focus in the following on the nearest-projection mapping within preCICE. Let's start with general information about mapping methods. The [preCICE docs](configuration-mapping.html) contains an overview with available mapping methods in preCICE. The nearest-projection mapping is a second-order method. But, contrary to the RBF mapping, mesh connectivity information is needed for the interpolation.
+There are two participants in each mapping, but the connectivity of one mesh is sufficient for an interpolation. Which of the participants must provide mesh connectivity is not arbitrary and depends on the constraint type:
+
+- for `consistent` mappings, the `from` participant needs to provide connectivity
+- for `conservative` mappings, the `to` participant needs to provide connectivity
+
+For example, in our case, we exchange `Temperature` data in a `consistent` way from the `Fluid` to the `Solid` participant. Hence, `Fluid` needs to provide mesh connectivity.
+
+Notes:
+
+- In a standard **CHT** calculation, both data sets (heat flux and temperature) are mapped consistently. Therefore, both participants need to provide connectivity.
+- In a standard **FSI** calculation, forces are mapped conservatively from `Fluid` to `Solid`, while displacements are mapped consistently from `Solid` to `Fluid`. Hence, it is `Solid` that needs to provide connectivity and not `Fluid`.
+
+If mesh connectivity is not provided in the described way, you are nevertheless able to define a nearest-projection mapping in your `precice-config.xml`file, but it will _fall back to a first-order nearest-neighbor mapping_.
+
+## Available solvers
+
+Fluid participant:
+
+* OpenFOAM (buoyantPimpleFoam). For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
+
+Solid participant:
+
+* OpenFOAM (laplacianFoam). For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
+
+Since OpenFOAM is a finite-volume based solver, data is located in the middle of the cell, or on the cell face centers for a coupling interface. Mesh connectivity can be given to preCICE using the methods `setMeshTriangle` and `setMeshEdge`. Using the face centers as arguments for these methods is cumbersome. The main reason is that, although OpenFOAM decomposes the mesh for parallel simulations and distributes the subdomains to different processes, mesh connectivity needs to be defined over the partitioned mesh boundaries. This problem vanishes if we define mesh connectivity based on the face nodes, since boundary nodes can be shared among processors. Therefore, mesh connectivity can only be provided on the face nodes (not on the face centers).
+
+As described already, the data is not stored on the face nodes, but on the face centers. Therefore, we use OpenFOAM functions to interpolate from face centers to face nodes. The following image illustrates the workflow:
+
+![nearest-projection](https://user-images.githubusercontent.com/33414590/55965109-3402b600-5c76-11e9-87eb-0cdb10b55f7b.png)
+
+Data is obtained at the face centers, then interpolated to face nodes. Here, we have provided mesh connectivity and finally, preCICE performs the nearest-projection mapping.
+It is important to notice that the target data location is again the face center mesh of the coupling partner. In the standard CHT case, where both data sets are exchanged by a nearest-projection mapping, this leads to two interface meshes (centers and nodes) per participant. Having both the centers and nodes defined, we can skip one interpolation step and read data directly to the centers (cf. picture solver B).
+
+### Supported fields
+As already mentioned, the `Fluid` participant does not need to provide the mesh connectivity in case of a standard FSI. Therefore, the `Solid` participant needs to provide it and nothing special needs to be considered compared to other mapping methods.
+This implementation supports all CHT-related fields, which are mapped with a `consistent` constraint. The required settings and differences compared to the basic tutorial are given below.
+
+### Changes in the Simulation Setup
+
+As we are defining two meshes for each participant, we need to define them in the `precice-config.xml` and `preciceDict` configuration files. Additionally, we need to enable the `connectivity` switch for the adapter.
+
+### Changes in `precice-config.xml`
+In order to map from face nodes to face centers, both meshes need to be specified. The nodes-based mesh uses the write data and the centers-based mesh uses the read data. Have a look in the given `precice-config.xml` in this tutorial. Example: `Temperature` is calculated by the `Fluid` participant and passed to the `Solid` participant. Therefore, it is the write data of the participant `Fluid` and the read data of the participant `Solid`. This results in the following two meshes for this data:
+```
+<mesh name="Fluid-Mesh-Nodes">
+  <use-data name="Temperature"/>
+</mesh>
+<mesh name="Solid-Mesh-Centers">
+  <use-data name="Temperature"/>
+</mesh>
+```
+All further changes follow from this interface splitting. Have a look in the given config files for all details.
+
+### Changes in `preciceDict`
+
+By default, the OpenFOAM adapter doesn't provide any connectivity information. Therefore, a new boolean variable called `connectivity` is introduced. This variable is associated to each interface and can be set accordingly. Note: Mesh connectivity can only be provided in case `locations faceNodes` is set (see section Adapter Implementation). Similar to the interface splitting in the `precice-config.xml` file, the interfaces also need to be defined in the `preciceDict` file. For example:
+
+```
+interfaces
+{
+  Interface1
+  {
+    mesh              Fluid-Mesh-Centers;
+    locations         faceCenters;
+    connectivity      false;
+    patches           (interface);
+
+    readData
+    (
+      Heat-Flux
+    );
+
+    writeData
+    (
+    );
+  };
+
+  Interface2
+  {
+    mesh              Fluid-Mesh-Nodes;
+    locations         faceNodes;
+    connectivity      true;
+    patches           (interface);
+
+    readData
+    (
+    );
+
+    writeData
+    (
+      Temperature
+    );
+  };
+};
+```
+The participant `Fluid` has its read data `Heat-Flux`, which is read on the `faceCenters`, and its write data `Temperature`, which is written to the `faceNodes`. The mesh connectivity needs only to be provided in case of the `faceNodes`, using the option `connectivity true`.
+
+### General Notes
+
+Since you now define mesh connectivity on your interface, you can export your coupling interface with the tag `<export:vtk directory="preCICE-output" />` in your `precice-config.xml`.
+
+Visualizing these files (e.g. using ParaView) will show a triangular mesh, even though you use hexahedral meshes. This has nothing to do with your mesh and is just caused by the way the connectivity is defined in preCICE. As described above, the function `setMeshTriangles` is used to define the connectivity. Hence, every interface cell/face is represented by two triangles. The following image should give you an impression of a possible triangulated coupling mesh, which consists purely of hexahedral cells:
+
+![triangulated](https://user-images.githubusercontent.com/33414590/55974257-96b07d80-5c87-11e9-9965-972b922c483d.png)
+
+Note: Connectivity is defined on meshes associated with mesh nodes, which are named respectively e.g. `Fluid-Mesh-Nodes`. In this case, you could directly see the interface without applying filters by loading the `.vtk` files. In order to visualize additionally center based meshes, where no connectivity is provided, select a Glyph filter in ParaView. Furthermore, it makes a difference, on which participant the `<export...` tag is defined in your `precice-config.xml` file. Each participant exports interface meshes, which he provides or receives. The receiving participant filters out mesh parts that it does not need (for the mapping). Hence, a received mesh might look incomplete.
+
+### Notes on 2D Cases
+
+The geometry of the tutorial differs compared to the existing example: The out-of-plane thickness of the domain is reduced clearly and it is recommended. Otherwise your face centers have a quite large distance to the face nodes, which might trigger a preCICE warning. In that case, preCICE may filter out one of the meshes, especially in parallel simulations.  
+
+{% include disclaimer.html content="This offering is not approved or endorsed by OpenCFD Limited, producer and distributor of the OpenFOAM software via www.openfoam.com, and owner of the OPENFOAM®  and OpenCFD®  trade marks." %}

--- a/flow-over-heated-plate-nearest-projection/README.md
+++ b/flow-over-heated-plate-nearest-projection/README.md
@@ -2,25 +2,12 @@
 title: Flow over heated plate nearest projection
 permalink: tutorials-flow-over-heated-plate-nearest-projection.html
 keywords: OpenFOAM, nearest-projection, CHT
-summary: This tutorial introduces an example simulation setup for nearest-projection mapping with the OpenFOAM adapter. The demonstrated "flow over a heated plate" scenario is exactly the same as in the `buoyantPimpleFoam-laplacianFoam` tutorial (with a thinner plate). The following text explains the _general functionality_ of the adapter, the _current capability_ of the adapter and the necessary _changes in the tutorials_ for your own simulation.
+summary: This tutorial introduces an example simulation setup for a nearest-projection mapping. At the moment, it only contains an example with the OpenFOAM adapter. The demonstrated "flow over a heated plate" scenario is exactly the same as in the `buoyantPimpleFoam-laplacianFoam` tutorial.
 ---
 
 ## Setup
 
-The setup is exactly the same as described in our [flow-over-heated-plate tutorial](tutorials-flow-over-heated-plate.html). Since the physical setup is not the main concern of this tutorial, we focus in the following on the nearest-projection mapping within preCICE. Let's start with general information about mapping methods. The [preCICE docs](configuration-mapping.html) contains an overview with available mapping methods in preCICE. The nearest-projection mapping is a second-order method. But, contrary to the RBF mapping, mesh connectivity information is needed for the interpolation.
-There are two participants in each mapping, but the connectivity of one mesh is sufficient for an interpolation. Which of the participants must provide mesh connectivity is not arbitrary and depends on the constraint type:
-
-- for `consistent` mappings, the `from` participant needs to provide connectivity
-- for `conservative` mappings, the `to` participant needs to provide connectivity
-
-For example, in our case, we exchange `Temperature` data in a `consistent` way from the `Fluid` to the `Solid` participant. Hence, `Fluid` needs to provide mesh connectivity.
-
-Notes:
-
-- In a standard **CHT** calculation, both data sets (heat flux and temperature) are mapped consistently. Therefore, both participants need to provide connectivity.
-- In a standard **FSI** calculation, forces are mapped conservatively from `Fluid` to `Solid`, while displacements are mapped consistently from `Solid` to `Fluid`. Hence, it is `Solid` that needs to provide connectivity and not `Fluid`.
-
-If mesh connectivity is not provided in the described way, you are nevertheless able to define a nearest-projection mapping in your `precice-config.xml`file, but it will _fall back to a first-order nearest-neighbor mapping_.
+The setup is exactly the same as described in our [flow-over-heated-plate tutorial](tutorials-flow-over-heated-plate.html).
 
 ## Available solvers
 
@@ -32,20 +19,26 @@ Solid participant:
 
 * OpenFOAM (laplacianFoam). For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
 
-Since OpenFOAM is a finite-volume based solver, data is located in the middle of the cell, or on the cell face centers for a coupling interface. Mesh connectivity can be given to preCICE using the methods `setMeshTriangle` and `setMeshEdge`. Using the face centers as arguments for these methods is cumbersome. The main reason is that, although OpenFOAM decomposes the mesh for parallel simulations and distributes the subdomains to different processes, mesh connectivity needs to be defined over the partitioned mesh boundaries. This problem vanishes if we define mesh connectivity based on the face nodes, since boundary nodes can be shared among processors. Therefore, mesh connectivity can only be provided on the face nodes (not on the face centers).
+The solvers are currently only OpenFOAM related. For information regarding the nearest-projection mapping, have a look in the [OpenFOAM configuration section](adapter-openfoam-config.html).
 
-As described already, the data is not stored on the face nodes, but on the face centers. Therefore, we use OpenFOAM functions to interpolate from face centers to face nodes. The following image illustrates the workflow:
 
-![nearest-projection](https://user-images.githubusercontent.com/33414590/55965109-3402b600-5c76-11e9-87eb-0cdb10b55f7b.png)
+## Running the Simulation
 
-Data is obtained at the face centers, then interpolated to face nodes. Here, we have provided mesh connectivity and finally, preCICE performs the nearest-projection mapping.
-It is important to notice that the target data location is again the face center mesh of the coupling partner. In the standard CHT case, where both data sets are exchanged by a nearest-projection mapping, this leads to two interface meshes (centers and nodes) per participant. Having both the centers and nodes defined, we can skip one interpolation step and read data directly to the centers (cf. picture solver B).
+Open two separate terminals and start each participant by calling the respective run script.
 
-### Supported fields
-As already mentioned, the `Fluid` participant does not need to provide the mesh connectivity in case of a standard FSI. Therefore, the `Solid` participant needs to provide it and nothing special needs to be considered compared to other mapping methods.
-This implementation supports all CHT-related fields, which are mapped with a `consistent` constraint. The required settings and differences compared to the basic tutorial are given below.
+```
+cd fluid-openfoam
+./run.sh
+```
+and
+```
+cd solid-openfoam
+./run.sh
+```
 
-### Changes in the Simulation Setup
+You can also run OpenFOAM in parallel by `./run.sh -parallel`. If you are using OpenFOAM v1712 / 5.x or older have a look in the `fluid-openfoam/system/controlDict` file and set the appropriate solver name.
+
+## Changes in the Simulation Setup
 
 As we are defining two meshes for each participant, we need to define them in the `precice-config.xml` and `preciceDict` configuration files. Additionally, we need to enable the `connectivity` switch for the adapter.
 
@@ -61,62 +54,19 @@ In order to map from face nodes to face centers, both meshes need to be specifie
 ```
 All further changes follow from this interface splitting. Have a look in the given config files for all details.
 
-### Changes in `preciceDict`
+### Notes on 2D Cases
 
-By default, the OpenFOAM adapter doesn't provide any connectivity information. Therefore, a new boolean variable called `connectivity` is introduced. This variable is associated to each interface and can be set accordingly. Note: Mesh connectivity can only be provided in case `locations faceNodes` is set (see section Adapter Implementation). Similar to the interface splitting in the `precice-config.xml` file, the interfaces also need to be defined in the `preciceDict` file. For example:
+from a preCICE point of view, the simulation here is in 3D as opposed to the original case. This leads to the fact that the out-of-plane thickness of the domain is reduced clearly and it is recommended. Otherwise your face centers have a quite large distance to the face nodes, which might trigger a preCICE warning. In that case, preCICE may filter out one of the meshes, especially in parallel simulations.
 
-```
-interfaces
-{
-  Interface1
-  {
-    mesh              Fluid-Mesh-Centers;
-    locations         faceCenters;
-    connectivity      false;
-    patches           (interface);
 
-    readData
-    (
-      Heat-Flux
-    );
+## Post-processing
 
-    writeData
-    (
-    );
-  };
-
-  Interface2
-  {
-    mesh              Fluid-Mesh-Nodes;
-    locations         faceNodes;
-    connectivity      true;
-    patches           (interface);
-
-    readData
-    (
-    );
-
-    writeData
-    (
-      Temperature
-    );
-  };
-};
-```
-The participant `Fluid` has its read data `Heat-Flux`, which is read on the `faceCenters`, and its write data `Temperature`, which is written to the `faceNodes`. The mesh connectivity needs only to be provided in case of the `faceNodes`, using the option `connectivity true`.
-
-### General Notes
-
-Since you now define mesh connectivity on your interface, you can export your coupling interface with the tag `<export:vtk directory="preCICE-output" />` in your `precice-config.xml`.
-
+Have a look at the [flow-over heated-plate](tutorials-flow-over-heated-plate.html) tutorial for the general aspects of post-processing.
+Since we now defined mesh connectivity on our interface, we can export the coupling interface with the tag `<export:vtk directory="preCICE-output" />` in our `precice-config.xml`.
 Visualizing these files (e.g. using ParaView) will show a triangular mesh, even though you use hexahedral meshes. This has nothing to do with your mesh and is just caused by the way the connectivity is defined in preCICE. As described above, the function `setMeshTriangles` is used to define the connectivity. Hence, every interface cell/face is represented by two triangles. The following image should give you an impression of a possible triangulated coupling mesh, which consists purely of hexahedral cells:
 
 ![triangulated](https://user-images.githubusercontent.com/33414590/55974257-96b07d80-5c87-11e9-9965-972b922c483d.png)
 
 Note: Connectivity is defined on meshes associated with mesh nodes, which are named respectively e.g. `Fluid-Mesh-Nodes`. In this case, you could directly see the interface without applying filters by loading the `.vtk` files. In order to visualize additionally center based meshes, where no connectivity is provided, select a Glyph filter in ParaView. Furthermore, it makes a difference, on which participant the `<export...` tag is defined in your `precice-config.xml` file. Each participant exports interface meshes, which he provides or receives. The receiving participant filters out mesh parts that it does not need (for the mapping). Hence, a received mesh might look incomplete.
-
-### Notes on 2D Cases
-
-The geometry of the tutorial differs compared to the existing example: The out-of-plane thickness of the domain is reduced clearly and it is recommended. Otherwise your face centers have a quite large distance to the face nodes, which might trigger a preCICE warning. In that case, preCICE may filter out one of the meshes, especially in parallel simulations.  
 
 {% include disclaimer.html content="This offering is not approved or endorsed by OpenCFD Limited, producer and distributor of the OpenFOAM software via www.openfoam.com, and owner of the OPENFOAM®  and OpenCFD®  trade marks." %}

--- a/flow-over-heated-plate-nearest-projection/README.md
+++ b/flow-over-heated-plate-nearest-projection/README.md
@@ -56,7 +56,7 @@ All further changes follow from this interface splitting. Have a look in the giv
 
 ### Notes on 2D Cases
 
-from a preCICE point of view, the simulation here is in 3D as opposed to the original case. This leads to the fact that the out-of-plane thickness of the domain is reduced clearly and it is recommended. Otherwise your face centers have a quite large distance to the face nodes, which might trigger a preCICE warning. In that case, preCICE may filter out one of the meshes, especially in parallel simulations.
+From the preCICE point of view, the simulation here is in 3D, as opposed to the original 2D case, as is often the case with 3D solvers (such as OpenFOAM). In such cases, we recommend keeping the out-of-plane thickness of the domain small and comparable to the in-plane cell size. Otherwise, the face centers will have a large distance to the face nodes, which might trigger a preCICE warning and preCICE may even filter out one of the meshes, especially in parallel simulations.
 
 
 ## Post-processing

--- a/flow-over-heated-plate-nearest-projection/clean.sh
+++ b/flow-over-heated-plate-nearest-projection/clean.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+cd ${0%/*} || exit 1    # Run from this directory
+
+echo "Cleaning..."
+
+clean_case(){
+    cd ${1}
+    # Clean the result and auxiliary files
+    rm -fv *.vtk
+    rm -fv ${1}.log
+    rm -fv precice-*.log \
+    rm -fv precice-postProcessingInfo.log \
+    rm -fv precice-*-events.json
+}
+
+finished_clean(){
+cd ..
+}
+
+# Openfoam
+Name="fluid-openfoam"
+clean_case ${Name}
+    # Clean specialized files
+    if [ -n "${WM_PROJECT}" ]; 
+    then
+        . $WM_PROJECT_DIR/bin/tools/CleanFunctions
+        cleanCase
+        rm -rfv ./0
+        touch ${Name}.foam
+    fi
+finished_clean
+
+Name="solid-openfoam"
+clean_case ${Name}
+    # Clean specialized files
+    if [ -n "${WM_PROJECT}" ]; 
+    then
+        . $WM_PROJECT_DIR/bin/tools/CleanFunctions
+        cleanCase
+        rm -rfv ./0
+        touch ${Name}.foam
+    fi
+finished_clean
+
+# Remove the preCICE address files
+rm -rfv precice-run
+
+echo "Cleaning complete!"
+#------------------------------------------------------------------------------

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/T
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/T
@@ -1,0 +1,60 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      T;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [ 0 0 0 1 0 0 0 ];
+
+internalField   uniform 300;
+
+boundaryField
+{
+    interface
+    {
+        type            fixedGradient;
+        gradient        uniform 0;
+    }
+    inlet
+    {
+        type            fixedValue;
+        value           $internalField;
+    }
+    outlet
+    {
+        type            zeroGradient;
+    }
+    top
+    {
+        type            zeroGradient;
+    }
+    bottom
+    {
+        type            zeroGradient;
+    }
+    slip-bottom
+    {
+        type            zeroGradient;
+    }
+    outerWall
+    {
+        type            zeroGradient;
+    }
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/T
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/T
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/U
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/U
@@ -1,0 +1,55 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volVectorField;
+    object      U;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [ 0 1 -1 0 0 0 0 ];
+
+internalField   uniform ( 0.1 0 0 );
+
+boundaryField
+{
+    interface
+    {
+        type            noSlip;
+    }
+    inlet
+    {
+        type            fixedValue;
+        value           $internalField;
+    }
+    outlet
+    {
+        type            zeroGradient;
+    }
+    top
+    {
+        type            slip;
+    }
+    bottom
+    {
+        type            noSlip;
+    }
+    slip-bottom
+    {
+        type            slip;
+    }
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/U
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/U
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/alphat
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/alphat
@@ -1,0 +1,61 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    location    "0";
+    object      alphat;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [ 1 -1 -1 0 0 0 0 ];
+
+internalField   uniform 0;
+
+boundaryField
+{
+    interface
+    {
+        type            compressible::alphatWallFunction;
+        value           uniform 0;
+    }
+    inlet
+    {
+        type            compressible::alphatWallFunction;
+        value           uniform 0;
+    }
+    outlet
+    {
+        type            compressible::alphatWallFunction;
+        value           uniform 0;
+    }
+    top
+    {
+        type            compressible::alphatWallFunction;
+        value           uniform 0;
+    }
+    bottom
+    {
+        type            compressible::alphatWallFunction;
+        value           uniform 0;
+    }
+    slip-bottom
+    {
+        type            compressible::alphatWallFunction;
+        value           uniform 0;
+    }
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/alphat
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/alphat
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/epsilon
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/epsilon
@@ -1,0 +1,61 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    location    "0";
+    object      epsilon;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [ 0 2 -3 0 0 0 0 ];
+
+internalField   uniform 0.01;
+
+boundaryField
+{
+    interface
+    {
+        type            epsilonWallFunction;
+        value           uniform 0.01;
+    }
+    inlet
+    {
+        type            epsilonWallFunction;
+        value           uniform 0.01;
+    }
+    outlet
+    {
+        type            epsilonWallFunction;
+        value           uniform 0.01;
+    }
+    top
+    {
+        type            epsilonWallFunction;
+        value           uniform 0.01;
+    }
+    bottom
+    {
+        type            epsilonWallFunction;
+        value           uniform 0.01;
+    }
+    slip-bottom
+    {
+        type            epsilonWallFunction;
+        value           uniform 0.01;
+    }
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/epsilon
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/epsilon
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/k
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/k
@@ -1,0 +1,61 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    location    "0";
+    object      k;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [ 0 2 -2 0 0 0 0 ];
+
+internalField   uniform 0.1;
+
+boundaryField
+{
+    interface
+    {
+        type            kqRWallFunction;
+        value           uniform 0.1;
+    }
+    inlet
+    {
+        type            kqRWallFunction;
+        value           uniform 0.1;
+    }
+    outlet
+    {
+        type            kqRWallFunction;
+        value           uniform 0.1;
+    }
+    top
+    {
+        type            kqRWallFunction;
+        value           uniform 0.1;
+    }
+    slip-bottom
+    {
+        type            kqRWallFunction;
+        value           uniform 0.1;
+    }
+    bottom
+    {
+        type            kqRWallFunction;
+        value           uniform 0.1;
+    }
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/k
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/k
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/nut
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/nut
@@ -1,0 +1,61 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    location    "0";
+    object      nut;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [ 0 2 -1 0 0 0 0 ];
+
+internalField   uniform 0;
+
+boundaryField
+{
+    interface
+    {
+        type            nutkWallFunction;
+        value           uniform 0;
+    }
+    inlet
+    {
+        type            nutkWallFunction;
+        value           uniform 0;
+    }
+    outlet
+    {
+        type            nutkWallFunction;
+        value           uniform 0;
+    }
+    top
+    {
+        type            nutkWallFunction;
+        value           uniform 0;
+    }
+    bottom
+    {
+        type            nutkWallFunction;
+        value           uniform 0;
+    }
+    slip-bottom
+    {
+        type            nutkWallFunction;
+        value           uniform 0;
+    }
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/nut
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/nut
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/p
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/p
@@ -1,0 +1,65 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      p;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [ 1 -1 -2 0 0 0 0 ];
+
+internalField   uniform 103500;
+
+boundaryField
+{
+    interface
+    {
+        type            calculated;
+        value           $internalField;
+    }
+    inlet
+    {
+        type            calculated;
+        value           $internalField;
+    }
+    outlet
+    {
+        type            calculated;
+        value           $internalField;
+    }
+    outerWall
+    {
+        type            calculated;
+        value           $internalField;
+    }
+    top
+    {
+        type            calculated;
+        value           $internalField;
+    }
+    bottom
+    {
+        type            calculated;
+        value           $internalField;
+    }
+    slip-bottom
+    {
+        type            calculated;
+        value           $internalField;
+    }
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/p
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/p
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/p_rgh
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/p_rgh
@@ -1,0 +1,55 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      p_rgh;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [ 1 -1 -2 0 0 0 0 ];
+
+internalField   uniform 103500;
+
+boundaryField
+{
+    interface
+    {
+        type            zeroGradient;
+    }
+    inlet
+    {
+        type            zeroGradient;
+    }
+    outlet
+    {
+        type            fixedValue;
+        value           $internalField;
+    }
+    top
+    {
+        type            zeroGradient;
+    }
+    slip-bottom
+    {
+        type            zeroGradient;
+    }
+    bottom
+    {
+        type            zeroGradient;
+    }
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/p_rgh
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/0.orig/p_rgh
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/g
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/g
@@ -1,0 +1,22 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       uniformDimensionedVectorField;
+    location    "constant";
+    object      g;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 1 -2 0 0 0 0];
+value           (0 -9.81 0);
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/g
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/g
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/thermophysicalProperties
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/thermophysicalProperties
@@ -1,0 +1,49 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      thermophysicalProperties;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+thermoType
+{
+    type            heRhoThermo;
+    mixture         pureMixture;
+    transport       const;
+    thermo          hConst;
+    equationOfState perfectGas;
+    specie          specie;
+    energy          sensibleEnthalpy;
+}
+
+mixture
+{
+    specie
+    {
+        nMoles          1;
+        molWeight       24.0999;
+    }
+    thermodynamics
+    {
+        Cp              5000.0;
+        Hf              0;
+    }
+    transport
+    {
+        mu              0.0002;
+        Pr              0.01;
+    }
+}
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/thermophysicalProperties
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/thermophysicalProperties
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/turbulenceProperties
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/turbulenceProperties
@@ -1,0 +1,26 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      turbulenceProperties;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+simulationType  laminar;
+
+RAS
+{
+    RASModel    kEpsilon;
+    turbulence  off;
+}
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/turbulenceProperties
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/turbulenceProperties
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/removeObsoleteFolders.sh
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/removeObsoleteFolders.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+echo "Looking for any time directories without results (e.g. stray functionObjectProperties files, see issue #26 on GitHub)..."
+
+for f in [0-9]* [0-9]*.[0-9]*; do
+	if ! [ -f $f/U ] && ! [ -f $f/T ]; then
+		rm -rfv $f
+	fi
+done
+if [ -d processor0 ]; then
+	for g in processor*; do
+		cd $g
+		for f in [0-9]* [0-9]*.[0-9]*; do
+			if ! [ -f $f/U ] && ! [ -f $f/T ]; then
+				rm -rfv $f
+			fi
+		done
+		cd ..
+	done
+fi
+cd ..
+

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/run.sh
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/run.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+cd ${0%/*} || exit 1    		    		# Run from this directory
+. $WM_PROJECT_DIR/bin/tools/RunFunctions    # Tutorial run functions
+
+# Fluid participant
+
+# Run this script in one terminal and the "runSolid" script in another terminal.
+# These scripts present how the two participants would be started manually.
+# Alternatively, you may execute the "Allrun" script in one terminal.
+
+# Run this script with "-parallel" for parallel simulations
+
+# The script "Allclean" cleans-up the result and log files.
+
+# 1 for true, 0 for false
+parallel=0
+if [ "$1" = "-parallel" ]; then
+    parallel=1
+fi
+
+echo "Preparing and running the Fluid participant..."
+
+rm -rfv 0/
+cp -r 0.orig/ 0/
+blockMesh
+checkMesh
+
+# Run
+solver=$(getApplication)
+procs=$(getNumberOfProcessors)
+
+if [ $parallel -eq 1 ]; then
+    decomposePar -force
+    mpirun -np $procs $solver -parallel
+    reconstructPar
+else
+    $solver
+fi
+
+# Workaround for issue #26
+./removeObsoleteFolders.sh
+
+echo ""
+echo "### NOTE ### Make sure to use the correct solver for your OpenFOAM version! (pimpleFoam for OpenFOAM v1806, OpenFOAM 6, or newer, vs pimpleDyMFoam for older) You may change this in your Fluid/system/controlDict file, if needed."

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/run.sh
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/run.sh
@@ -4,13 +4,8 @@ cd ${0%/*} || exit 1    		    		# Run from this directory
 
 # Fluid participant
 
-# Run this script in one terminal and the "runSolid" script in another terminal.
-# These scripts present how the two participants would be started manually.
-# Alternatively, you may execute the "Allrun" script in one terminal.
-
+# Run this script in one terminal in order to start this participant.
 # Run this script with "-parallel" for parallel simulations
-
-# The script "Allclean" cleans-up the result and log files.
 
 # 1 for true, 0 for false
 parallel=0

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/blockMeshDict
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/blockMeshDict
@@ -1,0 +1,121 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      blockMeshDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+convertToMeters 1;
+
+vertices
+(
+    (0 0 0)
+    (1 0 0)
+    (1 .5 0)
+    (0 .5 0)
+
+    (0 0 .01)
+    (1 0 .01)
+    (1 .5 .01)
+    (0 .5 .01)
+
+    (3 0 0)
+    (3 .5 0)
+
+    (3 0 .01)
+    (3 .5 .01)
+
+    (-.5 0 0)
+    (-.5 .5 0)
+
+    (-.5 .5 .01)
+    (-.5 0 .01)
+
+);
+
+blocks
+(
+    hex (12 0 3 13 15 4 7 14) (81 41 1) simpleGrading (.2 15 1)
+    hex (0 1 2 3 4 5 6 7) (161 41 1) simpleGrading (5 15 1)
+    hex (1 8 9 2 5 10 11 6) (51 41 1) simpleGrading (1 15 1)
+);
+
+edges
+(
+);
+
+boundary
+(
+
+    inlet
+    {
+        type wall;
+        faces
+        (
+            (13 12 15 14)
+        );
+    }
+
+    outlet
+    {
+        type wall;
+        faces
+        (
+            (8 9 11 10)
+        );
+    }
+
+    top
+    {
+        type wall;
+        faces
+        (
+            (7 6 2 3)
+            (9 2 6 11)
+            (13 3 7 14)
+        );
+    }
+
+    slip-bottom
+    {
+        type wall;
+        faces
+        (
+            (15 12 0 4)
+        );
+    }
+
+    bottom
+    {
+        type wall;
+        faces
+        (
+            (1 8 10 5)
+        );
+    }
+
+    interface
+    {
+        type wall;
+        faces
+        (
+            (4 0 1 5)
+        );
+    }
+
+);
+
+mergePatchPairs
+(
+);
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/blockMeshDict
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/blockMeshDict
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/controlDict
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/controlDict
@@ -1,0 +1,59 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      controlDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+application     buoyantPimpleFoam;
+
+startFrom       startTime;
+
+startTime       0;
+
+stopAt          endTime;
+
+endTime         1;
+
+deltaT          0.01;
+
+writeControl    runTime;
+
+writeInterval   0.2;
+
+purgeWrite      0;
+
+writeFormat     ascii;
+
+writePrecision  6;
+
+writeCompression off;
+
+timeFormat      general;
+
+timePrecision   6;
+
+runTimeModifiable false;
+
+functions
+{
+    preCICE_Adapter
+    {
+        type preciceAdapterFunctionObject;
+        libs ("libpreciceAdapterFunctionObject.so");
+    }
+}
+
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/controlDict
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/controlDict
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/decomposeParDict
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/decomposeParDict
@@ -1,0 +1,16 @@
+FoamFile {
+    version 2.0;
+    class dictionary;
+    object decomposeParDict;
+    format ascii;
+}
+
+numberOfSubdomains 2;
+
+method          simple;
+
+simpleCoeffs
+{
+    n               (2 1 1);
+    delta           0.001;
+}

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/fvSchemes
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/fvSchemes
@@ -1,0 +1,59 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSchemes;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+ddtSchemes
+{
+    default         Euler;
+}
+
+gradSchemes
+{
+    default         Gauss linear;
+}
+
+divSchemes
+{
+    default         none;
+    div(phi,U)      Gauss upwind;
+    div(phi,h)      Gauss upwind;
+    div(phi,e)      Gauss upwind;
+    div(phi,k)      Gauss upwind;
+    div(phi,epsilon) Gauss upwind;
+    div(phi,R)      Gauss upwind;
+    div(phi,K)      Gauss linear;
+    div(phi,Ekp)    Gauss linear;
+    div(R)          Gauss linear;
+    div(((rho*nuEff)*dev2(T(grad(U))))) Gauss linear;
+}
+
+laplacianSchemes
+{
+    default         Gauss linear corrected;
+}
+
+interpolationSchemes
+{
+    default         linear;
+}
+
+snGradSchemes
+{
+    default         corrected;
+}
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/fvSchemes
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/fvSchemes
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/fvSolution
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/fvSolution
@@ -1,0 +1,66 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSolution;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+solvers
+{
+    "rho.*"
+    {
+        solver          PCG;
+        preconditioner  DIC;
+        tolerance       0;
+        relTol          0;
+    }
+
+    p_rgh
+    {
+        solver          PCG;
+        preconditioner  DIC;
+        tolerance       1e-8;
+        relTol          0.01;
+    }
+
+    p_rghFinal
+    {
+        $p_rgh;
+        relTol          0;
+    }
+
+    "(U|h|e|k|epsilon|R)"
+    {
+        solver          PBiCGStab;
+        preconditioner  DILU;
+        tolerance       1e-6;
+        relTol          0.1;
+    }
+
+    "(U|h|e|k|epsilon|R)Final"
+    {
+        $U;
+        relTol          0;
+    }
+}
+
+PIMPLE
+{
+    momentumPredictor yes;
+    nOuterCorrectors 1;
+    nCorrectors     2;
+    nNonOrthogonalCorrectors 0;
+}
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/fvSolution
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/fvSolution
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/preciceDict
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/preciceDict
@@ -1,0 +1,51 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      preciceDict;
+}
+
+preciceConfig "../precice-config.xml";
+
+participant Fluid;
+
+modules (CHT);
+
+interfaces
+{
+  Interface1
+  {
+    mesh              Fluid-Mesh-Centers;
+    locations         faceCenters;
+    connectivity      false;
+    patches           (interface);
+    
+    readData
+    (
+      Heat-Flux
+    );
+    
+    writeData
+    (
+    );
+  };
+  
+  Interface2
+  {
+    mesh              Fluid-Mesh-Nodes;
+    locations         faceNodes;
+    connectivity      true;
+    patches           (interface);
+    
+    readData
+    (
+    );
+    
+    writeData
+    (
+      Temperature
+    );
+  };
+};

--- a/flow-over-heated-plate-nearest-projection/precice-config.xml
+++ b/flow-over-heated-plate-nearest-projection/precice-config.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <log>
+    <sink
+      filter="%Severity% > debug and %Rank% = 0"
+      format="---[precice] %ColorizedSeverity% %Message%"
+      enabled="true" />
+  </log>
+
+  <solver-interface dimensions="3">
+    <data:scalar name="Temperature" />
+    <data:scalar name="Heat-Flux" />
+
+    <mesh name="Fluid-Mesh-Centers">
+      <use-data name="Heat-Flux" />
+    </mesh>
+
+    <mesh name="Fluid-Mesh-Nodes">
+      <use-data name="Temperature" />
+    </mesh>
+
+    <mesh name="Solid-Mesh-Centers">
+      <use-data name="Temperature" />
+    </mesh>
+
+    <mesh name="Solid-Mesh-Nodes">
+      <use-data name="Heat-Flux" />
+    </mesh>
+
+    <participant name="Fluid">
+      <use-mesh name="Fluid-Mesh-Centers" provide="yes" />
+      <use-mesh name="Fluid-Mesh-Nodes" provide="yes" />
+      <use-mesh name="Solid-Mesh-Nodes" from="Solid" />
+      <read-data name="Heat-Flux" mesh="Fluid-Mesh-Centers" />
+      <write-data name="Temperature" mesh="Fluid-Mesh-Nodes" />
+      <mapping:nearest-projection
+        direction="read"
+        from="Solid-Mesh-Nodes"
+        to="Fluid-Mesh-Centers"
+        constraint="consistent" />
+    </participant>
+
+    <participant name="Solid">
+      <use-mesh name="Fluid-Mesh-Nodes" from="Fluid" />
+      <use-mesh name="Solid-Mesh-Nodes" provide="yes" />
+      <use-mesh name="Solid-Mesh-Centers" provide="yes" />
+      <read-data name="Temperature" mesh="Solid-Mesh-Centers" />
+      <write-data name="Heat-Flux" mesh="Solid-Mesh-Nodes" />
+      <!-- <export:vtk directory="preCICE-output" /> -->
+      <mapping:nearest-projection
+        direction="read"
+        from="Fluid-Mesh-Nodes"
+        to="Solid-Mesh-Centers"
+        constraint="consistent" />
+    </participant>
+
+    <m2n:sockets from="Fluid" to="Solid" exchange-directory=".."/>
+
+    <coupling-scheme:serial-implicit>
+      <time-window-size value="0.01" />
+      <max-time value="1" />
+      <participants first="Fluid" second="Solid" />
+      <exchange data="Temperature" mesh="Fluid-Mesh-Nodes" from="Fluid" to="Solid" />
+      <exchange data="Heat-Flux" mesh="Solid-Mesh-Nodes" from="Solid" to="Fluid" />
+      <max-iterations value="200" />
+      <relative-convergence-measure limit="1.0e-6" data="Temperature" mesh="Fluid-Mesh-Nodes" />
+      <acceleration:IQN-ILS>
+        <data mesh="Solid-Mesh-Nodes" name="Heat-Flux" />
+        <initial-relaxation value="0.01" />
+        <max-used-iterations value="80" />
+        <time-windows-reused value="10" />
+        <filter type="QR1" limit="1e-8" />
+      </acceleration:IQN-ILS>
+    </coupling-scheme:serial-implicit>
+  </solver-interface>
+</precice-configuration>

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/0.orig/T
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/0.orig/T
@@ -1,0 +1,47 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      T;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+dimensions      [0 0 0 1 0 0 0];
+
+internalField   uniform 310;
+
+boundaryField
+{
+    interface
+    {
+        type            fixedValue;
+        value           $internalField;
+    }
+    left
+    {
+        type            zeroGradient;
+    }
+    right
+    {
+        type            zeroGradient;
+    }
+    bottom
+    {
+        type            fixedValue;
+        value           $internalField;
+    }
+    defaultFaces
+    {
+        type            empty;
+    }
+}
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/0.orig/T
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/0.orig/T
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/constant/transportProperties
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/constant/transportProperties
@@ -1,0 +1,21 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      transportProperties;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+DT               DT  [ 0  2 -1  0 0 0 0 ] 1;
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/constant/transportProperties
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/constant/transportProperties
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/removeObsoleteFolders.sh
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/removeObsoleteFolders.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+echo "Looking for any time directories without results (e.g. stray functionObjectProperties files, see issue #26 on GitHub)..."
+
+for f in [0-9]* [0-9]*.[0-9]*; do
+	if ! [ -f $f/U ] && ! [ -f $f/T ]; then
+		rm -rfv $f
+	fi
+done
+if [ -d processor0 ]; then
+	for g in processor*; do
+		cd $g
+		for f in [0-9]* [0-9]*.[0-9]*; do
+			if ! [ -f $f/U ] && ! [ -f $f/T ]; then
+				rm -rfv $f
+			fi
+		done
+		cd ..
+	done
+fi
+cd ..
+

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/run.sh
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/run.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+cd ${0%/*} || exit 1    		    		# Run from this directory
+. $WM_PROJECT_DIR/bin/tools/RunFunctions    # Tutorial run functions
+
+# Fluid participant
+
+# Run this script in one terminal and the "runSolid" script in another terminal.
+# These scripts present how the two participants would be started manually.
+# Alternatively, you may execute the "Allrun" script in one terminal.
+
+# Run this script with "-parallel" for parallel simulations
+
+# The script "Allclean" cleans-up the result and log files.
+
+# 1 for true, 0 for false
+parallel=0
+if [ "$1" = "-parallel" ]; then
+    parallel=1
+fi
+
+echo "Preparing and running the Fluid participant..."
+
+rm -rfv 0/
+cp -r 0.orig/ 0/
+blockMesh
+checkMesh
+
+# Run
+solver=$(getApplication)
+procs=$(getNumberOfProcessors)
+
+if [ $parallel -eq 1 ]; then
+    decomposePar -force
+    mpirun -np $procs $solver -parallel
+    reconstructPar
+else
+    $solver
+fi
+
+# Workaround for issue #26
+./removeObsoleteFolders.sh
+
+echo ""
+echo "### NOTE ### Make sure to use the correct solver for your OpenFOAM version! (pimpleFoam for OpenFOAM v1806, OpenFOAM 6, or newer, vs pimpleDyMFoam for older) You may change this in your Fluid/system/controlDict file, if needed."

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/run.sh
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/run.sh
@@ -4,13 +4,8 @@ cd ${0%/*} || exit 1    		    		# Run from this directory
 
 # Fluid participant
 
-# Run this script in one terminal and the "runSolid" script in another terminal.
-# These scripts present how the two participants would be started manually.
-# Alternatively, you may execute the "Allrun" script in one terminal.
-
+# Run this script in one terminal in order to start this participant.
 # Run this script with "-parallel" for parallel simulations
-
-# The script "Allclean" cleans-up the result and log files.
 
 # 1 for true, 0 for false
 parallel=0

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/system/blockMeshDict
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/system/blockMeshDict
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  2.4.0                                 |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/system/blockMeshDict
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/system/blockMeshDict
@@ -1,0 +1,88 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  2.4.0                                 |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      blockMeshDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+convertToMeters 1;
+
+vertices
+(
+
+    (0 -.25 0)
+    (1 -.25 0)
+    (1 0 0)
+    (0 0 0)
+
+    (0 -.25 .01)
+    (1 -.25 .01)
+    (1 0 .01)
+    (0 0 .01)
+
+);
+
+blocks
+(
+    hex (0 1 2 3 4 5 6 7) (32 16 1) simpleGrading (1 1 1)
+);
+
+edges
+(
+);
+
+boundary
+(
+
+    left
+    {
+        type wall;
+        faces
+        (
+            (4 7 3 0)
+        );
+    }
+
+    right
+    {
+        type wall;
+        faces
+        (
+            (1 2 6 5)
+        );
+    }
+
+    interface
+    {
+        type wall;
+        faces
+        (
+            (7 6 2 3)
+        );
+    }
+
+    bottom
+    {
+        type wall;
+        faces
+        (
+            (4 0 1 5)
+        );
+    }
+
+);
+
+mergePatchPairs
+(
+);
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/system/controlDict
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/system/controlDict
@@ -1,0 +1,59 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      controlDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+application     laplacianFoam;
+
+startFrom       startTime;
+
+startTime       0;
+
+stopAt          endTime;
+
+endTime         1;
+
+deltaT          0.01;
+
+writeControl    runTime;
+
+writeInterval   0.2;
+
+purgeWrite      0;
+
+writeFormat     ascii;
+
+writePrecision  6;
+
+writeCompression off;
+
+timeFormat      general;
+
+timePrecision   6;
+
+runTimeModifiable false;
+
+functions
+{
+    preCICE_Adapter
+    {
+        type preciceAdapterFunctionObject;
+        libs ("libpreciceAdapterFunctionObject.so");
+    }
+}
+
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/system/controlDict
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/system/controlDict
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/system/decomposeParDict
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/system/decomposeParDict
@@ -1,0 +1,16 @@
+FoamFile {
+    version 2.0;
+    class dictionary;
+    object decomposeParDict;
+    format ascii;
+}
+
+numberOfSubdomains 2;
+
+method          simple;
+
+simpleCoeffs
+{
+    n               (2 1 1);
+    delta           0.001;
+}

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/system/fvSchemes
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/system/fvSchemes
@@ -1,0 +1,51 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSchemes;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+ddtSchemes
+{
+    default         Euler;
+}
+
+gradSchemes
+{
+    default         Gauss linear;
+    grad(T)         Gauss linear;
+}
+
+divSchemes
+{
+    default         none;
+}
+
+laplacianSchemes
+{
+    default         none;
+    laplacian(DT,T) Gauss linear corrected;
+}
+
+interpolationSchemes
+{
+    default         linear;
+}
+
+snGradSchemes
+{
+    default         corrected;
+}
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/system/fvSchemes
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/system/fvSchemes
@@ -1,11 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
-FoamFile
 {
     version     2.0;
     format      ascii;

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/system/fvSolution
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/system/fvSolution
@@ -1,0 +1,35 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  5                                     |
+|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSolution;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+solvers
+{
+    T
+    {
+        solver          PCG;
+        preconditioner  DIC;
+        tolerance       1e-06;
+        relTol          0;
+    }
+}
+
+SIMPLE
+{
+    nNonOrthogonalCorrectors 2;
+}
+
+
+// ************************************************************************* //

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/system/fvSolution
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/system/fvSolution
@@ -1,10 +1,3 @@
-/*--------------------------------*- C++ -*----------------------------------*\
-| =========                 |                                                 |
-| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  5                                     |
-|   \\  /    A nd           | Web:      www.OpenFOAM.org                      |
-|    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/system/preciceDict
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/system/preciceDict
@@ -1,0 +1,57 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      preciceDict;
+}
+
+preciceConfig "../precice-config.xml";
+
+participant Solid;
+
+modules (CHT);
+
+interfaces
+{
+  Interface1
+  {
+    mesh              Solid-Mesh-Centers;
+    locations         faceCenters;
+    connectivity      false;
+    patches           (interface);
+    
+    readData
+    (
+      Temperature
+    );
+    
+    writeData
+    (
+    );
+  };
+  
+  Interfaces2
+  {
+    mesh              Solid-Mesh-Nodes;
+    locations         faceNodes;
+    connectivity      true;
+    patches           (interface);
+    
+    readData
+    (
+    );
+    
+    writeData
+    (
+      Heat-Flux
+    );
+  };
+};
+
+CHT
+{
+   k   [ 1  1 -3 -1 0 0 0 ] 100;
+   solverType "basic";
+};

--- a/perpendicular-flap/fluid-openfoam/run.sh
+++ b/perpendicular-flap/fluid-openfoam/run.sh
@@ -4,13 +4,8 @@ cd ${0%/*} || exit 1    		    		# Run from this directory
 
 # Fluid participant
 
-# Run this script in one terminal and the "runSolid" script in another terminal.
-# These scripts present how the two participants would be started manually.
-# Alternatively, you may execute the "Allrun" script in one terminal.
-
+# Run this script in one terminal in order to start this participant.
 # Run this script with "-parallel" for parallel simulations
-
-# The script "Allclean" cleans-up the result and log files.
 
 # 1 for true, 0 for false
 parallel=0


### PR DESCRIPTION
Closes #136 and as discussed there.

This is a first draft version which has all functionality. However, the README was previously rather tied to the OpenFOAM case. Therefore I would like to hear the opinion of @MakisH which parts to move in the adapter docs and which parts to keep here in the tutorials. We could of course also keep as it is since we only have OpenFOAM at the moment. 