### PR TITLE
Change preCICE version to latest version

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -21,8 +21,8 @@ To get a feeling what preCICE does, watch a [short presentation](https://www.you
 1. Get and install preCICE. For Ubuntu 20.04 (Focal Fossa), this is pretty easy: [download](https://github.com/precice/precice/releases/latest) and install our binary package by clicking on it or using the following commands:
 
     ```bash
-    wget https://github.com/precice/precice/releases/download/v2.3.0/libprecice2_2.3.0_focal.deb
-    sudo apt install ./libprecice2_2.3.0_focal.deb
+    wget https://github.com/precice/precice/releases/download/v2.4.0/libprecice2_2.4.0_focal.deb
+    sudo apt install ./libprecice2_2.4.0_focal.deb
     ```
 
     - Are you using something else? Just pick what suits you best on [this overview page](https://precice.org/installation-overview.html).


### PR DESCRIPTION
In the quickstart guide change the download link of preCICE from 2.3.0 to 2.4.0

