### PR TITLE
Add resources for SSE basics

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -133,6 +133,6 @@ To become a preCICE pro:
 
 Are you just starting with simulation software on Linux? Note that much of the complexity for partitioned simulations comes from working with multiple software packages and some new tools. These resources may help your first steps:
 
-- Material of the course [Simulation Software Engineering](https://simulation-software-engineering.github.io/) (University of Stuttgart).
 - E-book [Research Software Engineering with Python](https://merely-useful.tech/py-rse/).
+- Material of the course [Simulation Software Engineering](https://simulation-software-engineering.github.io/) (University of Stuttgart).
 - Material of the course [The Missing Semester of Your CS Education](https://missing.csail.mit.edu/) (MIT).

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -130,3 +130,9 @@ To become a preCICE pro:
 - Meet our [community](https://precice.org/community.html).
 - Find out how to [couple your own solver](https://precice.org/couple-your-code-overview.html).
 - Tell us [your story](https://precice.org/community-projects.html).
+
+Are you just starting with simulation software on Linux? Note that much of the complexity for partitioned simulations comes from working with multiple software packages and some new tools. These resources may help your first steps:
+
+- Material of the course [Simulation Software Engineering](https://simulation-software-engineering.github.io/) (University of Stuttgart).
+- E-book [Research Software Engineering with Python](https://merely-useful.tech/py-rse/).
+- Material of the course [The Missing Semester of Your CS Education](https://missing.csail.mit.edu/) (MIT).


### PR DESCRIPTION
This adds a few good resources for beginners to simulation software, Linux, Git, and more. @carlosal1015 suggested this during the preCICE Workshop 2022.

Apart from the recent SSE course by @uekerman/ @ajaust / @IshaanDesai, this also refers to previous related resources that cover a bit different content (but with quite some overlap). We should probably not keep adding links here, but really select the 2-3 most fitting resources for this use case.

@uekerman is there anything else you would like to see here?

After merging:

- [ ] Update the submodules on the website