### PR TITLE
Fix `clean` and `run` for Nutils partitioned-heat

### DIFF
--- a/partitioned-heat-conduction/nutils/clean.sh
+++ b/partitioned-heat-conduction/nutils/clean.sh
@@ -3,4 +3,4 @@ set -e -u
 
 . ../../tools/cleaning-tools.sh
 
-clean_nutils
+clean_nutils .

--- a/partitioned-heat-conduction/nutils/run.sh
+++ b/partitioned-heat-conduction/nutils/run.sh
@@ -12,11 +12,11 @@ while getopts ":dn" opt; do
   case ${opt} in
   d)
     rm -rf Dirichlet-*.vtk
-    python3 heat.py --side=Dirichlet
+    python3 heat.py side=Dirichlet
     ;;
   n)
     rm -rf Neumann-*.vtk
-    python3 heat.py --side=Neumann
+    python3 heat.py side=Neumann
     ;;
   *)
     usage


### PR DESCRIPTION
Both scripts failed on my OS. Maybe someone else could confirm/approve these changes. A bit confusing that it only pops up now