### PR TITLE
Update fvSolution to fit OpenFOAM 9 and newer

### DIFF
--- a/elastic-tube-3d/fluid-openfoam/system/fvSolution
+++ b/elastic-tube-3d/fluid-openfoam/system/fvSolution
@@ -209,6 +209,25 @@ outerResidualControl
 }
 */
 
+// OpenFOAM 9 (.org) or newer
+// see also https://github.com/OpenFOAM/OpenFOAM-dev/commit/4c8122783aedaa7dadf0486163a98350e625db32
+/*
+outerCorrectorResidualControl
+{
+U
+{
+    tolerance 1e-5;
+    relTol	  0;
+}
+
+p
+{
+    tolerance 1e-5;
+    relTol	  0;
+}
+}
+*/
+
 relaxationFactors
 {
     U       0.5;

--- a/turek-hron-fsi3/fluid-openfoam/system/fvSolution
+++ b/turek-hron-fsi3/fluid-openfoam/system/fvSolution
@@ -85,13 +85,32 @@ PIMPLE
 	}
     }
 
-    // OpenFOAM 6 (.org) or newer
+    // OpenFOAM 6, 7, 8 (.org)
     // see also https://bugs.openfoam.org/view.php?id=3336
     /*
     outerResidualControl
     {
         U 1e-5;
         p 1e-5;
+    }
+    */
+    
+    // OpenFOAM 9 (.org) or newer
+    // see also https://github.com/OpenFOAM/OpenFOAM-dev/commit/4c8122783aedaa7dadf0486163a98350e625db32
+    /*
+    outerCorrectorResidualControl
+    {
+	U
+	{
+		tolerance 1e-5;
+		relTol	  0;
+	}
+
+	p
+	{
+		tolerance 1e-5;
+		relTol	  0;
+	}
     }
     */
 


### PR DESCRIPTION
Adds outerCorrectorResidualControl dictionary adapted to fit OpenFOAM 9 requirements. Also modifies wrong dictionary name for OpenFOAM 6, 7, 8 ("outerResidualControl" changed to "outerCorrectorResidualControl")

I should specify I am not sure this change does not apply to older OpenFOAM versions, but I can confirm based on experience that OpenFOAM 9 will not run without the modified dictionary.

<!-- Please submit your Pull Request to the `develop` branch.

It may help to have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->
