### PR TITLE
flow-over-heated-plate: Add density and pressure to problem parameters

### DIFF
--- a/flow-over-heated-plate/README.md
+++ b/flow-over-heated-plate/README.md
@@ -15,7 +15,7 @@ This scenario consists of one fluid and one solid participant and it is inspired
 
 The test case is two-dimensional and a serial-implicit coupling with Aitken underrelaxation is used for the coupling.
 
-The inlet velocity is $$ u_{\infty} = 0.1 m/s $$, the inlet temperature is $$ T_{\infty} = 300K $$. The fluid and solid have the same thermal conductivities $$ k_S = k_F = 100 W/m/K $$ and density $$ rho_S = rho_F = 1 kg/m^3 $$. Further material properties of the fluid are its viscosity $$ mu = 0.0002 kg/m/s $$ and specific heat capacity $$ c_p = 5000 J/kg/K $$. The Prandtl number $$ Pr = 0.01 $$ follows from thermal conductivity, viscosity and specific heat capacity. The solid has the thermal diffusivity $$ \alpha = 1 m^2/s $$. The gravitational acceleration is $$ g = 9.81 m/s^2 $$.
+The inlet velocity is $$ u_{\infty} = 0.1 m/s $$, the inlet temperature is $$ T_{\infty} = 300K $$ and ambient pressure is $$ p_0 = 103500 Pa $$ . The fluid and solid have the same thermal conductivities $$ k_S = k_F = 100 W/m/K $$ and densities $$ rho_S = rho_F = 1 kg/m^3 $$. Further material properties of the fluid are its viscosity $$ mu = 0.0002 kg/m/s $$ and specific heat capacity $$ c_p = 5000 J/kg/K $$. The Prandtl number $$ Pr = 0.01 $$ follows from thermal conductivity, viscosity and specific heat capacity. The solid has the thermal diffusivity $$ \alpha = 1 m^2/s $$. The gravitational acceleration is $$ g = 9.81 m/s^2 $$.
 
 ## Available solvers
 

--- a/flow-over-heated-plate/README.md
+++ b/flow-over-heated-plate/README.md
@@ -15,7 +15,7 @@ This scenario consists of one fluid and one solid participant and it is inspired
 
 The test case is two-dimensional and a serial-implicit coupling with Aitken underrelaxation is used for the coupling.
 
-The inlet velocity is $$ u_{\infty} = 0.1 m/s $$, the inlet temperature is $$ T_{\infty} = 300K $$. The fluid and solid have the same thermal conductivities $$ k_S = k_F = 100 W/m/K $$. Further material properties of the fluid are its viscosity $$ mu = 0.0002 kg/m/s $$ and specific heat capacity $$ c_p = 5000 J/kg/K $$. The Prandtl number $$ Pr = 0.01 $$ follows from thermal conductivity, viscosity and specific heat capacity. The solid has the thermal diffusivity $$ \alpha = 1 m^2/s $$. The gravitational acceleration is $$ g = 9.81 m/s^2 $$.
+The inlet velocity is $$ u_{\infty} = 0.1 m/s $$, the inlet temperature is $$ T_{\infty} = 300K $$. The fluid and solid have the same thermal conductivities $$ k_S = k_F = 100 W/m/K $$ and density $$ rho_S = rho_F = 1 kg/m^3 $$. Further material properties of the fluid are its viscosity $$ mu = 0.0002 kg/m/s $$ and specific heat capacity $$ c_p = 5000 J/kg/K $$. The Prandtl number $$ Pr = 0.01 $$ follows from thermal conductivity, viscosity and specific heat capacity. The solid has the thermal diffusivity $$ \alpha = 1 m^2/s $$. The gravitational acceleration is $$ g = 9.81 m/s^2 $$.
 
 ## Available solvers
 


### PR DESCRIPTION
Related to #226. Currently the density is missing. This is no problem for OpenFOAM, where density defaults to 1kg/m^3 (see https://github.com/precice/tutorials/issues/226#issuecomment-888344050), but for other solvers (e.g. ELMER), where the density must be specified by the user.

# Open questions

* Do we also need density for the solid solver? Let's try to solver this in #226.