### PR TITLE
Markdown-lint: Disable MD034

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
     "MD013": false,
-    "MD033": false
+    "MD033": false,
+    "MD034": false
 }


### PR DESCRIPTION
Similarly to https://github.com/precice/openfoam-adapter/pull/290, this PR disables the markdown-lint check for bare URLs, as this now started complaining about the OpenFOAM copyright disclaimer.

As this rule is actually useful (especially for accessibility), an alternative would be to remove the `www.` part from the disclaimer.