### PR TITLE
Minor update to first two Nutils examples

### DIFF
--- a/flow-over-heated-plate/solid-nutils/solid.py
+++ b/flow-over-heated-plate/solid-nutils/solid.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-import nutils
+from nutils import cli, mesh, function, solver, export 
 import treelog
 import numpy as np
 import precice
@@ -9,14 +9,14 @@ from mpi4py import MPI
 
 def main():
 
-    print("Running utils")
+    print("Running nutils")
 
     # define the Nutils mesh
     grid = [np.linspace(a, b, round((b - a) / size) + 1) for (a, b, size) in [(0, 1, 0.05), (-.25, 0, 0.05)]]
-    domain, geom = nutils.mesh.rectilinear(grid)
+    domain, geom = mesh.rectilinear(grid)
 
     # Nutils namespace
-    ns = nutils.function.Namespace()
+    ns = function.Namespace()
     ns.x = geom
 
     ns.basis = domain.basis('std', degree=1)  # linear finite elements
@@ -31,7 +31,7 @@ def main():
 
     # define Dirichlet boundary condition
     sqr = domain.boundary['bottom'].integral('(u - uwall)^2 d:x' @ ns, degree=2)
-    cons = nutils.solver.optimize('lhs', sqr, droptol=1e-15)
+    cons = solver.optimize('lhs', sqr, droptol=1e-15)
 
     # preCICE setup
     interface = precice.Interface("Solid", "../precice-config.xml", 0, 1)
@@ -63,11 +63,11 @@ def main():
 
     # set u = uwall as initial condition and visualize
     sqr = domain.integral('(u - uwall)^2' @ ns, degree=2)
-    lhs0 = nutils.solver.optimize('lhs', sqr)
+    lhs0 = solver.optimize('lhs', sqr)
     bezier = domain.sample('bezier', 2)
     x, u = bezier.eval(['x_i', 'u'] @ ns, lhs=lhs0)
     with treelog.add(treelog.DataLog()):
-        nutils.export.vtk('Solid_0', bezier.tri, x, T=u)
+        export.vtk('Solid_0', bezier.tri, x, T=u)
 
     while interface.is_coupling_ongoing():
 
@@ -77,7 +77,7 @@ def main():
             temperature_function = coupling_sample.asfunction(temperature_values)
 
             sqr = coupling_sample.integral((ns.u - temperature_function)**2)
-            cons = nutils.solver.optimize('lhs', sqr, droptol=1e-15, constrain=cons0)
+            cons = solver.optimize('lhs', sqr, droptol=1e-15, constrain=cons0)
 
         # save checkpoint
         if interface.is_action_required(precice.action_write_iteration_checkpoint()):
@@ -89,7 +89,7 @@ def main():
         dt = min(dt, precice_dt)
 
         # solve nutils timestep
-        lhs = nutils.solver.solve_linear('lhs', res, constrain=cons, arguments=dict(lhs0=lhs0, dt=dt))
+        lhs = solver.solve_linear('lhs', res, constrain=cons, arguments=dict(lhs0=lhs0, dt=dt))
 
         # write heat fluxes to interface
         if interface.is_write_data_required(dt):
@@ -114,10 +114,10 @@ def main():
                 bezier = domain.sample('bezier', 2)
                 x, u = bezier.eval(['x_i', 'u'] @ ns, lhs=lhs)
                 with treelog.add(treelog.DataLog()):
-                    nutils.export.vtk('Solid_' + str(timestep), bezier.tri, x, T=u)
+                    export.vtk('Solid_' + str(timestep), bezier.tri, x, T=u)
 
     interface.finalize()
 
 
 if __name__ == '__main__':
-    nutils.cli.run(main)
+    cli.run(main)

--- a/partitioned-heat-conduction/nutils/heat.py
+++ b/partitioned-heat-conduction/nutils/heat.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-import nutils
+from nutils import cli, mesh, function, solver, export
 import treelog
 import numpy as np
 import precice
@@ -27,10 +27,10 @@ def main(side='Dirichlet'):
     y_grid = np.linspace(y_bottom, y_top, n)
 
     # define the Nutils mesh
-    domain, geom = nutils.mesh.rectilinear([x_grid, y_grid])
+    domain, geom = mesh.rectilinear([x_grid, y_grid])
 
     # Nutils namespace
-    ns = nutils.function.Namespace()
+    ns = function.Namespace()
     ns.x = geom
 
     degree = 1  # linear finite elements
@@ -96,11 +96,11 @@ def main(side='Dirichlet'):
 
     # initial condition
     sqr = domain.integral('(u - uexact)^2' @ ns, degree=degree * 2)
-    lhs0 = nutils.solver.optimize('lhs', sqr, droptol=1e-15, arguments=dict(t=t))
+    lhs0 = solver.optimize('lhs', sqr, droptol=1e-15, arguments=dict(t=t))
     bezier = domain.sample('bezier', degree * 2)
     x, u, uexact = bezier.eval(['x_i', 'u', 'uexact'] @ ns, lhs=lhs0, t=t)
     with treelog.add(treelog.DataLog()):
-        nutils.export.vtk(side + '-0', bezier.tri, x, Temperature=u, reference=uexact)
+        export.vtk(side + '-0', bezier.tri, x, Temperature=u, reference=uexact)
 
     t += precice_dt
     timestep = 0
@@ -109,7 +109,7 @@ def main(side='Dirichlet'):
     while interface.is_coupling_ongoing():
 
         # update (time-dependent) boundary condition
-        cons0 = nutils.solver.optimize('lhs', sqr0, droptol=1e-15, arguments=dict(t=t))
+        cons0 = solver.optimize('lhs', sqr0, droptol=1e-15, arguments=dict(t=t))
 
         # read data from interface
         if interface.is_read_data_available():
@@ -118,7 +118,7 @@ def main(side='Dirichlet'):
 
             if side == 'Dirichlet':
                 sqr = coupling_sample.integral((ns.u - read_function)**2)
-                cons = nutils.solver.optimize('lhs', sqr, droptol=1e-15, constrain=cons0, arguments=dict(t=t))
+                cons = solver.optimize('lhs', sqr, droptol=1e-15, constrain=cons0, arguments=dict(t=t))
                 res = res0
             else:
                 cons = cons0
@@ -135,7 +135,7 @@ def main(side='Dirichlet'):
         dt = min(dt, precice_dt)
 
         # solve nutils timestep
-        lhs = nutils.solver.solve_linear('lhs', res, constrain=cons, arguments=dict(lhs0=lhs0, dt=dt, t=t))
+        lhs = solver.solve_linear('lhs', res, constrain=cons, arguments=dict(lhs0=lhs0, dt=dt, t=t))
 
         # write data to interface
         if interface.is_write_data_required(dt):
@@ -166,10 +166,9 @@ def main(side='Dirichlet'):
             x, u, uexact = bezier.eval(['x_i', 'u', 'uexact'] @ ns, lhs=lhs, t=t)
 
             with treelog.add(treelog.DataLog()):
-                nutils.export.vtk(side + "-" + str(timestep), bezier.tri, x, Temperature=u, reference=uexact)
+                export.vtk(side + "-" + str(timestep), bezier.tri, x, Temperature=u, reference=uexact)
 
     interface.finalize()
 
-
 if __name__ == '__main__':
-    nutils.cli.run(main)
+   cli.run(main)


### PR DESCRIPTION
The current active & stable nutils version is v7.0 (28ae68f3). With this pull request the first two examples are updated to nutils v7.0. At the moment the only change in this update is the way the libraries are imported. In order to have backward compatibility to previous nutils version, i.e., v6.3 (87281a0b), one needs to change only the importing style. The two styles of library import associated to the nutils version is demonstrated below.

nutils v7.0 (28ae68f3):

```python
from nutils import cli, solver

def main()
      lhs = solver(...)

cli.run(main)
```

nutils v6.3 (87281a0b):

```python
import nutils

def main():
      lhs = nutils.solver(...)

nutils.cli.run(main)
```




