### PR TITLE
flow-over-heated-plate: Remove unnecessary parameter

### DIFF
--- a/changelog-entries/234.md
+++ b/changelog-entries/234.md
@@ -1,0 +1,1 @@
+* Remove unnecessary parameter `nMoles` from flow-over-heated-plate cases with OpenFOAM #234

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/thermophysicalProperties
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/constant/thermophysicalProperties
@@ -23,7 +23,6 @@ mixture
 {
     specie
     {
-        nMoles          1;
         molWeight       24.0999;
     }
     thermodynamics

--- a/flow-over-heated-plate-steady-state/fluid-openfoam/constant/thermophysicalProperties
+++ b/flow-over-heated-plate-steady-state/fluid-openfoam/constant/thermophysicalProperties
@@ -25,7 +25,6 @@ mixture
 {
     specie
     {
-        nMoles          1;
         molWeight       24.09989;
     }
     thermodynamics

--- a/flow-over-heated-plate/fluid-openfoam/constant/thermophysicalProperties
+++ b/flow-over-heated-plate/fluid-openfoam/constant/thermophysicalProperties
@@ -30,7 +30,6 @@ mixture
 {
     specie
     {
-        nMoles          1;
         molWeight       24.0999;
     }
     thermodynamics


### PR DESCRIPTION
See https://github.com/precice/tutorials/issues/226#issuecomment-896933844: From my current perspective, we do not need `nMoles`.
