### PR TITLE
Add OpenFOAM partitioned heat equation

### DIFF
--- a/partitioned-heat-conduction/fenics/heat.py
+++ b/partitioned-heat-conduction/fenics/heat.py
@@ -170,7 +170,7 @@ f.t = t + dt(0)
 
 if problem is ProblemType.DIRICHLET:
     flux = Function(V_g)
-    flux.rename("Flux", "")
+    flux.rename("Heat-Flux", "")
 
 while precice.is_coupling_ongoing():
 

--- a/partitioned-heat-conduction/fenics/precice-adapter-config-D.json
+++ b/partitioned-heat-conduction/fenics/precice-adapter-config-D.json
@@ -3,7 +3,7 @@
   "config_file_name": "../precice-config.xml",
   "interface": {
       "coupling_mesh_name": "Dirichlet-Mesh",
-      "write_data_name": "Flux",
+      "write_data_name": "Heat-Flux",
       "read_data_name": "Temperature"
     }
 }

--- a/partitioned-heat-conduction/fenics/precice-adapter-config-N.json
+++ b/partitioned-heat-conduction/fenics/precice-adapter-config-N.json
@@ -4,6 +4,6 @@
   "interface": {
       "coupling_mesh_name": "Neumann-Mesh",
       "write_data_name": "Temperature",
-      "read_data_name": "Flux"
+      "read_data_name": "Heat-Flux"
     }
 }

--- a/partitioned-heat-conduction/nutils/heat.py
+++ b/partitioned-heat-conduction/nutils/heat.py
@@ -69,7 +69,7 @@ def main(side='Dirichlet'):
 
     # coupling data
     write_data = "Temperature" if side == "Neumann" else "Flux"
-    read_data = "Flux" if side == "Neumann" else "Temperature"
+    read_data = "Heat-Flux" if side == "Neumann" else "Temperature"
     write_data_id = interface.get_data_id(write_data, mesh_id)
     read_data_id = interface.get_data_id(read_data, mesh_id)
 

--- a/partitioned-heat-conduction/openfoam-dirichlet/0/T
+++ b/partitioned-heat-conduction/openfoam-dirichlet/0/T
@@ -1,46 +1,148 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  2012                                  |
+|   \\  /    A nd           | Website:  www.openfoam.com                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
 FoamFile
 {
     version     2.0;
     format      ascii;
     class       volScalarField;
+    location    "0";
     object      T;
 }
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
 dimensions      [0 0 0 1 0 0 0];
 
-internalField   uniform 1;
+
+internalField   nonuniform List<scalar> 
+100
+(
+1.01
+1.03
+1.07
+1.13
+1.21
+1.31
+1.43
+1.57
+1.73
+1.91
+1.07
+1.09
+1.13
+1.19
+1.27
+1.37
+1.49
+1.63
+1.79
+1.97
+1.19
+1.21
+1.25
+1.31
+1.39
+1.49
+1.61
+1.75
+1.91
+2.09
+1.37
+1.39
+1.43
+1.49
+1.57
+1.67
+1.79
+1.93
+2.09
+2.27
+1.61
+1.63
+1.67
+1.73
+1.81
+1.91
+2.03
+2.17
+2.33
+2.51
+1.91
+1.93
+1.97
+2.03
+2.11
+2.21
+2.33
+2.47
+2.63
+2.81
+2.27
+2.29
+2.33
+2.39
+2.47
+2.57
+2.69
+2.83
+2.99
+3.17
+2.69
+2.71
+2.75
+2.81
+2.89
+2.99
+3.11
+3.25
+3.41
+3.59
+3.17
+3.19
+3.23
+3.29
+3.37
+3.47
+3.59
+3.73
+3.89
+4.07
+3.71
+3.73
+3.77
+3.83
+3.91
+4.01
+4.13
+4.27
+4.43
+4.61
+)
+;
 
 boundaryField
 {
+    DirichletBoundary
+    {
+        type            groovyBC;
+	variables   "alpha=3;beta=1.3;para=1+pow(pos().x,2)+(alpha*pow(pos().y,2));";
+	valueExpression  "para+(beta*time())";
+	value        uniform 1;
+    }
     interface
     {
         type            fixedValue;
-        value           $internalField;
+	value           uniform 0;
     }
-
-    heatSource
-    {
-        type            fixedValue;
-        value           uniform 10;
-    }
-
-    left
-    {
-        type            zeroGradient;
-    }
-
-    top
-    {
-        type            zeroGradient;
-    }
-
-    bottom
-    {
-        type            zeroGradient;
-    }
-
     defaultFaces
     {
         type            empty;
     }
 }
+
+
+// ************************************************************************* //

--- a/partitioned-heat-conduction/openfoam-dirichlet/0/T
+++ b/partitioned-heat-conduction/openfoam-dirichlet/0/T
@@ -1,0 +1,46 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      T;
+}
+
+dimensions      [0 0 0 1 0 0 0];
+
+internalField   uniform 1;
+
+boundaryField
+{
+    interface
+    {
+        type            fixedValue;
+        value           $internalField;
+    }
+
+    heatSource
+    {
+        type            fixedValue;
+        value           uniform 10;
+    }
+
+    left
+    {
+        type            zeroGradient;
+    }
+
+    top
+    {
+        type            zeroGradient;
+    }
+
+    bottom
+    {
+        type            zeroGradient;
+    }
+
+    defaultFaces
+    {
+        type            empty;
+    }
+}

--- a/partitioned-heat-conduction/openfoam-dirichlet/clean.sh
+++ b/partitioned-heat-conduction/openfoam-dirichlet/clean.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e -u
+
+. ../../tools/cleaning-tools.sh
+
+clean_openfoam .

--- a/partitioned-heat-conduction/openfoam-dirichlet/constant/transportProperties
+++ b/partitioned-heat-conduction/openfoam-dirichlet/constant/transportProperties
@@ -1,0 +1,10 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      transportProperties;
+}
+
+DT               DT  [ 0  2 -1  0 0 0 0 ] 1;

--- a/partitioned-heat-conduction/openfoam-dirichlet/run.sh
+++ b/partitioned-heat-conduction/openfoam-dirichlet/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e -u
+
+blockMesh
+topoSet
+createPatch
+touch openfoam-dirichlet.foam
+
+../../tools/run-openfoam.sh "$@"
+. ../../tools/openfoam-remove-empty-dirs.sh && openfoam_remove_empty_dirs

--- a/partitioned-heat-conduction/openfoam-dirichlet/system/blockMeshDict
+++ b/partitioned-heat-conduction/openfoam-dirichlet/system/blockMeshDict
@@ -1,0 +1,75 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      blockMeshDict;
+}
+
+vertices
+(
+
+    (0 0 0)
+    (1 0 0)
+    (1 1 0)
+    (0 1 0)
+
+    (0 0 .1)
+    (1 0 .1)
+    (1 1 .1)
+    (0 1 .1)
+);
+
+blocks
+(
+    hex (0 1 2 3 4 5 6 7) (10 10 1) simpleGrading (1 1 1)
+);
+
+edges
+(
+);
+
+boundary
+(
+
+    left
+    {
+        type wall;
+        faces
+        (
+            (4 7 3 0)
+        );
+    }
+
+    interface
+    {
+        type wall;
+        faces
+        (
+            (1 2 6 5)
+        );
+    }
+
+    top
+    {
+        type wall;
+        faces
+        (
+            (7 6 2 3)
+        );
+    }
+
+    bottom
+    {
+        type wall;
+        faces
+        (
+            (4 0 1 5)
+        );
+    }
+
+);
+
+mergePatchPairs
+(
+);

--- a/partitioned-heat-conduction/openfoam-dirichlet/system/controlDict
+++ b/partitioned-heat-conduction/openfoam-dirichlet/system/controlDict
@@ -1,0 +1,47 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      controlDict;
+}
+
+application     laplacianFoam;
+
+startFrom       startTime;
+
+startTime       0;
+
+stopAt          endTime;
+
+endTime         1;
+
+deltaT          0.01;
+
+writeControl    runTime;
+
+writeInterval   0.2;
+
+purgeWrite      0;
+
+writeFormat     ascii;
+
+writePrecision  6;
+
+writeCompression off;
+
+timeFormat      general;
+
+timePrecision   6;
+
+runTimeModifiable false;
+
+functions
+{
+    preCICE_Adapter
+    {
+        type preciceAdapterFunctionObject;
+        libs ("libpreciceAdapterFunctionObject.so");
+    }
+}

--- a/partitioned-heat-conduction/openfoam-dirichlet/system/createPatchDict
+++ b/partitioned-heat-conduction/openfoam-dirichlet/system/createPatchDict
@@ -1,0 +1,24 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      createPatchDict;
+}
+
+pointSync true;
+
+patches
+(
+    {
+        name heatSource;
+
+        patchInfo
+        {
+            type patch;
+        }
+
+        constructFrom set;
+        set heatSourceSet;
+    }
+);

--- a/partitioned-heat-conduction/openfoam-dirichlet/system/decomposeParDict
+++ b/partitioned-heat-conduction/openfoam-dirichlet/system/decomposeParDict
@@ -1,0 +1,16 @@
+FoamFile {
+    version 2.0;
+    class dictionary;
+    object decomposeParDict;
+    format ascii;
+}
+
+numberOfSubdomains 2;
+
+method          simple;
+
+simpleCoeffs
+{
+    n               (2 1 1);
+    delta           0.001;
+}

--- a/partitioned-heat-conduction/openfoam-dirichlet/system/fvSchemes
+++ b/partitioned-heat-conduction/openfoam-dirichlet/system/fvSchemes
@@ -1,0 +1,40 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSchemes;
+}
+
+ddtSchemes
+{
+    default         Euler;
+}
+
+gradSchemes
+{
+    default         Gauss linear;
+    grad(T)         Gauss linear;
+}
+
+divSchemes
+{
+    default         none;
+}
+
+laplacianSchemes
+{
+    default         none;
+    laplacian(DT,T) Gauss linear corrected;
+}
+
+interpolationSchemes
+{
+    default         linear;
+}
+
+snGradSchemes
+{
+    default         corrected;
+}

--- a/partitioned-heat-conduction/openfoam-dirichlet/system/fvSolution
+++ b/partitioned-heat-conduction/openfoam-dirichlet/system/fvSolution
@@ -1,0 +1,24 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSolution;
+}
+
+solvers
+{
+    T
+    {
+        solver          PCG;
+        preconditioner  DIC;
+        tolerance       1e-06;
+        relTol          0;
+    }
+}
+
+SIMPLE
+{
+    nNonOrthogonalCorrectors 2;
+}

--- a/partitioned-heat-conduction/openfoam-dirichlet/system/preciceDict
+++ b/partitioned-heat-conduction/openfoam-dirichlet/system/preciceDict
@@ -1,0 +1,39 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      preciceDict;
+}
+
+preciceConfig "../precice-config.xml";
+
+participant Dirichlet;
+
+modules (CHT);
+
+interfaces
+{
+  Interface1
+  {
+    mesh              Dirichlet-Mesh;
+    patches           (interface);
+    
+    readData
+    (
+      Temperature
+    );
+    
+    writeData
+    (
+      Heat-Flux
+    );
+  };
+};
+
+CHT
+{
+   k   [ 1  1 -3 -1 0 0 0 ] 3;
+   solverType "basic";
+};

--- a/partitioned-heat-conduction/openfoam-dirichlet/system/topoSetDict
+++ b/partitioned-heat-conduction/openfoam-dirichlet/system/topoSetDict
@@ -1,0 +1,18 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      topoSetDict;
+}
+
+actions
+(
+    {
+        name        heatSourceSet;
+        type        faceSet;
+        action      new;
+        source      boxToFace;
+        box (0 0 0.01) (0.06 0.06 0.06);
+    }
+);

--- a/partitioned-heat-conduction/openfoam-neumann/0/T
+++ b/partitioned-heat-conduction/openfoam-neumann/0/T
@@ -1,0 +1,46 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volScalarField;
+    object      T;
+}
+
+dimensions      [0 0 0 1 0 0 0];
+
+internalField   uniform 8;
+
+boundaryField
+{
+    interface
+    {
+        type            fixedGradient;
+        gradient        uniform 0;
+    }
+
+    heatSink
+    {
+        type            fixedValue;
+        value           $internalField;
+    }
+    
+    right
+    {
+        type            zeroGradient;
+    }
+    
+    top
+    {
+        type            zeroGradient;   
+    }
+    
+    bottom
+    {
+        type            zeroGradient;   
+    }
+    
+    defaultFaces
+    {
+        type            empty;
+    }
+}

--- a/partitioned-heat-conduction/openfoam-neumann/clean.sh
+++ b/partitioned-heat-conduction/openfoam-neumann/clean.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e -u
+
+. ../../tools/cleaning-tools.sh
+
+clean_openfoam .

--- a/partitioned-heat-conduction/openfoam-neumann/constant/transportProperties
+++ b/partitioned-heat-conduction/openfoam-neumann/constant/transportProperties
@@ -1,0 +1,11 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      transportProperties;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+DT               DT  [ 0  2 -1  0 0 0 0 ] 1;

--- a/partitioned-heat-conduction/openfoam-neumann/run.sh
+++ b/partitioned-heat-conduction/openfoam-neumann/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e -u
+
+blockMesh
+topoSet
+touch openfoam-neumann.foam
+
+../../tools/run-openfoam.sh "$@"
+. ../../tools/openfoam-remove-empty-dirs.sh && openfoam_remove_empty_dirs

--- a/partitioned-heat-conduction/openfoam-neumann/system/blockMeshDict
+++ b/partitioned-heat-conduction/openfoam-neumann/system/blockMeshDict
@@ -1,0 +1,78 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      blockMeshDict;
+}
+
+convertToMeters 1;
+
+vertices
+(
+
+    (1 0 0)
+    (2 0 0)
+    (2 1 0)
+    (1 1 0)
+
+    (1 0 .1)
+    (2 0 .1)
+    (2 1 .1)
+    (1 1 .1)
+
+);
+
+blocks
+(
+    hex (0 1 2 3 4 5 6 7) (10 10 1) simpleGrading (1 1 1)
+);
+
+edges
+(
+);
+
+boundary
+(
+
+    interface
+    {
+        type wall;
+        faces
+        (
+            (4 7 3 0)
+        );
+    }
+
+    right
+    {
+        type wall;
+        faces
+        (
+            (1 2 6 5)
+        );
+    }
+
+    top
+    {
+        type wall;
+        faces
+        (
+            (7 6 2 3)
+        );
+    }
+
+    bottom
+    {
+        type wall;
+        faces
+        (
+            (4 0 1 5)
+        );
+    }
+
+);
+
+mergePatchPairs
+(
+);

--- a/partitioned-heat-conduction/openfoam-neumann/system/controlDict
+++ b/partitioned-heat-conduction/openfoam-neumann/system/controlDict
@@ -1,0 +1,47 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      controlDict;
+}
+
+application     laplacianFoam;
+
+startFrom       startTime;
+
+startTime       0;
+
+stopAt          endTime;
+
+endTime         1;
+
+deltaT          0.01;
+
+writeControl    runTime;
+
+writeInterval   0.2;
+
+purgeWrite      0;
+
+writeFormat     ascii;
+
+writePrecision  6;
+
+writeCompression off;
+
+timeFormat      general;
+
+timePrecision   6;
+
+runTimeModifiable false;
+
+functions
+{
+    preCICE_Adapter
+    {
+        type preciceAdapterFunctionObject;
+        libs ("libpreciceAdapterFunctionObject.so");
+    }
+}

--- a/partitioned-heat-conduction/openfoam-neumann/system/decomposeParDict
+++ b/partitioned-heat-conduction/openfoam-neumann/system/decomposeParDict
@@ -1,0 +1,16 @@
+FoamFile {
+    version 2.0;
+    class dictionary;
+    object decomposeParDict;
+    format ascii;
+}
+
+numberOfSubdomains 2;
+
+method          simple;
+
+simpleCoeffs
+{
+    n               (2 1 1);
+    delta           0.001;
+}

--- a/partitioned-heat-conduction/openfoam-neumann/system/fvSchemes
+++ b/partitioned-heat-conduction/openfoam-neumann/system/fvSchemes
@@ -1,0 +1,40 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSchemes;
+}
+
+ddtSchemes
+{
+    default         Euler;
+}
+
+gradSchemes
+{
+    default         Gauss linear;
+    grad(T)         Gauss linear;
+}
+
+divSchemes
+{
+    default         none;
+}
+
+laplacianSchemes
+{
+    default         none;
+    laplacian(DT,T) Gauss linear corrected;
+}
+
+interpolationSchemes
+{
+    default         linear;
+}
+
+snGradSchemes
+{
+    default         corrected;
+}

--- a/partitioned-heat-conduction/openfoam-neumann/system/fvSolution
+++ b/partitioned-heat-conduction/openfoam-neumann/system/fvSolution
@@ -1,0 +1,24 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSolution;
+}
+
+solvers
+{
+    T
+    {
+        solver          PCG;
+        preconditioner  DIC;
+        tolerance       1e-06;
+        relTol          0;
+    }
+}
+
+SIMPLE
+{
+    nNonOrthogonalCorrectors 2;
+}

--- a/partitioned-heat-conduction/openfoam-neumann/system/preciceDict
+++ b/partitioned-heat-conduction/openfoam-neumann/system/preciceDict
@@ -1,0 +1,39 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      preciceDict;
+}
+
+preciceConfig "../precice-config.xml";
+
+participant Neumann;
+
+modules (CHT);
+
+interfaces
+{
+  Interface1
+  {
+    mesh              Neumann-Mesh;
+    patches           (interface);
+    
+    readData
+    (
+      Heat-Flux
+    );
+    
+    writeData
+    (
+      Temperature
+    );
+  };
+};
+
+CHT
+{
+   k   [ 1  1 -3 -1 0 0 0 ] 3;
+   solverType "basic";
+};

--- a/partitioned-heat-conduction/openfoam-neumann/system/topoSetDict
+++ b/partitioned-heat-conduction/openfoam-neumann/system/topoSetDict
@@ -1,0 +1,19 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      topoSetDict;
+}
+
+actions
+(
+    {
+        name        heatSink;
+        type        cellSet;
+        action      new;
+        source      sphereToCell;
+        origin      (2 1 0);
+        radius      0.1;
+    }
+);

--- a/partitioned-heat-conduction/precice-config.xml
+++ b/partitioned-heat-conduction/precice-config.xml
@@ -9,22 +9,22 @@
   <solver-interface dimensions="2">
 
     <data:scalar name="Temperature"/>
-    <data:scalar name="Flux"/>
+    <data:scalar name="Heat-Flux"/>
 
     <mesh name="Dirichlet-Mesh">
       <use-data name="Temperature"/>
-      <use-data name="Flux"/>
+      <use-data name="Heat-Flux"/>
     </mesh>
 
     <mesh name="Neumann-Mesh">
       <use-data name="Temperature"/>
-      <use-data name="Flux"/>
+      <use-data name="Heat-Flux"/>
     </mesh>
 
     <participant name="Dirichlet">
       <use-mesh name="Dirichlet-Mesh" provide="yes"/>
       <use-mesh name="Neumann-Mesh" from="Neumann"/>
-      <write-data name="Flux" mesh="Dirichlet-Mesh"/>
+      <write-data name="Heat-Flux" mesh="Dirichlet-Mesh"/>
       <read-data name="Temperature" mesh="Dirichlet-Mesh"/>
       <mapping:rbf-thin-plate-splines direction="read" from="Neumann-Mesh" to="Dirichlet-Mesh" constraint="consistent" x-dead="true" />
     </participant>
@@ -33,7 +33,7 @@
       <use-mesh name="Neumann-Mesh" provide="yes"/>
       <use-mesh name="Dirichlet-Mesh" from="Dirichlet"/>
       <write-data name="Temperature" mesh="Neumann-Mesh"/>
-      <read-data name="Flux" mesh="Neumann-Mesh"/>
+      <read-data name="Heat-Flux" mesh="Neumann-Mesh"/>
       <mapping:rbf-thin-plate-splines direction="read" from="Dirichlet-Mesh" to="Neumann-Mesh" constraint="consistent" x-dead="true" />
     </participant>
 
@@ -44,9 +44,9 @@
       <max-time value="1.0"/>
       <time-window-size value="0.1"/>
       <max-iterations value="100"/>
-      <exchange data="Flux" mesh="Dirichlet-Mesh" from="Dirichlet" to="Neumann" />
+      <exchange data="Heat-Flux" mesh="Dirichlet-Mesh" from="Dirichlet" to="Neumann" />
       <exchange data="Temperature" mesh="Neumann-Mesh" from="Neumann" to="Dirichlet" initialize="true"/>
-      <relative-convergence-measure data="Flux" mesh="Dirichlet-Mesh" limit="1e-5"/>
+      <relative-convergence-measure data="Heat-Flux" mesh="Dirichlet-Mesh" limit="1e-5"/>
       <relative-convergence-measure data="Temperature" mesh="Neumann-Mesh" limit="1e-5"/>
       <acceleration:IQN-ILS>
         <data name="Temperature" mesh="Neumann-Mesh"/>


### PR DESCRIPTION
This is an attempt to port the [2x-laplacianFoam case from the OpenFOAM adapter repository](https://github.com/precice/openfoam-adapter/compare/HH) and shape it to simulate the same problem as the FEniCS and Nutils cases that are already here.

**Change with side effects:** In the `precice-config.xml`, the data `Flux` needs to be renamed to `Heat-Flux`, as the OpenFOAM adapter uses the data name (prefix) to determine the data type. Naming it `Flux` in the first case sounds like a historical residue and does not agree with our `flow-over-heated-plate` case. This change means that the data needs to be renamed in the (case-specific) FEniCS and Nutils examples.

This is only an incomplete attempt, as I cannot manage to set the heat source and sink to be a single point/cell in OpenFOAM. I have tried different (less or more wrong) approaches:

- Define an L-shape `faceSet` and create a patch from it using `createPatch`. This is the setup I include here. It runs, but not as expected: the additional patch does not get any temperature values and ParaView complains. A problem may be that there is a conflict of boundary conditions for the same faces.
- Define a cellSet and set its internal field with `setFields`. Somehow this also gave weird results.
- Define a smaller box around the corner in `blockMeshDict`. I guess the problem there was that the blocks were overlapping.

A trivial workaround is to set the complete bottom & left walls of the `Dirichlet` participant as a heat sink and the complete top & right walls of the `Neumann` participant as a heat source (I think I even swapped the names accidentally). But this is then a different setup and the isolines have completely different shape.

@DavidSCN if you want, feel free to start from this and debug it.

TODO:

- [ ] Make the case work with point source & sink.
- [ ] Check the case parameters for consistency. I have set `T_sink = 1`, `T_source = 8`, `k = 3` (which should be `alpha`). I have no clue what to do with `beta`.
- [ ] Make the same changes also to the Neumann participant.
- [ ] Cleanup any unused files: `topoSetDict`, `createPatchDict`, unused settings in `blockMeshDict`/`T`, etc.
- [ ] Update FEniCS / Nutils for `Flux`/`Heat-Flux`
- [ ] Add entry in the `README.md`

The original motivation for this case was to study https://github.com/precice/openfoam-adapter/issues/93. The issue is observable also in the current state of the case.

This also closes #204.