### PR TITLE
Use waveform iteration with partitioned-heat-conduction/fenics/heat.py

### DIFF
--- a/partitioned-heat-conduction/fenics/heat.py
+++ b/partitioned-heat-conduction/fenics/heat.py
@@ -62,7 +62,7 @@ parser.add_argument("-e", "--error-tol", help="set error tolerance", type=float,
 
 args = parser.parse_args()
 
-fenics_dt = .1  # time step size
+fenics_dt = .01  # time step size
 # Error is bounded by coupling accuracy. In theory we would obtain the analytical solution.
 error_tol = args.error_tol
 
@@ -178,7 +178,7 @@ while precice.is_coupling_ongoing():
     if precice.is_action_required(precice.action_write_iteration_checkpoint()):
         precice.store_checkpoint(u_n, t, n)
 
-    read_data = precice.read_data()
+    read_data = precice.read_data(dt(0))
 
     # Update the coupling expression with the new read data
     precice.update_coupling_expression(coupling_expression, read_data)

--- a/partitioned-heat-conduction/precice-config.xml
+++ b/partitioned-heat-conduction/precice-config.xml
@@ -7,7 +7,7 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
+  <solver-interface dimensions="2" experimental="true">
     <data:scalar name="Temperature" />
     <data:scalar name="Heat-Flux" />
 
@@ -25,7 +25,7 @@
       <use-mesh name="Dirichlet-Mesh" provide="yes" />
       <use-mesh name="Neumann-Mesh" from="Neumann" />
       <write-data name="Heat-Flux" mesh="Dirichlet-Mesh" />
-      <read-data name="Temperature" mesh="Dirichlet-Mesh" />
+      <read-data name="Temperature" mesh="Dirichlet-Mesh" waveform-order="1"/>
       <mapping:rbf-thin-plate-splines
         direction="read"
         from="Neumann-Mesh"
@@ -38,7 +38,7 @@
       <use-mesh name="Neumann-Mesh" provide="yes" />
       <use-mesh name="Dirichlet-Mesh" from="Dirichlet" />
       <write-data name="Temperature" mesh="Neumann-Mesh" />
-      <read-data name="Heat-Flux" mesh="Neumann-Mesh" />
+      <read-data name="Heat-Flux" mesh="Neumann-Mesh" waveform-order="0"/>
       <mapping:rbf-thin-plate-splines
         direction="read"
         from="Dirichlet-Mesh"


### PR DESCRIPTION
This PR introduces waveform iteration for the partitioned-heat-conduction case. Currently only the fenics-adapter supports this feature via https://github.com/precice/fenics-adapter/pull/153 + https://github.com/precice/python-bindings/pull/147. This also means that the tutorials for other adapters/solvers will break.

I think that the partitioned-heat-conduction case + subcycling is a nice test case for waveform iteration + subcycling. However, we might want to shift this specialized configuration of the case into an independent folder (as long as not all adapters support waveform iteration).

This is a breaking change, because some required features will only be introduced with preCICE v3.0.0.
