### PR TITLE
Add community-related files

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -3,6 +3,7 @@ name: Issue template
 about: Check this out before opening an issue
 
 ---
+<!-- markdownlint-disable-file MD041 -->
 <!-- 
        Hey! Thank you for reporting an issue!
        Just to make sure: is this really an issue or do you need some help

--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -3,7 +3,6 @@ name: Issue template
 about: Check this out before opening an issue
 
 ---
-
 <!-- 
        Hey! Thank you for reporting an issue!
        Just to make sure: is this really an issue or do you need some help
@@ -15,15 +14,12 @@ about: Check this out before opening an issue
        ```
        This is an error message
        ```
+
+       If this is a bug, please provide the following information.
+       You can generate log files with `./run.sh > solver.log 2>&1`.
 -->
-
-# Thank you for contributing
-
-If this is a bug, please provide the following information:
 
 - Tutorials state (last commit / release):
 - Versions of solvers and adapters used:
 - preCICE version:
 - Log files:
-
-You can generate log files with `./run.sh > solver.log 2>&1`.

--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -1,0 +1,29 @@
+---
+name: Issue template
+about: Check this out before opening an issue
+
+---
+
+<!-- 
+       Hey! Thank you for reporting an issue!
+       Just to make sure: is this really an issue or do you need some help
+       with troubleshooting? Please use our community channels if you need help:
+       https://precice.org/community-channels.html
+       Thanks! :-)
+
+       Please wrap any error messages with three backticks before and after:
+       ```
+       This is an error message
+       ```
+-->
+
+# Thank you for contributing
+
+If this is a bug, please provide the following information:
+
+- Tutorials state (last commit / release):
+- Versions of solvers and adapters used:
+- preCICE version:
+- Log files:
+
+You can generate log files with `./run.sh > solver.log 2>&1`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+# Thank you for contributing
+
+Please submit your Pull Request to the `develop` branch of the tutorials.
+
+It may help to have a look at the file `CONTRIBUTING.md` for a few hints and guidelines.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-# Thank you for contributing
+<!-- Please submit your Pull Request to the `develop` branch.
 
-Please submit your Pull Request to the `develop` branch of the tutorials.
-
-It may help to have a look at the file `CONTRIBUTING.md` for a few hints and guidelines.
+It may help to have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -10,5 +10,5 @@ jobs:
         uses: articulate/actions-markdownlint@v1
         with:
           config: .markdownlint.json
-          files: '. !.github'
-          ignore: changelog-entries
+          files: '.'
+          ignore: changelog-entries .github

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -10,5 +10,5 @@ jobs:
         uses: articulate/actions-markdownlint@v1
         with:
           config: .markdownlint.json
-          files: '.'
+          files: '. !.github'
           ignore: changelog-entries

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -11,4 +11,4 @@ jobs:
         with:
           config: .markdownlint.json
           files: '.'
-          ignore: changelog-entries .github
+          ignore: changelog-entries

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+<!-- markdownlint-configure-file {"MD034": false } -->
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+info at precice.org.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.


### PR DESCRIPTION
This adds the following long-overdue files (as previously decided):
- `CODE_OF_CONDUCT.md` - [Contributor Covenant](https://www.contributor-covenant.org/)
- Pull request template, pointing to `CONTRIBUTING.md` (which points to [contribute to preCICE](https://precice.org/community-contribute-to-precice.html)).
- Issue template, pointing to our community channels and asking for versions

Part of the motivation: tick all the boxes in the [Community insights](https://github.com/precice/tutorials/community). Another part: guide the users better.

@uekerman check the templates and merge if everything looks fine.