### PR TITLE
Remove 'www' from preCICE website links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # preCICE tutorials
 
-This repository contains ready-to-run tutorial cases for the coupling library [preCICE](http://www.precice.org/).
-The purpose of these cases is not to teach you how to use preCICE from scratch, but to serve as starting points for setting up similar simulation cases, as well as test cases. Read more on our [preCICE tutorials](https://www.precice.org/tutorials.html) documentation section.
+This repository contains ready-to-run tutorial cases for the coupling library [preCICE](https://precice.org/).
+The purpose of these cases is not to teach you how to use preCICE from scratch, but to serve as starting points for setting up similar simulation cases, as well as test cases. Read more on our [preCICE tutorials](https://precice.org/tutorials.html) documentation section.
 
 As a general rule, you can start each participant from inside their `<tutorial>/<participant>-<solver>` using `./run.sh`. Look into these short scripts and copy the parts you need for your new case. Before running again, execute the cleaning scripts you can find at each level, to clean from this point and deeper.
 

--- a/elastic-tube-1d/README.md
+++ b/elastic-tube-1d/README.md
@@ -5,7 +5,7 @@ keywords: OpenFOAM, python
 summary: The 1D Elastic Tube is a FSI case, that consists of an internal flow in a flexible tube. The flow is unsteady and incompressible. This tutorial contains C++ and Python variants of the fluid and solid solvers. Running the simulation takes just 1-2 minutes.  
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/elastic-tube-1d). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/elastic-tube-1d). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 ## Setup
 
@@ -31,8 +31,8 @@ Additionally the solvers use the parameters `N = 100` (number of cells), `tau = 
 
 Both fluid and solid participant are supported in:
 
-- *C++*: An example solver using the intrinsic [C++ API of preCICE](https://www.precice.org/couple-your-code-api.html). This solver also depends on LAPACK (e.g. on Ubuntu `sudo apt-get install liblapack-dev`)
-- *Python*: An example solver using the preCICE [Python bindings](https://www.precice.org/installation-bindings-python.html). This solver also depends on the Python libraries `numpy scipy matplotlib vtk mpi4py`, which you can get from your system package manager or with `pip3 install --user <package>`.
+- *C++*: An example solver using the intrinsic [C++ API of preCICE](https://precice.org/couple-your-code-api.html). This solver also depends on LAPACK (e.g. on Ubuntu `sudo apt-get install liblapack-dev`)
+- *Python*: An example solver using the preCICE [Python bindings](https://precice.org/installation-bindings-python.html). This solver also depends on the Python libraries `numpy scipy matplotlib vtk mpi4py`, which you can get from your system package manager or with `pip3 install --user <package>`.
 
 ### Building the C++ Solver
 

--- a/elastic-tube-3d/README.md
+++ b/elastic-tube-3d/README.md
@@ -5,23 +5,23 @@ keywords: FSI, OpenFOAM, CalculiX, nearest-projection, IMVJ
 summary: Tutorial for an FSI simulation of a three-dimensional expanding tube scenario
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/elastic-tube-3d). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/elastic-tube-3d). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 ## Setup
 
 The expanding tube test case involves a cylindrical fluid domain surrounded by a solid domain. A pressure inlet boundary condition is applied at the inlet for 3 milliseconds, and then 0 set to zero for a further 7 millisecond. The pressure of the fluid expands the tube which then relaxes once the pressure decreases.
 
-The expanding tube test case comes with the interface surface mesh connectivity of the solid domain. This allows the use of nearest-projection mapping of the displacements of the solid domain. In order to run the example with nearest projection mapping, the "node-mesh-with-connectivity" has been specified in the `solid-calculix/config.yml` file. More details can be found in the [CalculiX configuration description](https://www.precice.org/adapter-calculix-config.html#nearest-projection-mapping).
+The expanding tube test case comes with the interface surface mesh connectivity of the solid domain. This allows the use of nearest-projection mapping of the displacements of the solid domain. In order to run the example with nearest projection mapping, the "node-mesh-with-connectivity" has been specified in the `solid-calculix/config.yml` file. More details can be found in the [CalculiX configuration description](https://precice.org/adapter-calculix-config.html#nearest-projection-mapping).
 
 ## Available solvers
 
 Fluid participant:
 
-* OpenFOAM. This tutorial is known to work with OpenFOAM 4.1, 5.0, but it should also work with newer versions. The case files are prepared for the latest versions of OpenFOAM and use the solver `pimpleFoam`. In case you are using a previous OpenFOAM version you need to adjust the solver to `pimpleDyMFoam` in the `Fluid/system/controlDict` file. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
+* OpenFOAM. This tutorial is known to work with OpenFOAM 4.1, 5.0, but it should also work with newer versions. The case files are prepared for the latest versions of OpenFOAM and use the solver `pimpleFoam`. In case you are using a previous OpenFOAM version you need to adjust the solver to `pimpleDyMFoam` in the `Fluid/system/controlDict` file. For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
 Solid participant:
 
-* CalculiX. This tutorial is known to work with CalculiX 2.15, but it should also work with newer versions. For more information, have a look at the [CalculiX adapter documentation](https://www.precice.org/adapter-calculix-overview.html).
+* CalculiX. This tutorial is known to work with CalculiX 2.15, but it should also work with newer versions. For more information, have a look at the [CalculiX adapter documentation](https://precice.org/adapter-calculix-overview.html).
 
 ## Running the simulation
 

--- a/flow-over-heated-plate-nearest-projection/README.md
+++ b/flow-over-heated-plate-nearest-projection/README.md
@@ -5,23 +5,23 @@ keywords: OpenFOAM, nearest-projection, CHT
 summary: This tutorial introduces an example simulation setup for a nearest-projection mapping, based on the "flow over a heated plate" scenario.
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/flow-over-heated-plate-nearest-projection). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/flow-over-heated-plate-nearest-projection). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 ## Setup
 
-The setup is exactly the same as described in our [flow-over-heated-plate tutorial](https://www.precice.org/tutorials-flow-over-heated-plate.html).
+The setup is exactly the same as described in our [flow-over-heated-plate tutorial](https://precice.org/tutorials-flow-over-heated-plate.html).
 
 ## Available solvers
 
 Fluid participant:
 
-* OpenFOAM (buoyantPimpleFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
+* OpenFOAM (buoyantPimpleFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
 Solid participant:
 
-* OpenFOAM (laplacianFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
+* OpenFOAM (laplacianFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
-The solvers are currently only OpenFOAM related. For information regarding the nearest-projection mapping, have a look in the [OpenFOAM configuration section](https://www.precice.org/adapter-openfoam-config.html).
+The solvers are currently only OpenFOAM related. For information regarding the nearest-projection mapping, have a look in the [OpenFOAM configuration section](https://precice.org/adapter-openfoam-config.html).
 
 ## Running the Simulation
 
@@ -66,7 +66,7 @@ From the preCICE point of view, the simulation here is in 3D, as opposed to the 
 
 ## Post-processing
 
-Have a look at the [flow-over heated-plate](https://www.precice.org/tutorials-flow-over-heated-plate.html) tutorial for the general aspects of post-processing.
+Have a look at the [flow-over heated-plate](https://precice.org/tutorials-flow-over-heated-plate.html) tutorial for the general aspects of post-processing.
 Since we now defined mesh connectivity on our interface, we can export the coupling interface with the tag `<export:vtk directory="preCICE-output" />` in our `precice-config.xml`.
 Visualizing these files (e.g. using ParaView) will show a triangular mesh, even though you use hexahedral meshes. This has nothing to do with your mesh and is just caused by the way the connectivity is defined in preCICE. As described above, the function `setMeshTriangles` is used to define the connectivity. Hence, every interface cell/face is represented by two triangles. The following image should give you an impression of a possible triangulated coupling mesh, which consists purely of hexahedral cells:
 

--- a/flow-over-heated-plate-steady-state/README.md
+++ b/flow-over-heated-plate-steady-state/README.md
@@ -5,11 +5,11 @@ keywords: CHT, steady-state, Code_Aster, OpenFOAM
 summary: Using a steady-state OpenFOAM solver for a CHT coupling with code_aster. This tutorial is based on the "flow over a heated plate" scenario.
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/flow-over-heated-plate-steady-state). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/flow-over-heated-plate-steady-state). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 ## Setup
 
-The setup for this tutorial is similar to the [flow over a heated plate](https://www.precice.org/tutorials-flow-over-heated-plate.html) using OpenFOAM. In this tutorial OpenFOAM is used as the solver for the fluid domain, and code_aster is the solver for the solid domain. A difference here is that we are using a steady-state OpenFOAM solver for demonstration purposes, therefore the results between the two tutorials are not comparable.
+The setup for this tutorial is similar to the [flow over a heated plate](https://precice.org/tutorials-flow-over-heated-plate.html) using OpenFOAM. In this tutorial OpenFOAM is used as the solver for the fluid domain, and code_aster is the solver for the solid domain. A difference here is that we are using a steady-state OpenFOAM solver for demonstration purposes, therefore the results between the two tutorials are not comparable.
 
 {% include note.html content="This is a pseudo-2D case, but we still set a 3D `solver-interface` in `precice-config.xml`, because the code_aster case is set up like this at the moment. Contributions here are particularly welcome!" %}
 
@@ -17,11 +17,11 @@ The setup for this tutorial is similar to the [flow over a heated plate](https:/
 
 Fluid participant:
 
-* OpenFOAM. We use buoyantSimpleFoam instead of the transient buoyantPimpleFoam. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
+* OpenFOAM. We use buoyantSimpleFoam instead of the transient buoyantPimpleFoam. For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
 Solid participant:
 
-* code_aster. The [code_aster adapter documentation](https://www.precice.org/adapter-code_aster.html) is oriented on this tutorial case. In particular the described configuration settings.
+* code_aster. The [code_aster adapter documentation](https://precice.org/adapter-code_aster.html) is oriented on this tutorial case. In particular the described configuration settings.
 
 ## Running the Simulation
 

--- a/flow-over-heated-plate/README.md
+++ b/flow-over-heated-plate/README.md
@@ -5,7 +5,7 @@ keywords: tutorial, CHT, conjugate-heat transfer, OpenFOAM, FEniCS, Nutils
 summary: This tutorial describes how to run a conjugate heat transfer coupled simulation using preCICE and any fluid-solid solver combination of our <a href="adapters-overview.html">officially provided adapter codes</a>.
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/flow-over-heated-plate). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/flow-over-heated-plate). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 ## Setup
 
@@ -23,13 +23,13 @@ By default, the fluid participant reads heat-flux values and the solid participa
 
 Fluid participant:
 
-* OpenFOAM (buoyantPimpleFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
+* OpenFOAM (buoyantPimpleFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
 Solid participant:
 
-* OpenFOAM (laplacianFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
+* OpenFOAM (laplacianFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
-* FEniCS. For more information, have a look at the [FeniCS adapter documentation](https://www.precice.org/adapter-fenics.html).
+* FEniCS. For more information, have a look at the [FeniCS adapter documentation](https://precice.org/adapter-fenics.html).
 
 * Nutils. For more information, have a look at the [Nutils adapter documentation](https://precice.org/adapter-nutils.html).
 

--- a/heat-exchanger/README.md
+++ b/heat-exchanger/README.md
@@ -5,7 +5,7 @@ keywords: CHT, OpenFOAM, CalculiX
 summary: Tutorial for a shell-and-tube heat exchanger, using OpenFOAM and CalculiX
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/heat-exchanger). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/heat-exchanger). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 This tutorial describes how to run a conjugate heat transfer simulation with two separate OpenFOAM solvers and CalculiX. The files for this tutorial are located in this repository (directory CHT/heat_exchanger).
 
@@ -23,9 +23,9 @@ We define the participants `Inner-Fluid`, `Solid`, and `Outer-Fluid` and two int
 
 ## Available solvers
 
-* OpenFOAM. `buoyantSimpleFoam` is used for fluid flow (both participants). This is a solver for steady-state, buoyant, turbulent flow of compressible fluids for ventilation and heat transfer. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
+* OpenFOAM. `buoyantSimpleFoam` is used for fluid flow (both participants). This is a solver for steady-state, buoyant, turbulent flow of compressible fluids for ventilation and heat transfer. For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
-* CalculiX. For more information, have a look at the [CalculiX adapter documentation](https://www.precice.org/adapter-calculix-overview.html).
+* CalculiX. For more information, have a look at the [CalculiX adapter documentation](https://precice.org/adapter-calculix-overview.html).
 
 ## Running the Simulation
 

--- a/multiple-perpendicular-flaps/README.md
+++ b/multiple-perpendicular-flaps/README.md
@@ -5,7 +5,7 @@ keywords: multi-coupling, OpenFOAM, deal.II, FSI
 summary: In this case, a fluid and two solids are coupled together using a fully-implicit multi-coupling scheme.
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/multiple-perpendicular-flaps). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/multiple-perpendicular-flaps). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 ## Case Setup
 
@@ -21,11 +21,11 @@ The inflow velocity is 5 m/s (uniform) on the left boundary.
 At the outlet, pressure is set to zero and velocity to `zeroGradient`.
 The top, bottom and flap are walls with a `noslip` condition.
 
-For a case showing fluid-structure interaction only (no multi-coupling), take a look at the [single perpendicular flap tutorial](https://www.precice.org/tutorials-perpendicular-flap.html).
+For a case showing fluid-structure interaction only (no multi-coupling), take a look at the [single perpendicular flap tutorial](https://precice.org/tutorials-perpendicular-flap.html).
 
 ## Why multi-coupling?
 
-This is a case with three participants: the fluid and each flap. In preCICE, there are two options to [couple more than two participants](https://www.precice.org/configuration-coupling-multi.html). The first option a composition of bi-coupling schemes, in which we must specify the exchange of data in a participant to participant manner. However, such a composition is not suited for combining multiple strong fluid-structure interations [1]. Thus, in this case, we use the second option, fully-implicit multi-coupling.
+This is a case with three participants: the fluid and each flap. In preCICE, there are two options to [couple more than two participants](https://precice.org/configuration-coupling-multi.html). The first option a composition of bi-coupling schemes, in which we must specify the exchange of data in a participant to participant manner. However, such a composition is not suited for combining multiple strong fluid-structure interations [1]. Thus, in this case, we use the second option, fully-implicit multi-coupling.
 
 We can set this in our `precice-config.xml`:
 
@@ -67,7 +67,7 @@ The scenario settings are implemented similarly for the nonlinear case.
 ## Running the Simulation
 
 1. Preparation:
-   To run the coupled simulation, copy the deal.II executable `linear_elasticity` or `nonlinear_elasticity` into the main folder. To learn how to obtain the deal.II executable take a look at the description on the  [deal.II-adapter page](https://www.precice.org/adapter-dealii-overview.html).
+   To run the coupled simulation, copy the deal.II executable `linear_elasticity` or `nonlinear_elasticity` into the main folder. To learn how to obtain the deal.II executable take a look at the description on the  [deal.II-adapter page](https://precice.org/adapter-dealii-overview.html).
 2. Starting:
 
    We are going to run each solver in a different terminal. It is important that first we navigate to the simulation directory so that all solvers start in the same directory.

--- a/partitioned-elastic-beam/README.md
+++ b/partitioned-elastic-beam/README.md
@@ -5,7 +5,7 @@ keywords: Structure-Structure Coupling, CalculiX, solid mechanics
 summary: This tutorial describes how to run a structure-structure interaction simulation with CalculiX running on both sides.
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/partitioned-elastic-beam). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/partitioned-elastic-beam). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 ## Setup
 
@@ -15,7 +15,7 @@ We have a rectangular linear elastic beam of dimensions 1 x 1 x 8 m, divided in 
 
 ## Available solvers
 
-* CalculiX. CalculiX is used for both structural parts. For more information, have a look at the [CalculiX adapter documentation](https://www.precice.org/adapter-calculix-overview.html) for more.
+* CalculiX. CalculiX is used for both structural parts. For more information, have a look at the [CalculiX adapter documentation](https://precice.org/adapter-calculix-overview.html) for more.
 
 ## Running the Simulation
 

--- a/partitioned-heat-conduction-complex/README.md
+++ b/partitioned-heat-conduction-complex/README.md
@@ -5,7 +5,7 @@ keywords: FEniCS, Heat conduction
 summary: This tutorial is the advanced version of the "partitioned heat conduction" tutorial, showcasing more advanced features and geometries.
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction-complex). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction-complex). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 ## Setup
 

--- a/partitioned-heat-conduction/README.md
+++ b/partitioned-heat-conduction/README.md
@@ -5,7 +5,7 @@ keywords: FEniCS, Nutils, Heat conduction
 summary: We solve a simple heat equation. The domain is partitioned and the coupling is established in a Dirichlet-Neumann fashion.
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 ## Setup
 
@@ -27,7 +27,7 @@ You can either couple a solver with itself or different solvers with each other.
 
 * Nutils. Install [Nutils](http://www.nutils.org/en/latest/).
 
-* OpenFOAM. Install OpenFOAM and the [OpenFOAM adapter](https://www.precice.org/adapter-openfoam-overview.html). This tutorial uses a custom solver, which you can find in `tutorials/partitioned-heat-conduction/openfoam-solver` and build using `cd tutorials/partitioned-heat-conduction/openfoam-solver && wmake`. Have a look at the section below (Notes on the OpenFOAM case) for further information.
+* OpenFOAM. Install OpenFOAM and the [OpenFOAM adapter](https://precice.org/adapter-openfoam-overview.html). This tutorial uses a custom solver, which you can find in `tutorials/partitioned-heat-conduction/openfoam-solver` and build using `cd tutorials/partitioned-heat-conduction/openfoam-solver && wmake`. Have a look at the section below (Notes on the OpenFOAM case) for further information.
 
 ### Notes on the OpenFOAM case
 

--- a/partitioned-pipe/README.md
+++ b/partitioned-pipe/README.md
@@ -5,7 +5,7 @@ keywords: tutorial, FF, fluid-fluid coupling, OpenFOAM, pimpleFoam, sonicLiquidF
 summary: This tutorial describes how to run a partitioned fluid simulation using preCICE.
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/partitioned-pipe). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/partitioned-pipe). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 ## Setup
 
@@ -17,9 +17,9 @@ On the coupling interface, Fluid1 sends velocity and pressure gradient to Fluid2
 
 Both for Fluid1 and Fluid2, the following participants are available:
 
-* OpenFOAM (pimpleFoam). An incompressible OpenFOAM solver. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
+* OpenFOAM (pimpleFoam). An incompressible OpenFOAM solver. For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
-* OpenFOAM (sonicLiquidFoam). A compressible OpenFOAM solver. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
+* OpenFOAM (sonicLiquidFoam). A compressible OpenFOAM solver. For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
 ## Running the Simulation
 

--- a/perpendicular-flap/README.md
+++ b/perpendicular-flap/README.md
@@ -5,7 +5,7 @@ keywords: fluid-structure interaction, FSI, OpenFOAM, FEniCS, Nutils, deal.II, C
 summary: This tutorial describes how to run a fluid-structure interaction using preCICE and any fluid-solid solver combination of our <a href="adapters-overview.html">officially provided adapter codes</a>.
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/perpendicular-flap). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/perpendicular-flap). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 ## Setup
 
@@ -19,19 +19,19 @@ The simulated flow domain is 6 units long (x) and 4 units tall (y). The flap is 
 
 Fluid participant:
 
-* OpenFOAM. For older OpenFOAM versions, the solver name differs: If you are using OpenFOAM v1712 / 5.x or older have a look at `fluid-openfoam/system/controlDict` and set the appropriate solver name. The solver can run in parallel using the command line argument `run.sh -parallel`. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
+* OpenFOAM. For older OpenFOAM versions, the solver name differs: If you are using OpenFOAM v1712 / 5.x or older have a look at `fluid-openfoam/system/controlDict` and set the appropriate solver name. The solver can run in parallel using the command line argument `run.sh -parallel`. For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
-* Nutils. For more information, have a look at the [Nutils adapter documentation](https://www.precice.org/adapter-nutils.html). This Nutils solver requires at least Nutils v6.0.
+* Nutils. For more information, have a look at the [Nutils adapter documentation](https://precice.org/adapter-nutils.html). This Nutils solver requires at least Nutils v6.0.
 
-* SU2. As opposed to the other two fluid codes, SU2 is in particular specialized for compressible flow. Therefore the default simulation parameters haven been adjusted in order to pull the setup into the compressible flow regime. For more information, have a look at the [SU2 adapter documentation](https://www.precice.org/adapter-su2-overview.html).
+* SU2. As opposed to the other two fluid codes, SU2 is in particular specialized for compressible flow. Therefore the default simulation parameters haven been adjusted in order to pull the setup into the compressible flow regime. For more information, have a look at the [SU2 adapter documentation](https://precice.org/adapter-su2-overview.html).
 
 Solid participant:
 
-* FEniCS. The structural model is currently limited to linear elasticity. For more information, have a look at the [FeniCS adapter documentation](https://www.precice.org/adapter-fenics.html).
+* FEniCS. The structural model is currently limited to linear elasticity. For more information, have a look at the [FeniCS adapter documentation](https://precice.org/adapter-fenics.html).
 
-* CalculiX. In order to allow a reasonable comparison to all solid codes, the geometrically non-linear solver has been disabled and only a linear model is used by default. For more information, have a look at the [CalculiX adapter documentation](https://www.precice.org/adapter-calculix-overview.html)
+* CalculiX. In order to allow a reasonable comparison to all solid codes, the geometrically non-linear solver has been disabled and only a linear model is used by default. For more information, have a look at the [CalculiX adapter documentation](https://precice.org/adapter-calculix-overview.html)
 
-* deal.II. For compatibility reasons, the solver reads `Force` data from other `Fluid` participants. Reading and applying `Force` data is currently only implemented in the linear elastic solid model (`Model = linear` in the parameter file). Thus, the default simulation setup is only compatible with the linear elastic solid model. If you want to apply the non-linear solid model, please use `Stress` data for your read data, which is supported by the OpenFOAM adapter as well (example given in Turek-Hron-FSI). The `./run.sh` script takes the compiled executable `elasticity` as input argument (`run.sh -e=/path/to/elasticity`) and is required in case the executable is not discoverable at runtime (e.g. has been added to the system `PATH`). For more information, have a look at the [deal.II adapter documentation](https://www.precice.org/adapter-dealii-overview.html).
+* deal.II. For compatibility reasons, the solver reads `Force` data from other `Fluid` participants. Reading and applying `Force` data is currently only implemented in the linear elastic solid model (`Model = linear` in the parameter file). Thus, the default simulation setup is only compatible with the linear elastic solid model. If you want to apply the non-linear solid model, please use `Stress` data for your read data, which is supported by the OpenFOAM adapter as well (example given in Turek-Hron-FSI). The `./run.sh` script takes the compiled executable `elasticity` as input argument (`run.sh -e=/path/to/elasticity`) and is required in case the executable is not discoverable at runtime (e.g. has been added to the system `PATH`). For more information, have a look at the [deal.II adapter documentation](https://precice.org/adapter-dealii-overview.html).
 
 ## Running the Simulation
 

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -25,9 +25,9 @@ To get a feeling what preCICE does, watch a [short presentation](https://www.you
     sudo apt install ./libprecice2_2.2.1_focal.deb
     ```
 
-    - Are you using something else? Just pick what suits you best on [this overview page](https://www.precice.org/installation-overview.html).
-    - Facing any problems? [Ask for help](https://www.precice.org/community-channels.html).
-2. We will use OpenFOAM here and in many of our tutorial cases, so [install OpenFOAM](https://www.precice.org/adapter-openfoam-support.html):
+    - Are you using something else? Just pick what suits you best on [this overview page](https://precice.org/installation-overview.html).
+    - Facing any problems? [Ask for help](https://precice.org/community-channels.html).
+2. We will use OpenFOAM here and in many of our tutorial cases, so [install OpenFOAM](https://precice.org/adapter-openfoam-support.html):
 
     ```bash
     # Add the signing key, add the repository, update (check this):
@@ -45,7 +45,7 @@ To get a feeling what preCICE does, watch a [short presentation](https://www.you
     sudo apt install build-essential pkg-config cmake git
     ```
 
-4. Download and install the [OpenFOAM-preCICE adapter](https://www.precice.org/adapter-openfoam-get.html):
+4. Download and install the [OpenFOAM-preCICE adapter](https://precice.org/adapter-openfoam-get.html):
 
     ```bash
      git clone --branch=master --depth 1 https://github.com/precice/openfoam-adapter
@@ -61,7 +61,7 @@ To get a feeling what preCICE does, watch a [short presentation](https://www.you
     cd tutorials/quickstart
     ```
 
-If you prefer to easily try everything in an isolated environment, you may prefer using our [demo virtual machine](https://www.precice.org/installation-vm.html).
+If you prefer to easily try everything in an isolated environment, you may prefer using our [demo virtual machine](https://precice.org/installation-vm.html).
 
 ## Case setup
 
@@ -116,10 +116,10 @@ You may be curious what displacements OpenFOAM received from the rigid body solv
 
 To become a preCICE pro:
 
-- Get an overview of the [preCICE docs](https://www.precice.org/docs.html).
+- Get an overview of the [preCICE docs](https://precice.org/docs.html).
 - See what users talk about in the [preCICE forum](https://precice.discourse.group/).
-- Run [tutorials with other coupled solvers](https://www.precice.org/tutorials.html).
+- Run [tutorials with other coupled solvers](https://precice.org/tutorials.html).
 - Watch some [preCICE videos](https://www.youtube.com/c/preCICECoupling/).
-- Meet our [community](https://www.precice.org/community.html).
-- Find out how to [couple your own solver](https://www.precice.org/couple-your-code-overview.html).
-- Tell us [your story](https://www.precice.org/community-projects.html).
+- Meet our [community](https://precice.org/community.html).
+- Find out how to [couple your own solver](https://precice.org/couple-your-code-overview.html).
+- Tell us [your story](https://precice.org/community-projects.html).

--- a/turek-hron-fsi3/README.md
+++ b/turek-hron-fsi3/README.md
@@ -5,7 +5,7 @@ keywords: OpenFOAM, deal.II, verification
 summary: The Turek-Hron FSI cases are well-established numerical benchmarks and, therefore, well suited for verification of preCICE itself and the used adapters. In this tutorial, we focus on the FSI3 case, which presents the most challenging case in terms of added mass. Please note that the meshes of this case are significantly finer than for other tutorials. Running the simulation might take a few hours. We do not recommend to run this tutorials as your first preCICE tutorial.  
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/turek-hron-fsi3). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/master/turek-hron-fsi3). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 ## Setup
 
@@ -19,13 +19,13 @@ For more information please refer to the original publication of the benchmark [
 
 Fluid participant:
 
-* OpenFOAM. For more information, have a look at the [OpenFOAM adapter documentation](https://www.precice.org/adapter-openfoam-overview.html).
+* OpenFOAM. For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
 {% include important.html content="For the parabolic inflow profile, this tutorial requires groovyBC. groovyBC is part of swak4Foam. You can find more explanations in [openfoamwiki.net](https://openfoamwiki.net/index.php/Contrib/swak4Foam) or get it from an [unofficial GitHub mirror](https://github.com/Unofficial-Extend-Project-Mirror/openfoam-extend-swak4Foam-dev.git). Please follow the building instructions there." %}
 
 Solid participant:
 
-* deal.II. For more information, have a look at the [deal.II adapter documentation](https://www.precice.org/adapter-dealii-overview.html). This tutorial requires the nonlinear solid solver. Please copy the nonlinear solver executable to the `solid-dealii` folder or make it discoverable at runtime and update the `solid-dealii/run.sh` script.
+* deal.II. For more information, have a look at the [deal.II adapter documentation](https://precice.org/adapter-dealii-overview.html). This tutorial requires the nonlinear solid solver. Please copy the nonlinear solver executable to the `solid-dealii` folder or make it discoverable at runtime and update the `solid-dealii/run.sh` script.
 
 ## Running the Simulation
 
@@ -86,7 +86,7 @@ For the double-refined mesh, it is wisely to use local basis functions in the RB
                             support-radius="0.011" constraint="consistent" />
 ```
 
-You can find more information on RBF data mapping in the [documentation](https://www.precice.org/configuration-mapping.html#radial-basis-function-mapping).
+You can find more information on RBF data mapping in the [documentation](https://precice.org/configuration-mapping.html#radial-basis-function-mapping).
 
 ## References
 

--- a/volume-coupled-diffusion/README.md
+++ b/volume-coupled-diffusion/README.md
@@ -5,7 +5,7 @@ keywords: FEniCS, Diffusion, Volume Coupling
 summary: This tutorial illustrates volume coupling with a simple example.
 ---
 
-{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/develop/volume-coupled-diffusion). Read how in the [tutorials introduction](https://www.precice.org/tutorials.html)." %}
+{% include note.html content="Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/develop/volume-coupled-diffusion). Read how in the [tutorials introduction](https://precice.org/tutorials.html)." %}
 
 ## Setup
 


### PR DESCRIPTION
```bash
perl -pi -e 's/https:\/\/www.precice.org/https:\/\/precice.org/g;' `find *.md */*md -type f`
```