### PR TITLE
Add GitHub actions to check Markdown files and links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,14 @@
+name: Check links
+on: [push, pull_request]
+jobs:
+  check_links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Check links in markdown files (markdown-link-check)
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'no'
+          config-file: '.markdown-link-check-config.json'

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -1,0 +1,14 @@
+name: Lint docs and check links
+on: [push, pull_request]
+jobs:
+  check_md:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Lint markdown files (markdownlint)
+        uses: articulate/actions-markdownlint@v1
+        with:
+          config: .markdownlint.json
+          files: '.'
+          ignore: changelog-entries

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -1,4 +1,4 @@
-name: Lint docs and check links
+name: Lint docs
 on: [push, pull_request]
 jobs:
   check_md:

--- a/.github/workflows/check-scripts.yaml
+++ b/.github/workflows/check-scripts.yaml
@@ -1,7 +1,7 @@
-name: Checks
+name: Check scripts
 on: [push, pull_request]
 jobs:
-  checks:
+  check_scripts:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.markdown-link-check-config.json
+++ b/.markdown-link-check-config.json
@@ -1,0 +1,3 @@
+{
+  "aliveStatusCodes": [429, 200]
+}

--- a/.markdown-link-check-config.json
+++ b/.markdown-link-check-config.json
@@ -1,3 +1,3 @@
 {
-  "aliveStatusCodes": [429, 200]
+  "aliveStatusCodes": [429, 403, 200]
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+    "MD013": false,
+    "MD033": false
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contribute to the preCICE tutorials
+
 It is amazing that you want to contribute a tutorial case for preCICE!
 
 We welcome contributions and we have a few guidelines and tips that you can follow in the [preCICE website](https://precice.org/community-contribute-to-precice.html).

--- a/elastic-tube-1d/README.md
+++ b/elastic-tube-1d/README.md
@@ -29,8 +29,8 @@ The following parameters have been chosen:
 
 Both fluid and solid participant are supported in:
 
-- *C++*: An example solver using the intrinsic [C++ API of preCICE](couple-your-code-api.html). This solver also depends on LAPACK (e.g. on Ubuntu `sudo apt-get install liblapack-dev`)
-- *Python*: An example solver using the preCICE [Python bindings](installation-bindings-python.html). This solver also depends on the Python libraries `numpy scipy matplotlib vtk mpi4py`, which you can get from your system package manager or with `pip3 install --user <package>`.
+- *C++*: An example solver using the intrinsic [C++ API of preCICE](https://www.precice.org/couple-your-code-api.html). This solver also depends on LAPACK (e.g. on Ubuntu `sudo apt-get install liblapack-dev`)
+- *Python*: An example solver using the preCICE [Python bindings](https://www.precice.org/installation-bindings-python.html). This solver also depends on the Python libraries `numpy scipy matplotlib vtk mpi4py`, which you can get from your system package manager or with `pip3 install --user <package>`.
 
 ### Building the C++ Solver
 

--- a/elastic-tube-3d/README.md
+++ b/elastic-tube-3d/README.md
@@ -11,17 +11,17 @@ summary: Tutorial for an FSI simulation of a three-dimensional expanding tube sc
 
 The expanding tube test case involves a cylindrical fluid domain surrounded by a solid domain. A pressure inlet boundary condition is applied at the inlet for 3 milliseconds, and then 0 set to zero for a further 7 millisecond. The pressure of the fluid expands the tube which then relaxes once the pressure decreases.
 
-The expanding tube test case comes with the interface surface mesh connectivity of the solid domain. This allows the use of nearest-projection mapping of the displacements of the solid domain. In order to run the example with nearest projection mapping, the "node-mesh-with-connectivity" has been specified in the `solid-calculix/config.yml` file. More details can be found in the [CalculiX configuration description](adapter-calculix-config.html#nearest-projection-mapping).
+The expanding tube test case comes with the interface surface mesh connectivity of the solid domain. This allows the use of nearest-projection mapping of the displacements of the solid domain. In order to run the example with nearest projection mapping, the "node-mesh-with-connectivity" has been specified in the `solid-calculix/config.yml` file. More details can be found in the [CalculiX configuration description](https://www.precice.org/adapter-calculix-config.html#nearest-projection-mapping).
 
 ## Available solvers
 
 Fluid participant:
 
-* OpenFOAM. This tutorial is known to work with OpenFOAM 4.1, 5.0, but it should also work with newer versions. The case files are prepared for the latest versions of OpenFOAM and use the solver `pimpleFoam`. In case you are using a previous OpenFOAM version you need to adjust the solver to `pimpleDyMFoam` in the `Fluid/system/controlDict` file. For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
+* OpenFOAM. This tutorial is known to work with OpenFOAM 4.1, 5.0, but it should also work with newer versions. The case files are prepared for the latest versions of OpenFOAM and use the solver `pimpleFoam`. In case you are using a previous OpenFOAM version you need to adjust the solver to `pimpleDyMFoam` in the `Fluid/system/controlDict` file. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
 
 Solid participant:
 
-* CalculiX. This tutorial is known to work with CalculiX 2.15, but it should also work with newer versions. For more information, have a look at the [CalculiX adapter documentation](adapter-calculix-overview.html).
+* CalculiX. This tutorial is known to work with CalculiX 2.15, but it should also work with newer versions. For more information, have a look at the [CalculiX adapter documentation](https://www.precice.org/adapter-calculix-overview.html).
 
 ## Running the simulation
 

--- a/flow-over-heated-plate-nearest-projection/README.md
+++ b/flow-over-heated-plate-nearest-projection/README.md
@@ -9,19 +9,19 @@ summary: This tutorial introduces an example simulation setup for a nearest-proj
 
 ## Setup
 
-The setup is exactly the same as described in our [flow-over-heated-plate tutorial](tutorials-flow-over-heated-plate.html).
+The setup is exactly the same as described in our [flow-over-heated-plate tutorial](https://www.precice.org/tutorials-flow-over-heated-plate.html).
 
 ## Available solvers
 
 Fluid participant:
 
-* OpenFOAM (buoyantPimpleFoam). For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
+* OpenFOAM (buoyantPimpleFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
 
 Solid participant:
 
-* OpenFOAM (laplacianFoam). For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
+* OpenFOAM (laplacianFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
 
-The solvers are currently only OpenFOAM related. For information regarding the nearest-projection mapping, have a look in the [OpenFOAM configuration section](adapter-openfoam-config.html).
+The solvers are currently only OpenFOAM related. For information regarding the nearest-projection mapping, have a look in the [OpenFOAM configuration section](https://www.precice.org/adapter-openfoam-config.html).
 
 ## Running the Simulation
 
@@ -66,7 +66,7 @@ From the preCICE point of view, the simulation here is in 3D, as opposed to the 
 
 ## Post-processing
 
-Have a look at the [flow-over heated-plate](tutorials-flow-over-heated-plate.html) tutorial for the general aspects of post-processing.
+Have a look at the [flow-over heated-plate](https://www.precice.org/tutorials-flow-over-heated-plate.html) tutorial for the general aspects of post-processing.
 Since we now defined mesh connectivity on our interface, we can export the coupling interface with the tag `<export:vtk directory="preCICE-output" />` in our `precice-config.xml`.
 Visualizing these files (e.g. using ParaView) will show a triangular mesh, even though you use hexahedral meshes. This has nothing to do with your mesh and is just caused by the way the connectivity is defined in preCICE. As described above, the function `setMeshTriangles` is used to define the connectivity. Hence, every interface cell/face is represented by two triangles. The following image should give you an impression of a possible triangulated coupling mesh, which consists purely of hexahedral cells:
 

--- a/flow-over-heated-plate-nearest-projection/README.md
+++ b/flow-over-heated-plate-nearest-projection/README.md
@@ -23,7 +23,6 @@ Solid participant:
 
 The solvers are currently only OpenFOAM related. For information regarding the nearest-projection mapping, have a look in the [OpenFOAM configuration section](adapter-openfoam-config.html).
 
-
 ## Running the Simulation
 
 Open two separate terminals and start each participant by calling the respective run script.

--- a/flow-over-heated-plate-steady-state/README.md
+++ b/flow-over-heated-plate-steady-state/README.md
@@ -9,7 +9,7 @@ summary: Using a steady-state OpenFOAM solver for a CHT coupling with code_aster
 
 ## Setup
 
-The setup for this tutorial is similar to the [flow over a heated plate](tutorials-flow-over-heated-plate.html) using OpenFOAM. In this tutorial OpenFOAM is used as the solver for the fluid domain, and code_aster is the solver for the solid domain. A difference here is that we are using a steady-state OpenFOAM solver for demonstration purposes, therefore the results between the two tutorials are not comparable.
+The setup for this tutorial is similar to the [flow over a heated plate](https://www.precice.org/tutorials-flow-over-heated-plate.html) using OpenFOAM. In this tutorial OpenFOAM is used as the solver for the fluid domain, and code_aster is the solver for the solid domain. A difference here is that we are using a steady-state OpenFOAM solver for demonstration purposes, therefore the results between the two tutorials are not comparable.
 
 {% include note.html content="This is a pseudo-2D case, but we still set a 3D `solver-interface` in `precice-config.xml`, because the code_aster case is set up like this at the moment. Contributions here are particularly welcome!" %}
 
@@ -17,11 +17,11 @@ The setup for this tutorial is similar to the [flow over a heated plate](tutoria
 
 Fluid participant:
 
-* OpenFOAM. We use buoyantSimpleFoam instead of the transient buoyantPimpleFoam. For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
+* OpenFOAM. We use buoyantSimpleFoam instead of the transient buoyantPimpleFoam. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
 
 Solid participant:
 
-* code_aster. The [code_aster adapter documentation](adapter-code_aster.html) is oriented on this tutorial case. In particular the described configuration settings.
+* code_aster. The [code_aster adapter documentation](https://www.precice.org/adapter-code_aster.html) is oriented on this tutorial case. In particular the described configuration settings.
 
 ## Running the Simulation
 

--- a/flow-over-heated-plate/README.md
+++ b/flow-over-heated-plate/README.md
@@ -35,15 +35,18 @@ Solid participant:
 
 All listed solvers can be used in order to run the simulation. Open two separate terminals and start the desired fluid and solid participant by calling the respective run script `run.sh` located in the participant directory. For example:
 
-```
+```bash
 cd fluid-openfoam
 ./run.sh
 ```
+
 and
-```
+
+```bash
 cd solid-fenics
 ./run.sh
 ```
+
 in order to use OpenFOAM and FEniCS for this test case. Feel free to try different combinations, they should all run and give approximately similar results.
 
 ## Post-processing
@@ -65,7 +68,7 @@ You may use additional filters, such as the Calculator and the Plot Over Line, t
 
 First generate the output for each run by adding export to the participant `Solid` in `precice-config.xml`:
 
-```
+```xml
 <participant name="Solid">
   <export:vtk directory="preCICE-output" />
   <use-mesh name="Fluid-Mesh" from="Fluid" />
@@ -76,7 +79,7 @@ First generate the output for each run by adding export to the participant `Soli
 
 After that running a case from this tutorial will export data into `solid-*/preCICE-output`. To visualize and compare these results run `python3 plot-final-interface-temperature.py` (You can install the required python packages by running `pip3 install -r plot-final-interface-temperature-requirements.txt`). This will plot the dimensionless temperature `theta = (T-300)/(310-300)` (with `T` being the temperature) across the coupling interface, i.e. where the solid and the fluid meet and exchange heat. The x-axis shows the x coordinate and the y-axis the dimensionless temperature `theta` at the interface. If you want to exclude certain cases, simply comment out the corresponding lines in the script. For reference see below:
 
-![](images/tutorials-flow-over-heated-plate-results-comparison.png)
+![Comparison of the results with different solvers](images/tutorials-flow-over-heated-plate-results-comparison.png)
 
 ## References
 

--- a/flow-over-heated-plate/README.md
+++ b/flow-over-heated-plate/README.md
@@ -23,13 +23,13 @@ By default, the fluid participant reads heat-flux values and the solid participa
 
 Fluid participant:
 
-* OpenFOAM (buoyantPimpleFoam). For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
+* OpenFOAM (buoyantPimpleFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
 
 Solid participant:
 
-* OpenFOAM (laplacianFoam). For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
+* OpenFOAM (laplacianFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
 
-* FEniCS. For more information, have a look at the [FeniCS adapter documentation](adapter-fenics.html).
+* FEniCS. For more information, have a look at the [FeniCS adapter documentation](https://www.precice.org/adapter-fenics.html).
 
 ## Running the Simulation
 

--- a/heat-exchanger/README.md
+++ b/heat-exchanger/README.md
@@ -23,9 +23,9 @@ We define the participants `Inner-Fluid`, `Solid`, and `Outer-Fluid` and two int
 
 ## Available solvers
 
-* OpenFOAM. `buoyantSimpleFoam` is used for fluid flow (both participants). This is a solver for steady-state, buoyant, turbulent flow of compressible fluids for ventilation and heat transfer. For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
+* OpenFOAM. `buoyantSimpleFoam` is used for fluid flow (both participants). This is a solver for steady-state, buoyant, turbulent flow of compressible fluids for ventilation and heat transfer. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
 
-* CalculiX. For more information, have a look at the [CalculiX adapter documentation](adapter-calculix-overview.html).
+* CalculiX. For more information, have a look at the [CalculiX adapter documentation](https://www.precice.org/adapter-calculix-overview.html).
 
 ## Running the Simulation
 

--- a/multiple-perpendicular-flaps/README.md
+++ b/multiple-perpendicular-flaps/README.md
@@ -107,7 +107,7 @@ The scenario settings are implemented similarly for the nonlinear case.
 
 After the simulation has finished, you can visualize your results using e.g. ParaView. Fluid results are in the OpenFOAM format and you may load the `fluid-openfoam.foam` file. Looking at the fluid results is enough to obtain information about the behaviour of the flaps. You can also visualize the solid participants' vtks though.
 
-![](images/tutorials-multiple-perpendicular-flaps-results.png)
+![Example visualization](images/tutorials-multiple-perpendicular-flaps-results.png)
 
 ## References
 

--- a/multiple-perpendicular-flaps/README.md
+++ b/multiple-perpendicular-flaps/README.md
@@ -21,11 +21,11 @@ The inflow velocity is 5 m/s (uniform) on the left boundary.
 At the outlet, pressure is set to zero and velocity to `zeroGradient`.
 The top, bottom and flap are walls with a `noslip` condition.
 
-For a case showing fluid-structure interaction only (no multi-coupling), take a look at the [single perpendicular flap tutorial](tutorials-perpendicular-flap.html).
+For a case showing fluid-structure interaction only (no multi-coupling), take a look at the [single perpendicular flap tutorial](https://www.precice.org/tutorials-perpendicular-flap.html).
 
 ## Why multi-coupling?
 
-This is a case with three participants: the fluid and each flap. In preCICE, there are two options to [couple more than two participants](configuration-coupling-multi.html). The first option a composition of bi-coupling schemes, in which we must specify the exchange of data in a participant to participant manner. However, such a composition is not suited for combining multiple strong fluid-structure interations [1]. Thus, in this case, we use the second option, fully-implicit multi-coupling.
+This is a case with three participants: the fluid and each flap. In preCICE, there are two options to [couple more than two participants](https://www.precice.org/configuration-coupling-multi.html). The first option a composition of bi-coupling schemes, in which we must specify the exchange of data in a participant to participant manner. However, such a composition is not suited for combining multiple strong fluid-structure interations [1]. Thus, in this case, we use the second option, fully-implicit multi-coupling.
 
 We can set this in our `precice-config.xml`:
 
@@ -67,7 +67,7 @@ The scenario settings are implemented similarly for the nonlinear case.
 ## Running the Simulation
 
 1. Preparation:
-   To run the coupled simulation, copy the deal.II executable `linear_elasticity` or `nonlinear_elasticity` into the main folder. To learn how to obtain the deal.II executable take a look at the description on the  [deal.II-adapter page](adapter-dealii-overview.html).
+   To run the coupled simulation, copy the deal.II executable `linear_elasticity` or `nonlinear_elasticity` into the main folder. To learn how to obtain the deal.II executable take a look at the description on the  [deal.II-adapter page](https://www.precice.org/adapter-dealii-overview.html).
 2. Starting:
 
    We are going to run each solver in a different terminal. It is important that first we navigate to the simulation directory so that all solvers start in the same directory.

--- a/partitioned-elastic-beam/README.md
+++ b/partitioned-elastic-beam/README.md
@@ -15,7 +15,7 @@ We have a rectangular linear elastic beam of dimensions 1 x 1 x 8 m, divided in 
 
 ## Available solvers
 
-* CalculiX. CalculiX is used for both structural parts. For more information, have a look at the [CalculiX adapter documentation](adapter-calculix-overview.html) for more.
+* CalculiX. CalculiX is used for both structural parts. For more information, have a look at the [CalculiX adapter documentation](https://www.precice.org/adapter-calculix-overview.html) for more.
 
 ## Running the Simulation
 

--- a/partitioned-pipe/README.md
+++ b/partitioned-pipe/README.md
@@ -17,9 +17,9 @@ On the coupling interface, Fluid1 sends velocity and pressure gradient to Fluid2
 
 Both for Fluid1 and Fluid2, the following participants are available:
 
-* OpenFOAM (pimpleFoam). An incompressible OpenFOAM solver. For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
+* OpenFOAM (pimpleFoam). An incompressible OpenFOAM solver. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
 
-* OpenFOAM (sonicLiquidFoam). A compressible OpenFOAM solver. For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
+* OpenFOAM (sonicLiquidFoam). A compressible OpenFOAM solver. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
 
 ## Running the Simulation
 

--- a/perpendicular-flap/README.md
+++ b/perpendicular-flap/README.md
@@ -19,19 +19,19 @@ The simulated flow domain is 6 units long (x) and 4 units tall (y). The flap is 
 
 Fluid participant:
 
-* OpenFOAM. For older OpenFOAM versions, the solver name differs: If you are using OpenFOAM v1712 / 5.x or older have a look at `fluid-openfoam/system/controlDict` and set the appropriate solver name. The solver can run in parallel using the command line argument `run.sh -parallel`. For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
+* OpenFOAM. For older OpenFOAM versions, the solver name differs: If you are using OpenFOAM v1712 / 5.x or older have a look at `fluid-openfoam/system/controlDict` and set the appropriate solver name. The solver can run in parallel using the command line argument `run.sh -parallel`. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
 
-* Nutils. For more information, have a look at the [Nutils adapter documentation](adapter-nutils.html). This Nutils solver requires at least Nutils v6.0.
+* Nutils. For more information, have a look at the [Nutils adapter documentation](https://www.precice.org/adapter-nutils.html). This Nutils solver requires at least Nutils v6.0.
 
-* SU2. As opposed to the other two fluid codes, SU2 is in particular specialized for compressible flow. Therefore the default simulation parameters haven been adjusted in order to pull the setup into the compressible flow regime. For more information, have a look at the [SU2 adapter documentation](adapter-su2-overview.html).
+* SU2. As opposed to the other two fluid codes, SU2 is in particular specialized for compressible flow. Therefore the default simulation parameters haven been adjusted in order to pull the setup into the compressible flow regime. For more information, have a look at the [SU2 adapter documentation](https://www.precice.org/adapter-su2-overview.html).
 
 Solid participant:
 
-* FEniCS. The structural model is currently limited to linear elasticity. For more information, have a look at the [FeniCS adapter documentation](adapter-fenics.html).
+* FEniCS. The structural model is currently limited to linear elasticity. For more information, have a look at the [FeniCS adapter documentation](https://www.precice.org/adapter-fenics.html).
 
-* CalculiX. In order to allow a reasonable comparison to all solid codes, the geometrically non-linear solver has been disabled and only a linear model is used by default. For more information, have a look at the [CalculiX adapter documentation](adapter-calculix-overview.html)
+* CalculiX. In order to allow a reasonable comparison to all solid codes, the geometrically non-linear solver has been disabled and only a linear model is used by default. For more information, have a look at the [CalculiX adapter documentation](https://www.precice.org/adapter-calculix-overview.html)
 
-* deal.II. This tutorial works only with `Model = linear` since the deal.II codes were developed with read data `Stress` instead of `Force` as applied here (example given in Turek-Hron-FSI) in the first place. The `./run.sh` script takes the compiled executable `elasticity` as input argument (`run.sh -e=/path/to/elasticity`) and is required in case the executable is not discoverable at runtime (e.g. has been added to the system `PATH`). For more information, have a look at the [deal.II adapter documentation](adapter-dealii-overview.html).
+* deal.II. This tutorial works only with `Model = linear` since the deal.II codes were developed with read data `Stress` instead of `Force` as applied here (example given in Turek-Hron-FSI) in the first place. The `./run.sh` script takes the compiled executable `elasticity` as input argument (`run.sh -e=/path/to/elasticity`) and is required in case the executable is not discoverable at runtime (e.g. has been added to the system `PATH`). For more information, have a look at the [deal.II adapter documentation](https://www.precice.org/adapter-dealii-overview.html).
 
 ## Running the Simulation
 

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -114,10 +114,10 @@ You may be curious what displacements OpenFOAM received from the rigid body solv
 
 To become a preCICE pro:
 
-- Get an overview of the [preCICE docs](docs.html).
+- Get an overview of the [preCICE docs](https://www.precice.org/docs.html).
 - See what users talk about in the [preCICE forum](https://precice.discourse.group/).
-- Run [tutorials with other coupled solvers](tutorials.html).
+- Run [tutorials with other coupled solvers](https://www.precice.org/tutorials.html).
 - Watch some [preCICE videos](https://www.youtube.com/c/preCICECoupling/).
-- Meet our [community](community.html).
-- Find out how to [couple your own solver](couple-your-code-overview.html).
-- Tell us [your story](community-projects.html).
+- Meet our [community](https://www.precice.org/community.html).
+- Find out how to [couple your own solver](https://www.precice.org/couple-your-code-overview.html).
+- Tell us [your story](https://www.precice.org/community-projects.html).

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -25,9 +25,9 @@ To get a feeling what preCICE does, watch a [short presentation](https://www.you
     sudo apt install ./libprecice2_2.2.0_focal.deb
     ```
 
-    - Are you using something else? Just pick what suits you best on [this overview page](installation-overview.html).
-    - Facing any problems? [Ask for help](community-channels.html).
-2. We will use OpenFOAM here and in many of our tutorial cases, so [install OpenFOAM](adapter-openfoam-support.html):
+    - Are you using something else? Just pick what suits you best on [this overview page](https://www.precice.org/installation-overview.html).
+    - Facing any problems? [Ask for help](https://www.precice.org/community-channels.html).
+2. We will use OpenFOAM here and in many of our tutorial cases, so [install OpenFOAM](https://www.precice.org/adapter-openfoam-support.html):
 
     ```bash
     # Add the signing key, add the repository, update (check this):
@@ -45,7 +45,7 @@ To get a feeling what preCICE does, watch a [short presentation](https://www.you
     sudo apt install build-essential pkg-config cmake git
     ```
 
-4. Download and install the [OpenFOAM-preCICE adapter](adapter-openfoam-get.html):
+4. Download and install the [OpenFOAM-preCICE adapter](https://www.precice.org/adapter-openfoam-get.html):
 
     ```bash
      git clone --branch=master --depth 1 https://github.com/precice/openfoam-adapter
@@ -61,7 +61,7 @@ To get a feeling what preCICE does, watch a [short presentation](https://www.you
     cd tutorials/quickstart
     ```
 
-If you prefer to easily try everything in an isolated environment, you may prefer using our [demo virtual machine](installation-vm.html).
+If you prefer to easily try everything in an isolated environment, you may prefer using our [demo virtual machine](https://www.precice.org/installation-vm.html).
 
 ## Case setup
 

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -74,6 +74,7 @@ In order to gain more control over the rigid body oscillation, a rotational spri
 ## Building the rigid body solver
 
 Before starting the coupled simulation, we need to build the rigid body solver. You can run the following commands from the `solid-cpp` directory to build the `rigid_body_solver.cpp`:
+
 ```bash
 cd tutorials/quickstart/solid-cpp
 cmake . && make

--- a/turek-hron-fsi3/README.md
+++ b/turek-hron-fsi3/README.md
@@ -19,13 +19,13 @@ For more information please refer to the original publication of the benchmark [
 
 Fluid participant:
 
-* OpenFOAM. For more information, have a look at the [OpenFOAM adapter documentation](adapter-openfoam-overview.html).
+* OpenFOAM. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
 
 {% include important.html content="For the parabolic inflow profile, this tutorial requires groovyBC. groovyBC is part of swak4Foam. You can find more explanations in [openfoamwiki.net](https://openfoamwiki.net/index.php/Contrib/swak4Foam) or get it from an [unofficial GitHub mirror](https://github.com/Unofficial-Extend-Project-Mirror/openfoam-extend-swak4Foam-dev.git). Please follow the building instructions there." %}
 
 Solid participant:
 
-* deal.II. For more information, have a look at the [deal.II adapter documentation](adapter-dealii-overview.html). This tutorial requires the nonlinear solid solver. Please copy the nonlinear solver executable to the `solid-dealii` folder or make it discoverable at runtime and update the `solid-dealii/run.sh` script.
+* deal.II. For more information, have a look at the [deal.II adapter documentation](https://www.precice.org/adapter-dealii-overview.html). This tutorial requires the nonlinear solid solver. Please copy the nonlinear solver executable to the `solid-dealii` folder or make it discoverable at runtime and update the `solid-dealii/run.sh` script.
 
 ## Running the Simulation
 
@@ -86,7 +86,7 @@ For the double-refined mesh, it is wisely to use local basis functions in the RB
                             support-radius="0.011" constraint="consistent" />
 ```
 
-You can find more information on RBF data mapping in the [documentation](configuration-mapping.html#radial-basis-function-mapping).
+You can find more information on RBF data mapping in the [documentation](https://www.precice.org/configuration-mapping.html#radial-basis-function-mapping).
 
 ## References
 


### PR DESCRIPTION
Similarly to https://github.com/precice/openfoam-adapter/pull/169, this adds a GitHub action to check Markdown files for common issues and another GitHub action to check for dead links.

Following a decision we recently had, this replaces all relative links to precice.org with static ones.