### PR TITLE
Update all FEniCS participants to be compatible with precice:develop (v3)

### DIFF
--- a/elastic-tube-3d/solid-fenics/solid.py
+++ b/elastic-tube-3d/solid-fenics/solid.py
@@ -172,7 +172,7 @@ displacement_out << u_n
 
 while precice.is_coupling_ongoing():
 
-    if precice.is_action_required(precice.action_write_iteration_checkpoint()):  # write checkpoint
+    if precice.requires_writing_checkpoint():  # write checkpoint
         precice.store_checkpoint(u_n, t, n)
 
     # read data from preCICE and get a new coupling expression
@@ -205,7 +205,7 @@ while precice.is_coupling_ongoing():
     precice_dt = precice.advance(dt(0))
 
     # Either revert to old step if timestep has not converged or move to next timestep
-    if precice.is_action_required(precice.action_read_iteration_checkpoint()):  # roll back to checkpoint
+    if precice.requires_reading_checkpoint():  # roll back to checkpoint
         u_cp, t_cp, n_cp = precice.retrieve_checkpoint()
         u_n.assign(u_cp)
         t = t_cp

--- a/flow-over-heated-plate/solid-fenics/solid.py
+++ b/flow-over-heated-plate/solid-fenics/solid.py
@@ -159,7 +159,7 @@ fluxes.rename("Fluxes", "")
 
 while precice.is_coupling_ongoing():
 
-    if precice.is_action_required(precice.action_write_iteration_checkpoint()):  # write checkpoint
+    if precice.requires_writing_checkpoint():  # write checkpoint
         precice.store_checkpoint(u_n, t, n)
 
     read_data = precice.read_data()
@@ -179,7 +179,7 @@ while precice.is_coupling_ongoing():
 
     precice_dt = precice.advance(dt(0))
 
-    if precice.is_action_required(precice.action_read_iteration_checkpoint()):  # roll back to checkpoint
+    if precice.requires_reading_checkpoint():  # roll back to checkpoint
         u_cp, t_cp, n_cp = precice.retrieve_checkpoint()
         u_n.assign(u_cp)
         t = t_cp

--- a/partitioned-heat-conduction-complex/fenics/heat.py
+++ b/partitioned-heat-conduction-complex/fenics/heat.py
@@ -191,7 +191,7 @@ flux.rename("Flux", "")
 while precice.is_coupling_ongoing():
 
     # write checkpoint
-    if precice.is_action_required(precice.action_write_iteration_checkpoint()):
+    if precice.requires_writing_checkpoint():
         precice.store_checkpoint(u_n, t, n)
 
     read_data = precice.read_data()
@@ -220,7 +220,7 @@ while precice.is_coupling_ongoing():
     precice_dt = precice.advance(dt(0))
 
     # roll back to checkpoint
-    if precice.is_action_required(precice.action_read_iteration_checkpoint()):
+    if precice.requires_reading_checkpoint():
         u_cp, t_cp, n_cp = precice.retrieve_checkpoint()
         u_n.assign(u_cp)
         t = t_cp

--- a/partitioned-heat-conduction/fenics/heat.py
+++ b/partitioned-heat-conduction/fenics/heat.py
@@ -175,7 +175,7 @@ if problem is ProblemType.DIRICHLET:
 while precice.is_coupling_ongoing():
 
     # write checkpoint
-    if precice.is_action_required(precice.action_write_iteration_checkpoint()):
+    if precice.requires_writing_checkpoint():
         precice.store_checkpoint(u_n, t, n)
 
     read_data = precice.read_data()
@@ -201,7 +201,7 @@ while precice.is_coupling_ongoing():
     precice_dt = precice.advance(dt(0))
 
     # roll back to checkpoint
-    if precice.is_action_required(precice.action_read_iteration_checkpoint()):
+    if precice.requires_reading_checkpoint():
         u_cp, t_cp, n_cp = precice.retrieve_checkpoint()
         u_n.assign(u_cp)
         t = t_cp

--- a/perpendicular-flap/solid-fenics/solid.py
+++ b/perpendicular-flap/solid-fenics/solid.py
@@ -178,7 +178,7 @@ displacement_out << u_n
 
 while precice.is_coupling_ongoing():
 
-    if precice.is_action_required(precice.action_write_iteration_checkpoint()):  # write checkpoint
+    if precice.requires_writing_checkpoint():  # write checkpoint
         precice.store_checkpoint(u_n, t, n)
 
     # read data from preCICE and get a new coupling expression
@@ -208,7 +208,7 @@ while precice.is_coupling_ongoing():
     precice_dt = precice.advance(dt(0))
 
     # Either revert to old step if timestep has not converged or move to next timestep
-    if precice.is_action_required(precice.action_read_iteration_checkpoint()):  # roll back to checkpoint
+    if precice.requires_reading_checkpoint():  # roll back to checkpoint
         u_cp, t_cp, n_cp = precice.retrieve_checkpoint()
         u_n.assign(u_cp)
         t = t_cp

--- a/volume-coupled-diffusion/fenics/volume-coupled-diffusion.py
+++ b/volume-coupled-diffusion/fenics/volume-coupled-diffusion.py
@@ -93,7 +93,7 @@ ranks << mesh_rank
 while precice.is_coupling_ongoing():
 
     # write checkpoint
-    if precice.is_action_required(precice.action_write_iteration_checkpoint()):
+    if precice.requires_writing_checkpoint():
         precice.store_checkpoint(u_n, t, n)
 
     read_data = precice.read_data()
@@ -114,7 +114,7 @@ while precice.is_coupling_ongoing():
     dt = precice.advance(dt)
 
     # roll back to checkpoint
-    if precice.is_action_required(precice.action_read_iteration_checkpoint()):
+    if precice.requires_reading_checkpoint():
         u_cp, t_cp, n_cp = precice.retrieve_checkpoint()
         u_n.assign(u_cp)
         t = t_cp


### PR DESCRIPTION
This PR updates all FEniCS participants to be compatible with precice:develop. The changes should be tested with https://github.com/precice/fenics-adapter/pull/153. Manual testing is necessary, and once cases are known to work, this PR needs to be merged so that the PR mentioned earlier can be tested via CI.