### PR TITLE
Add note for motionSolver in OpenFOAM 9

### DIFF
--- a/elastic-tube-3d/fluid-openfoam/constant/dynamicMeshDict
+++ b/elastic-tube-3d/fluid-openfoam/constant/dynamicMeshDict
@@ -11,6 +11,7 @@ dynamicFvMesh   dynamicMotionSolverFvMesh;
 motionSolverLibs ( "libfvMotionSolvers.so" );
 
 solver          displacementLaplacian;
+# OpenFOAM9 or newer: rename "solver" to "motionSolver"
 
 displacementLaplacianCoeffs
 {

--- a/multiple-perpendicular-flaps/fluid-openfoam/constant/dynamicMeshDict
+++ b/multiple-perpendicular-flaps/fluid-openfoam/constant/dynamicMeshDict
@@ -11,6 +11,7 @@ dynamicFvMesh       dynamicMotionSolverFvMesh;
 motionSolverLibs    ("libfvMotionSolvers.so");
 
 solver              displacementLaplacian;
+# OpenFOAM9 or newer: rename "solver" to "motionSolver"
 
 displacementLaplacianCoeffs {
     diffusivity quadratic inverseDistance (flap1);

--- a/perpendicular-flap/fluid-openfoam/constant/dynamicMeshDict
+++ b/perpendicular-flap/fluid-openfoam/constant/dynamicMeshDict
@@ -11,6 +11,7 @@ dynamicFvMesh dynamicMotionSolverFvMesh;
 motionSolverLibs ("libfvMotionSolvers.so");
 
 solver      displacementLaplacian;
+# OpenFOAM9 or newer: rename "solver" to "motionSolver"
 
 displacementLaplacianCoeffs {
     diffusivity quadratic inverseDistance (flap);

--- a/quickstart/fluid-openfoam/constant/dynamicMeshDict
+++ b/quickstart/fluid-openfoam/constant/dynamicMeshDict
@@ -12,6 +12,7 @@ dynamicFvMesh dynamicMotionSolverFvMesh;
 motionSolverLibs ("libfvMotionSolvers.so");
 
 solver      displacementLaplacian;
+# OpenFOAM9 or newer: rename "solver" to "motionSolver"
 
 displacementLaplacianCoeffs {
     diffusivity quadratic inverseDistance (flap);

--- a/turek-hron-fsi3/fluid-openfoam/constant/dynamicMeshDict
+++ b/turek-hron-fsi3/fluid-openfoam/constant/dynamicMeshDict
@@ -11,6 +11,7 @@ dynamicFvMesh   dynamicMotionSolverFvMesh;
 motionSolverLibs ("libfvMotionSolvers.so");
 
 solver          displacementLaplacian;
+# OpenFOAM9 or newer: rename "solver" to "motionSolver"
 
 displacementLaplacianCoeffs {
     diffusivity quadratic inverseDistance (flap);


### PR DESCRIPTION
https://github.com/precice/openfoam-adapter/pull/222 adds support for OpenFOAM 9.

One of the changes that OpenFOAM 9 brought (not easily seen / clearly documented in the [release notes](https://openfoam.org/release/9/)) is the renaming of `solver` to `motionSolver` in `constant/dynamicMeshDict`.

Running our tutorials without renaming, will lead to the following error:
```
Selecting dynamicFvMesh dynamicMotionSolverFvMesh


--> FOAM FATAL IO ERROR: 
keyword motionSolver is undefined in dictionary "/home/vagrant/tutorials/perpendicular-flap/fluid-openfoam/constant/dynamicMeshDict"

file: /home/vagrant/tutorials/perpendicular-flap/fluid-openfoam/constant/dynamicMeshDict from line 9 to line 16.

    From function T Foam::dictionary::lookup(const Foam::word&, bool, bool) const [with T = Foam::word]
    in file /home/ubuntu/OpenFOAM/OpenFOAM-9/src/OpenFOAM/lnInclude/dictionaryTemplates.C at line 43.

FOAM exiting
```

I will also document this in the adapter documentation, but opening this for future reference.

@DavidSCN please have a quick look, mostly as sanity check that I did not forget anything.

After merging:

- [ ] Update the website submodules.