### PR TITLE
Quickstart: Update the recommended OpenFOAM version to v2306

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -32,10 +32,10 @@ To get a feeling what preCICE does, watch a [short presentation](https://www.you
     ```bash
     # Add the signing key, add the repository, update (check this):
     wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
-    # Install OpenFOAM v2206:
-    sudo apt install openfoam2206-dev
+    # Install OpenFOAM v2306:
+    sudo apt install openfoam2306-dev
     # Enable OpenFOAM by default in your system and apply now:
-    echo "source /usr/lib/openfoam/openfoam2206/etc/bashrc" >> ~/.bashrc
+    echo "source /usr/lib/openfoam/openfoam2306/etc/bashrc" >> ~/.bashrc
     source ~/.bashrc
     ```
 


### PR DESCRIPTION
Following https://github.com/precice/openfoam-adapter/pull/296.


