### PR TITLE
Convert check links to manual

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,7 +1,5 @@
-name: Check links
-on:
-  schedule:
-    - cron: '0 0 * * SUN'
+name: Check links (manual)
+on: workflow_dispatch
 jobs:
   check_links:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Same motivation and implementation as in https://github.com/precice/openfoam-adapter/pull/215.

Already right now, `master` reports as `failed` because the cron job failed at some point.