### PR TITLE
Add checks for permalinks and image names

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,12 @@
+name: Checks
+on: [push, pull_request]
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Check image names
+        run:  bash tools/checkimages.sh
+      - name: Check permalinks
+        run:  bash tools/checkpermalinks.sh

--- a/tools/checkimages.sh
+++ b/tools/checkimages.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Run this script at the root of the repository to check images for correct prefixes
+
+tutorials=$(find . -mindepth 2 -maxdepth 2 -type d -name images | cut -d/ -f2)
+
+CODE=0
+for tutorial in $tutorials; do
+  images=$(find ./$tutorial/images -type f)
+  prefix="tutorials-$tutorial-"
+  for img in $images; do
+    if ! [[ $img =~ ^./$tutorial/images/$prefix ]]; then
+      echo "$img: error: wrong filename"
+      echo "$img: note: expected prefix \"$prefix\""
+      CODE=1
+    else
+      echo "$img: info: correct filename"
+    fi
+    echo
+  done
+done
+
+[ ! "$CODE" -eq "0" ] && echo "There have been errors"
+exit $CODE

--- a/tools/checkimages.sh
+++ b/tools/checkimages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Run this script at the root of the repository to check images for correct prefixes
 
-tutorials=$(find . -mindepth 2 -maxdepth 2 -type d -name images | cut -d/ -f2)
+tutorials=$(find . -mindepth 2 -maxdepth 2 -type d -name images -not -path "./quickstart/*" | cut -d/ -f2)
 
 CODE=0
 for tutorial in $tutorials; do

--- a/tools/checkpermalinks.sh
+++ b/tools/checkpermalinks.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Run this script at the root of the repository to check permalinks
+
+FILES=$(find . -mindepth 2 -maxdepth 2 -type f -name "*.md" -not -path "./quickstart/*")
+tutorials=$(echo "$FILES" | cut -d/ -f2 | sort -u)
+
+CODE=0
+for tutorial in $tutorials; do
+  files=$(find ./$tutorial -maxdepth 1 -type f -name "*.md")
+  for file in $files; do
+    link=$(grep "permalink:" $file | sed "s/permalink: \+//")
+    prefix="tutorials-$tutorial"
+
+    if ! [[ $link =~ ^$prefix ]]; then
+      echo "$file: error: wrong permalink"
+      echo "$file: note: permalink \"$link\" does not start with \"$prefix\""
+      CODE=1
+    else
+      echo "$file: info: correct permalink"
+      echo "$file: note: permalink is \"$link\""
+    fi
+    echo
+  done
+done
+
+[ ! "$CODE" -eq "0" ] && echo "There have been errors"
+exit $CODE


### PR DESCRIPTION
This workflow adds a basic check for tutorials:
* permalinks of pages have to start with `tutorials-NAME` (this allows `tutorials-epic.html`, but also `tutorials-epic-introduction.html`)
* image names have to strart with `tutorials-NAME-`

This currently ignores the quickstart.