### PR TITLE
Fix shellcheck notice on solid-codeaster/run.sh

### DIFF
--- a/flow-over-heated-plate-steady-state/solid-codeaster/run.sh
+++ b/flow-over-heated-plate-steady-state/solid-codeaster/run.sh
@@ -7,6 +7,6 @@ echo "See the tutorial and code_aster adapter documentation pages for more:"
 echo "https://www.precice.org/adapter-code_aster.html"
 echo ""
 
-export TUTORIAL_ROOT=${PWD}
+export TUTORIAL_ROOT="${PWD}"
 export PRECICE_PARTICIPANT=Solid
 as_run --run solid.export


### PR DESCRIPTION
Reported by the latest shellcheck as

```
Notice: ./flow-over-heated-plate-steady-state/solid-codeaster/run.sh:10:22: note: Double quote to prevent globbing and word splitting. [SC2086]
```

e.g., in https://github.com/precice/tutorials/runs/4455201577?check_suite_focus=true
