### PR TITLE
Fixed a docker-compose race condition

### DIFF
--- a/flow-over-heated-plate/tests/docker-compose.yml
+++ b/flow-over-heated-plate/tests/docker-compose.yml
@@ -14,7 +14,8 @@ services:
 
   fluid-openfoam:
     depends_on:
-      - prepare
+      prepare:
+        condition: service_completed_successfully
     image: "ghcr.io/precice/openfoam-adapter:${TAG_OPENFOAM_ADAPTER}"
     user: ${MY_UID}:${MY_GID}
     volumes:
@@ -22,13 +23,14 @@ services:
       - /etc/group:/etc/group:ro
       - ../..:/tests
     command: >
-      /bin/bash -c "id &&
+      /bin/bash -c "id && 
       cd /tests/flow-over-heated-plate/fluid-openfoam &&
       openfoam2112 ./run.sh | tee fluid-openfoam.log 2>&1"
 
   solid-openfoam:
     depends_on:
-      - prepare
+      prepare:
+        condition: service_completed_successfully
     image: "ghcr.io/precice/openfoam-adapter:${TAG_OPENFOAM_ADAPTER}"
     user: ${MY_UID}:${MY_GID}
     volumes:
@@ -42,8 +44,10 @@ services:
 
   cleanup:
     depends_on:
-      - fluid-openfoam
-      - solid-openfoam
+      fluid-openfoam:
+        condition: service_completed_successfully
+      solid-openfoam:
+        condition: service_completed_successfully
     image: ubuntu:latest
     user: ${MY_UID}:${MY_GID}
     volumes:
@@ -54,4 +58,3 @@ services:
       /bin/bash -c "id &&
       cd /tests/flow-over-heated-plate &&
       sed -i 's|m2n:sockets network=\"eth0\" from|m2n:sockets from|g' precice-config.xml"
-    


### PR DESCRIPTION
Sometimes the cleanup service ran faster than the openfoam-adapter container leading to a missing "eth0" entry in the network configuration of the `precice-config.xml`

Now the [startup order](https://docs.docker.com/compose/startup-order/) is enforced via conditions.

