### PR TITLE
Reduce the writing frquency of partitioned-pipe

### DIFF
--- a/partitioned-pipe/fluid1-openfoam-pimplefoam/system/controlDict
+++ b/partitioned-pipe/fluid1-openfoam-pimplefoam/system/controlDict
@@ -21,7 +21,7 @@ deltaT          0.01;
 
 writeControl    adjustableRunTime;
 
-writeInterval   0.01;
+writeInterval   0.1;
 
 purgeWrite      0;
 

--- a/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/system/controlDict
+++ b/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/system/controlDict
@@ -21,7 +21,7 @@ deltaT          0.01;
 
 writeControl    adjustableRunTime;
 
-writeInterval   0.01;
+writeInterval   0.1;
 
 purgeWrite      0;
 

--- a/partitioned-pipe/fluid2-openfoam-pimplefoam/system/controlDict
+++ b/partitioned-pipe/fluid2-openfoam-pimplefoam/system/controlDict
@@ -21,7 +21,7 @@ deltaT          0.01;
 
 writeControl    adjustableRunTime;
 
-writeInterval   0.01;
+writeInterval   0.1;
 
 purgeWrite      0;
 

--- a/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/system/controlDict
+++ b/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/system/controlDict
@@ -21,7 +21,7 @@ deltaT          0.01;
 
 writeControl    adjustableRunTime;
 
-writeInterval   0.01;
+writeInterval   0.1;
 
 purgeWrite      0;
 


### PR DESCRIPTION
While running the partitioned-pipe in an OpenFOAM Adapter custom build, I noticed that the results were approx. 160MB in size, which is, I think, unreasonable for what we need.

This increases the `writeTime` from `0.01` to `0.1`. This is 10x fewer files, while 0.1s is still enough to capture the initial discontinuity (this may turn interesting later on in results comparisons).

I did not switch on results compression (i.e., making the output files binary), since eventually we may want to store them as reference results here and make some easy-to-check file comparisons, at least for the last time. If in the end we only check preCICE VTK files, we can enable compression everywhere.

@DavidSCN does this sound reasonable? Should we absolutely apply the same change to some other tutorial? If not, feel free to merge.