### PR TITLE
Action to check links: ignore domains that are known to return 403

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,5 +1,7 @@
 name: Check links
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: '0 0 * * SUN'
 jobs:
   check_links:
     runs-on: ubuntu-latest

--- a/.markdown-link-check-config.json
+++ b/.markdown-link-check-config.json
@@ -1,0 +1,11 @@
+{
+  "aliveStatusCodes": [429, 200],
+  "ignorePatterns": [
+    {
+      "pattern": "^https://openfoamwiki.net/"
+    },
+    {
+      "pattern": "^https://doi.org/"
+    }
+  ]
+}

--- a/.markdown-lint-check-config.json
+++ b/.markdown-lint-check-config.json
@@ -1,3 +1,0 @@
-{
-  "aliveStatusCodes": [429, 403, 200]
-}


### PR DESCRIPTION
Several websites are returning e.g. `403: Forbidden` as a protection measure against denial-of-service attacks. This could also mean that indeed a link stopped working.

To distinguish between these two reasons is rather difficult, if not impossible in this context. Therefore, instead ofconsidering all 403 as `alive`, this ignores specific domains that are known to follow this practice. Meaning, indeed, that we will not be checking these links automatically.

Previously, there was also a typo in the name of the configuration file, which is probably why `403` was not being ignored completely. Happy coincidence to notice it now.

To save some unnecessary requests, the action now runs only once per week, every Sunday at midnight.

@IshaanDesai do you understand this change? Did you notice any other domains we should exclude?