### PR TITLE
Remove std::pow from constexpr

### DIFF
--- a/quickstart/solid-cpp/rigid_body_solver.cpp
+++ b/quickstart/solid-cpp/rigid_body_solver.cpp
@@ -114,7 +114,7 @@ int main()
   // The moment of inertia is computed according to the rigid body configuration:
   // a thin rectangular plate of height h, length l and mass m with axis of rotation
   // at the end of the plate: I = (1/12)*m*(4*l^2+h^2)
-  constexpr double inertia_moment = (1. / 12) * mass * (4 * std::pow(length, 2) + std::pow(height, 2));
+  constexpr double inertia_moment = (1. / 12) * mass * (4 * length * length + height * height);
   constexpr double delta_y        = height / (n_vertical_nodes - 1);
   constexpr double delta_x        = length / (n_horizontal_nodes - 1);
 


### PR DESCRIPTION
using `std::pow` in a `constexpr` is not supported by Intel oneAPI C++ compiler:
```
rigid_body_solver.cpp(117): error: expression must have a constant value
    constexpr double inertia_moment = (1. / 12) * mass * (4 * std::pow(length, 2) + std::pow(height, 2));
                                      ^
/usr/include/c++/8/cmath(418): note: cannot call non-constexpr function "pow" (declared at line 140 of "/usr/include/bits/mathcalls.h")
        return pow(__type(__x), __type(__y));
               ^
```

<!-- Please submit your Pull Request to the `develop` branch.

It may help to have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->
