### PR TITLE
Make cleaning scripts less strict

### DIFF
--- a/tools/cleaning-tools.sh
+++ b/tools/cleaning-tools.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e -u
 
 error() {
     echo "Error: $1" >&2; exit 1;
@@ -7,6 +6,7 @@ error() {
 
 clean_tutorial() {
     (
+        set -e -u
         cd "$1"
         echo "-- Cleaning up all cases in $(pwd)..."
         rm -rfv ./precice-run/
@@ -22,6 +22,7 @@ clean_tutorial() {
 
 clean_precice_logs() {
     (
+        set -e -u
         cd "$1"
         echo "---- Cleaning up preCICE logs in $(pwd)"
         rm -fv ./precice-*-iterations.log \
@@ -36,6 +37,7 @@ clean_precice_logs() {
 
 clean_calculix() {
     (
+        set -e -u
         cd "$1"
         echo "--- Cleaning up CalculiX case in $(pwd)"
         rm -fv ./*.cvg ./*.dat ./*.frd ./*.sta ./*.12d spooles.out
@@ -45,9 +47,10 @@ clean_calculix() {
 
 clean_codeaster() {
     (
+        set -e -u
         cd "$1"
         echo "--- Cleaning up code_aster case in $(pwd)"
-        rm -fv ./*.mess ./*.resu ./*.rmed  # TODO: Check this list
+        rm -fv ./*.mess ./*.resu ./*.rmed
         rm -rfv ./REPE_OUT/*
         clean_precice_logs .
     )
@@ -55,6 +58,7 @@ clean_codeaster() {
 
 clean_dealii() {
     (
+        set -e -u
         cd "$1"
         echo "--- Cleaning up deal.II case in $(pwd)"
         rm -fv ./dealii-output/solution-*.vtk
@@ -64,15 +68,17 @@ clean_dealii() {
 
 clean_fenics() {
     (
+        set -e -u
         cd "$1"
         echo "--- Cleaning up FEniCS case in $(pwd)"
-        rm -fv ./*.pvd spooles.out FSI-S/* # TODO: Check this list
+        rm -fv ./*.pvd spooles.out FSI-S/*
         clean_precice_logs .
     )
 }
 
 clean_nutils() {
     (
+        set -e -u
         cd "$1"
         echo "--- Cleaning up Nutils case in $(pwd)"
         clean_precice_logs .
@@ -81,6 +87,7 @@ clean_nutils() {
 
 clean_openfoam() {
     (
+        set -e -u
         cd "$1"
         echo "--- Cleaning up OpenFOAM case in $(pwd)"
         if [ -n "${WM_PROJECT:-}" ] || error "No OpenFOAM environment is active."; then
@@ -94,6 +101,7 @@ clean_openfoam() {
 
 clean_su2() {
     (
+        set -e -u
         cd "$1"
         echo "--- Cleaning up SU2 case in $(pwd)"
         rm -fv ./restart_flow_*.dat forces_breakdown.dat ./surface_flow_*.csv ./flow_*.vtk ./history_*.vtk

--- a/tools/openfoam-remove-empty-dirs.sh
+++ b/tools/openfoam-remove-empty-dirs.sh
@@ -1,6 +1,7 @@
 #! /bin/sh
 
 openfoam_remove_empty_dirs() {
+	(
 	set -e -u
 	echo "Looking for any time directories without results (e.g. stray functionObjectProperties files, see openfoam-adapter issue #26 on GitHub)..."
 
@@ -20,4 +21,5 @@ openfoam_remove_empty_dirs() {
 			cd ..
 		done
 	fi
+	)
 }

--- a/tools/openfoam-remove-empty-dirs.sh
+++ b/tools/openfoam-remove-empty-dirs.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
-set -e -u
 
 openfoam_remove_empty_dirs() {
+	set -e -u
 	echo "Looking for any time directories without results (e.g. stray functionObjectProperties files, see openfoam-adapter issue #26 on GitHub)..."
 
 	for f in [0-9]* [0-9]*.[0-9]*; do


### PR DESCRIPTION
In #169, I created some function-only files with tools to clean tutorial cases and to remove obsolete OpenFOAM directories. Trying to follow "safety first", I set `-e -u` in every script, including the function ones. This made it very unpractical to source globally.

I now moved these options inside each function.

This means that one can now source these scripts in their `~/.bashrc`:
```
source /path/to/tools/cleaning-tools.sh
source /path/to/tools/openfoam-remove-empty-dirs.sh
```
and use them from inside the directory which they want to clean as:
```
clean_tutorial
clean_openfoam
...
openfoam_remove_empty_dirs
```
Tab-completion also works.

I am not sure where to document this.

@DavidSCN does this close #179 for you? I tried once more making the scripts runnable from any path, but I think there is no clean way to do it in simple POSIX-compliant shells.

P.S.: This also removes two `TODO` comments that should actually be addressed only if an issue arises.