### PR TITLE
Build cpp solvers as part of run

### DIFF
--- a/elastic-tube-1d/fluid-cpp/run.sh
+++ b/elastic-tube-1d/fluid-cpp/run.sh
@@ -4,8 +4,7 @@ set -e -u
 if [ ! -d build ]; then
   mkdir build
   cmake -S . -B build
+  cmake --build build
 fi
-
-cmake --build build
 
 ./build/FluidSolver ../precice-config.xml

--- a/elastic-tube-1d/fluid-cpp/run.sh
+++ b/elastic-tube-1d/fluid-cpp/run.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 set -e -u
 
+if [ ! -d build ]; then
+  mkdir build
+  cmake -S . -B build
+fi
+
+cmake --build build
+
 ./build/FluidSolver ../precice-config.xml

--- a/elastic-tube-1d/solid-cpp/run.sh
+++ b/elastic-tube-1d/solid-cpp/run.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 set -e -u
 
+if [ ! -d build ]; then
+  mkdir build
+  cmake -S . -B build
+fi
+
+cmake --build build
+
 ./build/SolidSolver ../precice-config.xml

--- a/elastic-tube-1d/solid-cpp/run.sh
+++ b/elastic-tube-1d/solid-cpp/run.sh
@@ -4,8 +4,7 @@ set -e -u
 if [ ! -d build ]; then
   mkdir build
   cmake -S . -B build
+  cmake --build build
 fi
-
-cmake --build build
 
 ./build/SolidSolver ../precice-config.xml


### PR DESCRIPTION
The elastic-tube-1d cpp solvers require to be build inside `build` directories.
In-source builds don't work:
```
cd elastic-tube-1d/solid-cpp
cmake .
cmake --build .
./run.sh
Cannot find ./build/SolidSolver
```

This PR changes the run script to automatically configure and (re)build the solver.

@MakisH is this compatible with the VM?
