### PR TITLE
Fix inconsistent naming in heat exchanger

### DIFF
--- a/heat-exchanger/fluid-inner-openfoam/system/preciceDict
+++ b/heat-exchanger/fluid-inner-openfoam/system/preciceDict
@@ -9,7 +9,7 @@ FoamFile
 
 preciceConfig "../precice-config.xml";
 
-participant Inner-Fluid;
+participant Fluid-Inner;
 
 modules (CHT);
 
@@ -17,7 +17,7 @@ interfaces
 {
   Interface1
   {
-    mesh              Inner-Fluid-to-Solid;
+    mesh              Fluid-Inner-to-Solid;
     patches           (interface);
     
     readData
@@ -28,8 +28,8 @@ interfaces
     
     writeData
     (
-      Sink-Temperature-Inner-Fluid
-      Heat-Transfer-Coefficient-Inner-Fluid
+      Sink-Temperature-Fluid-Inner
+      Heat-Transfer-Coefficient-Fluid-Inner
     );
   };
 };

--- a/heat-exchanger/fluid-outer-openfoam/system/preciceDict
+++ b/heat-exchanger/fluid-outer-openfoam/system/preciceDict
@@ -9,7 +9,7 @@ FoamFile
 
 preciceConfig "../precice-config.xml";
 
-participant Outer-Fluid;
+participant Fluid-Outer;
 
 modules (CHT);
 
@@ -17,7 +17,7 @@ interfaces
 {
   Interface1
   {
-    mesh              Outer-Fluid-to-Solid;
+    mesh              Fluid-Outer-to-Solid;
     patches           (interface);
     
     readData
@@ -28,8 +28,8 @@ interfaces
     
     writeData
     (
-      Sink-Temperature-Outer-Fluid
-      Heat-Transfer-Coefficient-Outer-Fluid
+      Sink-Temperature-Fluid-Outer
+      Heat-Transfer-Coefficient-Fluid-Outer
     );
   };
 };

--- a/heat-exchanger/precice-config.xml
+++ b/heat-exchanger/precice-config.xml
@@ -10,152 +10,152 @@
   <solver-interface dimensions="3">
     <data:scalar name="Heat-Transfer-Coefficient-Solid" />
     <data:scalar name="Sink-Temperature-Solid" />
-    <data:scalar name="Heat-Transfer-Coefficient-Inner-Fluid" />
-    <data:scalar name="Sink-Temperature-Inner-Fluid" />
-    <data:scalar name="Heat-Transfer-Coefficient-Outer-Fluid" />
-    <data:scalar name="Sink-Temperature-Outer-Fluid" />
+    <data:scalar name="Heat-Transfer-Coefficient-Fluid-Inner" />
+    <data:scalar name="Sink-Temperature-Fluid-Inner" />
+    <data:scalar name="Heat-Transfer-Coefficient-Fluid-Outer" />
+    <data:scalar name="Sink-Temperature-Fluid-Outer" />
 
-    <mesh name="Solid-to-Inner-Fluid">
+    <mesh name="Solid-to-Fluid-Inner">
       <use-data name="Sink-Temperature-Solid" />
       <use-data name="Heat-Transfer-Coefficient-Solid" />
-      <use-data name="Sink-Temperature-Inner-Fluid" />
-      <use-data name="Heat-Transfer-Coefficient-Inner-Fluid" />
+      <use-data name="Sink-Temperature-Fluid-Inner" />
+      <use-data name="Heat-Transfer-Coefficient-Fluid-Inner" />
     </mesh>
 
-    <mesh name="Solid-to-Outer-Fluid">
+    <mesh name="Solid-to-Fluid-Outer">
       <use-data name="Sink-Temperature-Solid" />
       <use-data name="Heat-Transfer-Coefficient-Solid" />
-      <use-data name="Sink-Temperature-Outer-Fluid" />
-      <use-data name="Heat-Transfer-Coefficient-Outer-Fluid" />
+      <use-data name="Sink-Temperature-Fluid-Outer" />
+      <use-data name="Heat-Transfer-Coefficient-Fluid-Outer" />
     </mesh>
 
-    <mesh name="Inner-Fluid-to-Solid">
-      <use-data name="Sink-Temperature-Inner-Fluid" />
-      <use-data name="Heat-Transfer-Coefficient-Inner-Fluid" />
+    <mesh name="Fluid-Inner-to-Solid">
+      <use-data name="Sink-Temperature-Fluid-Inner" />
+      <use-data name="Heat-Transfer-Coefficient-Fluid-Inner" />
       <use-data name="Sink-Temperature-Solid" />
       <use-data name="Heat-Transfer-Coefficient-Solid" />
     </mesh>
 
-    <mesh name="Outer-Fluid-to-Solid">
-      <use-data name="Sink-Temperature-Outer-Fluid" />
-      <use-data name="Heat-Transfer-Coefficient-Outer-Fluid" />
+    <mesh name="Fluid-Outer-to-Solid">
+      <use-data name="Sink-Temperature-Fluid-Outer" />
+      <use-data name="Heat-Transfer-Coefficient-Fluid-Outer" />
       <use-data name="Sink-Temperature-Solid" />
       <use-data name="Heat-Transfer-Coefficient-Solid" />
     </mesh>
 
     <participant name="Solid">
-      <use-mesh name="Solid-to-Inner-Fluid" provide="yes" />
-      <use-mesh name="Inner-Fluid-to-Solid" from="Inner-Fluid" />
-      <write-data mesh="Solid-to-Inner-Fluid" name="Sink-Temperature-Solid" />
-      <write-data mesh="Solid-to-Inner-Fluid" name="Heat-Transfer-Coefficient-Solid" />
-      <read-data mesh="Solid-to-Inner-Fluid" name="Sink-Temperature-Inner-Fluid" />
-      <read-data mesh="Solid-to-Inner-Fluid" name="Heat-Transfer-Coefficient-Inner-Fluid" />
+      <use-mesh name="Solid-to-Fluid-Inner" provide="yes" />
+      <use-mesh name="Fluid-Inner-to-Solid" from="Fluid-Inner" />
+      <write-data mesh="Solid-to-Fluid-Inner" name="Sink-Temperature-Solid" />
+      <write-data mesh="Solid-to-Fluid-Inner" name="Heat-Transfer-Coefficient-Solid" />
+      <read-data mesh="Solid-to-Fluid-Inner" name="Sink-Temperature-Fluid-Inner" />
+      <read-data mesh="Solid-to-Fluid-Inner" name="Heat-Transfer-Coefficient-Fluid-Inner" />
       <mapping:nearest-neighbor
         constraint="consistent"
         direction="read"
-        to="Solid-to-Inner-Fluid"
-        from="Inner-Fluid-to-Solid" />
-      <use-mesh name="Solid-to-Outer-Fluid" provide="yes" />
-      <use-mesh name="Outer-Fluid-to-Solid" from="Outer-Fluid" />
-      <write-data mesh="Solid-to-Outer-Fluid" name="Sink-Temperature-Solid" />
-      <write-data mesh="Solid-to-Outer-Fluid" name="Heat-Transfer-Coefficient-Solid" />
-      <read-data mesh="Solid-to-Outer-Fluid" name="Sink-Temperature-Outer-Fluid" />
-      <read-data mesh="Solid-to-Outer-Fluid" name="Heat-Transfer-Coefficient-Outer-Fluid" />
+        to="Solid-to-Fluid-Inner"
+        from="Fluid-Inner-to-Solid" />
+      <use-mesh name="Solid-to-Fluid-Outer" provide="yes" />
+      <use-mesh name="Fluid-Outer-to-Solid" from="Fluid-Outer" />
+      <write-data mesh="Solid-to-Fluid-Outer" name="Sink-Temperature-Solid" />
+      <write-data mesh="Solid-to-Fluid-Outer" name="Heat-Transfer-Coefficient-Solid" />
+      <read-data mesh="Solid-to-Fluid-Outer" name="Sink-Temperature-Fluid-Outer" />
+      <read-data mesh="Solid-to-Fluid-Outer" name="Heat-Transfer-Coefficient-Fluid-Outer" />
       <mapping:nearest-neighbor
         constraint="consistent"
         direction="read"
-        to="Solid-to-Outer-Fluid"
-        from="Outer-Fluid-to-Solid" />
+        to="Solid-to-Fluid-Outer"
+        from="Fluid-Outer-to-Solid" />
     </participant>
 
-    <participant name="Inner-Fluid">
-      <use-mesh name="Inner-Fluid-to-Solid" provide="yes" />
-      <use-mesh name="Solid-to-Inner-Fluid" from="Solid" />
-      <write-data mesh="Inner-Fluid-to-Solid" name="Sink-Temperature-Inner-Fluid" />
-      <write-data mesh="Inner-Fluid-to-Solid" name="Heat-Transfer-Coefficient-Inner-Fluid" />
-      <read-data mesh="Inner-Fluid-to-Solid" name="Sink-Temperature-Solid" />
-      <read-data mesh="Inner-Fluid-to-Solid" name="Heat-Transfer-Coefficient-Solid" />
+    <participant name="Fluid-Inner">
+      <use-mesh name="Fluid-Inner-to-Solid" provide="yes" />
+      <use-mesh name="Solid-to-Fluid-Inner" from="Solid" />
+      <write-data mesh="Fluid-Inner-to-Solid" name="Sink-Temperature-Fluid-Inner" />
+      <write-data mesh="Fluid-Inner-to-Solid" name="Heat-Transfer-Coefficient-Fluid-Inner" />
+      <read-data mesh="Fluid-Inner-to-Solid" name="Sink-Temperature-Solid" />
+      <read-data mesh="Fluid-Inner-to-Solid" name="Heat-Transfer-Coefficient-Solid" />
       <mapping:nearest-neighbor
         constraint="consistent"
         direction="read"
-        to="Inner-Fluid-to-Solid"
-        from="Solid-to-Inner-Fluid" />
+        to="Fluid-Inner-to-Solid"
+        from="Solid-to-Fluid-Inner" />
     </participant>
 
-    <participant name="Outer-Fluid">
-      <use-mesh name="Outer-Fluid-to-Solid" provide="yes" />
-      <use-mesh name="Solid-to-Outer-Fluid" from="Solid" />
-      <write-data mesh="Outer-Fluid-to-Solid" name="Sink-Temperature-Outer-Fluid" />
-      <write-data mesh="Outer-Fluid-to-Solid" name="Heat-Transfer-Coefficient-Outer-Fluid" />
-      <read-data mesh="Outer-Fluid-to-Solid" name="Sink-Temperature-Solid" />
-      <read-data mesh="Outer-Fluid-to-Solid" name="Heat-Transfer-Coefficient-Solid" />
+    <participant name="Fluid-Outer">
+      <use-mesh name="Fluid-Outer-to-Solid" provide="yes" />
+      <use-mesh name="Solid-to-Fluid-Outer" from="Solid" />
+      <write-data mesh="Fluid-Outer-to-Solid" name="Sink-Temperature-Fluid-Outer" />
+      <write-data mesh="Fluid-Outer-to-Solid" name="Heat-Transfer-Coefficient-Fluid-Outer" />
+      <read-data mesh="Fluid-Outer-to-Solid" name="Sink-Temperature-Solid" />
+      <read-data mesh="Fluid-Outer-to-Solid" name="Heat-Transfer-Coefficient-Solid" />
       <mapping:nearest-neighbor
         constraint="consistent"
         direction="read"
-        to="Outer-Fluid-to-Solid"
-        from="Solid-to-Outer-Fluid" />
+        to="Fluid-Outer-to-Solid"
+        from="Solid-to-Fluid-Outer" />
     </participant>
 
-    <m2n:sockets to="Inner-Fluid" from="Solid" exchange-directory=".." />
+    <m2n:sockets to="Fluid-Inner" from="Solid" exchange-directory=".." />
 
     <coupling-scheme:parallel-explicit>
       <time-window-size value="1" />
       <max-time value="500" />
-      <participants first="Solid" second="Inner-Fluid" />
+      <participants first="Solid" second="Fluid-Inner" />
       <exchange
         data="Sink-Temperature-Solid"
-        mesh="Solid-to-Inner-Fluid"
+        mesh="Solid-to-Fluid-Inner"
         from="Solid"
-        to="Inner-Fluid"
+        to="Fluid-Inner"
         initialize="yes" />
       <exchange
         data="Heat-Transfer-Coefficient-Solid"
-        mesh="Solid-to-Inner-Fluid"
+        mesh="Solid-to-Fluid-Inner"
         from="Solid"
-        to="Inner-Fluid"
+        to="Fluid-Inner"
         initialize="yes" />
       <exchange
-        data="Sink-Temperature-Inner-Fluid"
-        mesh="Inner-Fluid-to-Solid"
-        from="Inner-Fluid"
+        data="Sink-Temperature-Fluid-Inner"
+        mesh="Fluid-Inner-to-Solid"
+        from="Fluid-Inner"
         to="Solid"
         initialize="yes" />
       <exchange
-        data="Heat-Transfer-Coefficient-Inner-Fluid"
-        mesh="Inner-Fluid-to-Solid"
-        from="Inner-Fluid"
+        data="Heat-Transfer-Coefficient-Fluid-Inner"
+        mesh="Fluid-Inner-to-Solid"
+        from="Fluid-Inner"
         to="Solid"
         initialize="yes" />
     </coupling-scheme:parallel-explicit>
 
-    <m2n:sockets to="Outer-Fluid" from="Solid" exchange-directory=".." />
+    <m2n:sockets to="Fluid-Outer" from="Solid" exchange-directory=".." />
 
     <coupling-scheme:parallel-explicit>
       <time-window-size value="1" />
       <max-time value="500" />
-      <participants first="Solid" second="Outer-Fluid" />
+      <participants first="Solid" second="Fluid-Outer" />
       <exchange
         data="Sink-Temperature-Solid"
-        mesh="Solid-to-Outer-Fluid"
+        mesh="Solid-to-Fluid-Outer"
         from="Solid"
-        to="Outer-Fluid"
+        to="Fluid-Outer"
         initialize="yes" />
       <exchange
         data="Heat-Transfer-Coefficient-Solid"
-        mesh="Solid-to-Outer-Fluid"
+        mesh="Solid-to-Fluid-Outer"
         from="Solid"
-        to="Outer-Fluid"
+        to="Fluid-Outer"
         initialize="yes" />
       <exchange
-        data="Sink-Temperature-Outer-Fluid"
-        mesh="Outer-Fluid-to-Solid"
-        from="Outer-Fluid"
+        data="Sink-Temperature-Fluid-Outer"
+        mesh="Fluid-Outer-to-Solid"
+        from="Fluid-Outer"
         to="Solid"
         initialize="yes" />
       <exchange
-        data="Heat-Transfer-Coefficient-Outer-Fluid"
-        mesh="Outer-Fluid-to-Solid"
-        from="Outer-Fluid"
+        data="Heat-Transfer-Coefficient-Fluid-Outer"
+        mesh="Fluid-Outer-to-Solid"
+        from="Fluid-Outer"
         to="Solid"
         initialize="yes" />
     </coupling-scheme:parallel-explicit>

--- a/heat-exchanger/solid-calculix/config.yml
+++ b/heat-exchanger/solid-calculix/config.yml
@@ -1,14 +1,14 @@
 participants:
-  # The configuration files for the Inner-Fluid and Outer-Fluid participants
+  # The configuration files for the Fluid-Inner and Fluid-Outer participants
   # are located in each participant's directory.
   Solid:
     interfaces:
-    - mesh: Solid-to-Inner-Fluid
+    - mesh: Solid-to-Fluid-Inner
       patch: inner-interface
-      read-data: [Sink-Temperature-Inner-Fluid, Heat-Transfer-Coefficient-Inner-Fluid]
+      read-data: [Sink-Temperature-Fluid-Inner, Heat-Transfer-Coefficient-Fluid-Inner]
       write-data: [Sink-Temperature-Solid, Heat-Transfer-Coefficient-Solid]
-    - mesh: Solid-to-Outer-Fluid
+    - mesh: Solid-to-Fluid-Outer
       patch: outer-interface
-      read-data: [Sink-Temperature-Outer-Fluid, Heat-Transfer-Coefficient-Outer-Fluid]
+      read-data: [Sink-Temperature-Fluid-Outer, Heat-Transfer-Coefficient-Fluid-Outer]
       write-data: [Sink-Temperature-Solid, Heat-Transfer-Coefficient-Solid]
 precice-config-file: ../precice-config.xml


### PR DESCRIPTION
To make it consistent with the folder names:
* fluid-inner-openfoam
* fluid-outer-openfoam