### PR TITLE
Fix note regarding OpenFOAM and residual control

### DIFF
--- a/elastic-tube-3d/fluid-openfoam/system/fvSolution
+++ b/elastic-tube-3d/fluid-openfoam/system/fvSolution
@@ -199,7 +199,7 @@ residualControl
 }
 */
 
-// OpenFOAM 6 (.org) or newer probably
+// OpenFOAM 6 (.org) or newer
 // see also https://bugs.openfoam.org/view.php?id=3336
 /*
 outerResidualControl

--- a/elastic-tube-3d/fluid-openfoam/system/fvSolution
+++ b/elastic-tube-3d/fluid-openfoam/system/fvSolution
@@ -199,9 +199,10 @@ residualControl
 }
 */
 
-// OpenFOAM 6 (.org) or newer
+// OpenFOAM 6 (.org) or newer probably
+// see also https://bugs.openfoam.org/view.php?id=3336
 /*
-residualControl
+outerResidualControl
 {
     U 0.0001;
     p 0.0001;

--- a/turek-hron-fsi3/fluid-openfoam/system/fvSolution
+++ b/turek-hron-fsi3/fluid-openfoam/system/fvSolution
@@ -87,9 +87,10 @@ PIMPLE
 	}
     }
 
-    // OpenFOAM 6 (.org) or newer
+    // OpenFOAM 6 (.org) or newer probably
+    // see also https://bugs.openfoam.org/view.php?id=3336
     /*
-    residualControl
+    outerResidualControl
     {
         U 1e-5;
         p 1e-5;

--- a/turek-hron-fsi3/fluid-openfoam/system/fvSolution
+++ b/turek-hron-fsi3/fluid-openfoam/system/fvSolution
@@ -87,7 +87,7 @@ PIMPLE
 	}
     }
 
-    // OpenFOAM 6 (.org) or newer probably
+    // OpenFOAM 6 (.org) or newer
     // see also https://bugs.openfoam.org/view.php?id=3336
     /*
     outerResidualControl


### PR DESCRIPTION
I received a message on discourse pointing out that our hint for the ´residualControl` for OpenFOAM foundation versions is actually not correct. I added a note here and also a link to the corresponding OpenFOAM bug. 