### PR TITLE
Rename force field name for solid participants

### DIFF
--- a/perpendicular-flap/solid-openfoam/system/preciceDict
+++ b/perpendicular-flap/solid-openfoam/system/preciceDict
@@ -46,5 +46,5 @@ FSI
     namePointDisplacement unused;
 
     // Name of the force field on the solid
-    forceFieldName solidForce;
+    nameForce solidForce;
 }

--- a/perpendicular-flap/solid-solids4foam/system/preciceDict
+++ b/perpendicular-flap/solid-solids4foam/system/preciceDict
@@ -42,5 +42,5 @@ FSI
     nameCellDisplacement D;
 
     // Name of the force field on the solid
-    forceFieldName solidForce;
+    nameForce solidForce;
 }


### PR DESCRIPTION
According to https://github.com/precice/openfoam-adapter/pull/252

Does not need a changelog entry (not previously released).

No clue why the PEP8 CI check fails, this does not touch any Python files.

