### PR TITLE
Remove XML tag solver-interface from all tutorials

### DIFF
--- a/aste-turbine/precice-config.xml
+++ b/aste-turbine/precice-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<precice-configuration>
+<precice-configuration dimensions="3">
 
   <log>
     <sink
@@ -8,48 +8,44 @@
       format="---[precice] %ColorizedSeverity% %Message%"
       enabled="true" />
   </log>
+    
+  <data:scalar name="Data" />
+
+  <mesh name="A-Mesh">
+    <use-data name="Data" />
+  </mesh>
+
+  <mesh name="B-Mesh">
+    <use-data name="Data" />
+  </mesh>
   
-  <solver-interface dimensions="3">
-    
-    <data:scalar name="Data" />
+  <m2n:sockets acceptor="A" connector="B" exchange-directory="." />
 
-    <mesh name="A-Mesh">
-      <use-data name="Data" />
-    </mesh>
+  <participant name="A">
+    <provide-mesh name="A-Mesh" />
+    <write-data name="Data" mesh="A-Mesh" />
+  </participant>
+  
+  <participant name="B">
+    <receive-mesh name="A-Mesh" from="A" />
+    <provide-mesh name="B-Mesh" />
+    <read-data name="Data" mesh="B-Mesh" />
 
-    <mesh name="B-Mesh">
-      <use-data name="Data" />
-    </mesh>
-    
-    <m2n:sockets acceptor="A" connector="B" exchange-directory="." />
-
-    <participant name="A">
-      <provide-mesh name="A-Mesh" />
-      <write-data name="Data" mesh="A-Mesh" />
-    </participant>
-    
-    <participant name="B">
-      <receive-mesh name="A-Mesh" from="A" />
-      <provide-mesh name="B-Mesh" />
-      <read-data name="Data" mesh="B-Mesh" />
-
-      <mapping:nearest-neighbor constraint="consistent" direction="read" from="A-Mesh" to="B-Mesh" />
-      <!-- <mapping:nearest-projection constraint="consistent" direction="read" from="A-Mesh" to="B-Mesh" /> -->
-      <!-- <mapping:rbf-pum-direct constraint="consistent" direction="read" from="A-Mesh" to="B-Mesh" />
-            <basis-function:compact-polynomial-c6 support-radius="0.1" />
-           </mapping:rbf-pum-direct> -->
-      <!-- <mapping:rbf-global-direct constraint="consistent" direction="read" from="A-Mesh" to="B-Mesh" />
-            <basis-function:compact-polynomial-c6 support-radius="0.1" />
-           </mapping:rbf-global-direct> -->
-    </participant>
-    
-    <coupling-scheme:parallel-explicit>
-      <participants first="A" second="B" />
-      <max-time value="1.0" />
-      <time-window-size value="1" />
-      <exchange data="Data" mesh="A-Mesh" from="A" to="B" />
-    </coupling-scheme:parallel-explicit>
-    
-  </solver-interface>
+    <mapping:nearest-neighbor constraint="consistent" direction="read" from="A-Mesh" to="B-Mesh" />
+    <!-- <mapping:nearest-projection constraint="consistent" direction="read" from="A-Mesh" to="B-Mesh" /> -->
+    <!-- <mapping:rbf-pum-direct constraint="consistent" direction="read" from="A-Mesh" to="B-Mesh" />
+          <basis-function:compact-polynomial-c6 support-radius="0.1" />
+          </mapping:rbf-pum-direct> -->
+    <!-- <mapping:rbf-global-direct constraint="consistent" direction="read" from="A-Mesh" to="B-Mesh" />
+          <basis-function:compact-polynomial-c6 support-radius="0.1" />
+          </mapping:rbf-global-direct> -->
+  </participant>
+  
+  <coupling-scheme:parallel-explicit>
+    <participants first="A" second="B" />
+    <max-time value="1.0" />
+    <time-window-size value="1" />
+    <exchange data="Data" mesh="A-Mesh" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
   
 </precice-configuration>

--- a/channel-transport-reaction/precice-config.xml
+++ b/channel-transport-reaction/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="2">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,42 +7,40 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:vector name="Velocity" />
+  <data:vector name="Velocity" />
 
-    <mesh name="Flow-Mesh">
-      <use-data name="Velocity" />
-    </mesh>
+  <mesh name="Flow-Mesh">
+    <use-data name="Velocity" />
+  </mesh>
 
-    <mesh name="Chemical-Mesh">
-      <use-data name="Velocity" />
-    </mesh>
+  <mesh name="Chemical-Mesh">
+    <use-data name="Velocity" />
+  </mesh>
 
-    <participant name="Flow">
-      <provide-mesh name="Flow-Mesh" />
-      <receive-mesh name="Chemical-Mesh" from="Chemical" />
-      <write-data name="Velocity" mesh="Flow-Mesh" />
-    </participant>
+  <participant name="Flow">
+    <provide-mesh name="Flow-Mesh" />
+    <receive-mesh name="Chemical-Mesh" from="Chemical" />
+    <write-data name="Velocity" mesh="Flow-Mesh" />
+  </participant>
 
-    <participant name="Chemical">
-      <provide-mesh name="Chemical-Mesh" />
-      <receive-mesh name="Flow-Mesh" from="Flow" />
-      <read-data name="Velocity" mesh="Chemical-Mesh" />
-      <mapping:linear-cell-interpolation
-        direction="read"
-        from="Flow-Mesh"
-        to="Chemical-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Chemical">
+    <provide-mesh name="Chemical-Mesh" />
+    <receive-mesh name="Flow-Mesh" from="Flow" />
+    <read-data name="Velocity" mesh="Chemical-Mesh" />
+    <mapping:linear-cell-interpolation
+      direction="read"
+      from="Flow-Mesh"
+      to="Chemical-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <m2n:sockets acceptor="Flow" connector="Chemical" exchange-directory=".." />
+  <m2n:sockets acceptor="Flow" connector="Chemical" exchange-directory=".." />
 
-    <coupling-scheme:serial-explicit>
-      <participants first="Flow" second="Chemical" />
-      <max-time value="5.0" />
-      <time-window-size value="0.05" />
-      <exchange data="Velocity" mesh="Flow-Mesh" from="Flow" to="Chemical" />
+  <coupling-scheme:serial-explicit>
+    <participants first="Flow" second="Chemical" />
+    <max-time value="5.0" />
+    <time-window-size value="0.05" />
+    <exchange data="Velocity" mesh="Flow-Mesh" from="Flow" to="Chemical" />
 
-    </coupling-scheme:serial-explicit>
-  </solver-interface>
+  </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/channel-transport/precice-config.xml
+++ b/channel-transport/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="2">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,38 +7,36 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:vector name="Velocity" />
+  <data:vector name="Velocity" />
 
-    <mesh name="Fluid-Mesh">
-      <use-data name="Velocity" />
-    </mesh>
+  <mesh name="Fluid-Mesh">
+    <use-data name="Velocity" />
+  </mesh>
 
-    <mesh name="Transport-Mesh">
-      <use-data name="Velocity" />
-    </mesh>
+  <mesh name="Transport-Mesh">
+    <use-data name="Velocity" />
+  </mesh>
 
-    <participant name="Fluid">
-      <provide-mesh name="Fluid-Mesh" />
-      <receive-mesh name="Transport-Mesh" from="Transport" />
-      <write-data name="Velocity" mesh="Fluid-Mesh" />
-      <mapping:rbf direction="write" from="Fluid-Mesh" to="Transport-Mesh" constraint="consistent">
-        <basis-function:compact-tps-c2 support-radius="0.4" />
-      </mapping:rbf>
-    </participant>
+  <participant name="Fluid">
+    <provide-mesh name="Fluid-Mesh" />
+    <receive-mesh name="Transport-Mesh" from="Transport" />
+    <write-data name="Velocity" mesh="Fluid-Mesh" />
+    <mapping:rbf direction="write" from="Fluid-Mesh" to="Transport-Mesh" constraint="consistent">
+      <basis-function:compact-tps-c2 support-radius="0.4" />
+    </mapping:rbf>
+  </participant>
 
-    <participant name="Transport">
-      <provide-mesh name="Transport-Mesh" />
-      <read-data name="Velocity" mesh="Transport-Mesh" />
-    </participant>
+  <participant name="Transport">
+    <provide-mesh name="Transport-Mesh" />
+    <read-data name="Velocity" mesh="Transport-Mesh" />
+  </participant>
 
-    <m2n:sockets acceptor="Fluid" connector="Transport" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid" connector="Transport" exchange-directory=".." />
 
-    <coupling-scheme:serial-explicit>
-      <time-window-size value="0.005" />
-      <max-time value="1.0" />
-      <participants first="Fluid" second="Transport" />
-      <exchange data="Velocity" mesh="Transport-Mesh" from="Fluid" to="Transport" />
-    </coupling-scheme:serial-explicit>
-  </solver-interface>
+  <coupling-scheme:serial-explicit>
+    <time-window-size value="0.005" />
+    <max-time value="1.0" />
+    <participants first="Fluid" second="Transport" />
+    <exchange data="Velocity" mesh="Transport-Mesh" from="Fluid" to="Transport" />
+  </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/elastic-tube-1d/precice-config.xml
+++ b/elastic-tube-1d/precice-config.xml
@@ -1,73 +1,71 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="2">
   <log enabled="1">
     <sink filter="%Severity% > debug" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:scalar name="Pressure" />
-    <data:scalar name="CrossSectionLength" />
+  <data:scalar name="Pressure" />
+  <data:scalar name="CrossSectionLength" />
 
-    <mesh name="Fluid-Nodes-Mesh">
-      <use-data name="CrossSectionLength" />
-      <use-data name="Pressure" />
-    </mesh>
+  <mesh name="Fluid-Nodes-Mesh">
+    <use-data name="CrossSectionLength" />
+    <use-data name="Pressure" />
+  </mesh>
 
-    <mesh name="Solid-Nodes-Mesh">
-      <use-data name="CrossSectionLength" />
-      <use-data name="Pressure" />
-    </mesh>
+  <mesh name="Solid-Nodes-Mesh">
+    <use-data name="CrossSectionLength" />
+    <use-data name="Pressure" />
+  </mesh>
 
-    <participant name="Fluid">
-      <provide-mesh name="Fluid-Nodes-Mesh" />
-      <receive-mesh name="Solid-Nodes-Mesh" from="Solid" />
-      <write-data name="Pressure" mesh="Fluid-Nodes-Mesh" />
-      <read-data name="CrossSectionLength" mesh="Fluid-Nodes-Mesh" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Solid-Nodes-Mesh"
-        to="Fluid-Nodes-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid">
+    <provide-mesh name="Fluid-Nodes-Mesh" />
+    <receive-mesh name="Solid-Nodes-Mesh" from="Solid" />
+    <write-data name="Pressure" mesh="Fluid-Nodes-Mesh" />
+    <read-data name="CrossSectionLength" mesh="Fluid-Nodes-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Solid-Nodes-Mesh"
+      to="Fluid-Nodes-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <participant name="Solid">
-      <provide-mesh name="Solid-Nodes-Mesh" />
-      <receive-mesh name="Fluid-Nodes-Mesh" from="Fluid" />
-      <write-data name="CrossSectionLength" mesh="Solid-Nodes-Mesh" />
-      <read-data name="Pressure" mesh="Solid-Nodes-Mesh" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid-Nodes-Mesh"
-        to="Solid-Nodes-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Solid">
+    <provide-mesh name="Solid-Nodes-Mesh" />
+    <receive-mesh name="Fluid-Nodes-Mesh" from="Fluid" />
+    <write-data name="CrossSectionLength" mesh="Solid-Nodes-Mesh" />
+    <read-data name="Pressure" mesh="Solid-Nodes-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid-Nodes-Mesh"
+      to="Solid-Nodes-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".."/>
+  <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".."/>
 
-    <coupling-scheme:serial-implicit>
-      <participants first="Fluid" second="Solid" />
-      <max-time value="1.0" />
-      <time-window-size value="0.01" valid-digits="8" />
-      <max-iterations value="40" />
-      <exchange data="Pressure" mesh="Fluid-Nodes-Mesh" from="Fluid" to="Solid" />
-      <exchange
-        data="CrossSectionLength"
-        mesh="Solid-Nodes-Mesh"
-        from="Solid"
-        to="Fluid"
-        initialize="true" />
-      <relative-convergence-measure data="Pressure" mesh="Fluid-Nodes-Mesh" limit="1e-5" />
-      <relative-convergence-measure
-        data="CrossSectionLength"
-        mesh="Solid-Nodes-Mesh"
-        limit="1e-5" />
-      <acceleration:IQN-ILS>
-        <data name="CrossSectionLength" mesh="Solid-Nodes-Mesh" />
-        <initial-relaxation value="0.01" />
-        <max-used-iterations value="50" />
-        <time-windows-reused value="8" />
-        <filter type="QR2" limit="1e-3" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:serial-implicit>
-  </solver-interface>
+  <coupling-scheme:serial-implicit>
+    <participants first="Fluid" second="Solid" />
+    <max-time value="1.0" />
+    <time-window-size value="0.01" valid-digits="8" />
+    <max-iterations value="40" />
+    <exchange data="Pressure" mesh="Fluid-Nodes-Mesh" from="Fluid" to="Solid" />
+    <exchange
+      data="CrossSectionLength"
+      mesh="Solid-Nodes-Mesh"
+      from="Solid"
+      to="Fluid"
+      initialize="true" />
+    <relative-convergence-measure data="Pressure" mesh="Fluid-Nodes-Mesh" limit="1e-5" />
+    <relative-convergence-measure
+      data="CrossSectionLength"
+      mesh="Solid-Nodes-Mesh"
+      limit="1e-5" />
+    <acceleration:IQN-ILS>
+      <data name="CrossSectionLength" mesh="Solid-Nodes-Mesh" />
+      <initial-relaxation value="0.01" />
+      <max-used-iterations value="50" />
+      <time-windows-reused value="8" />
+      <filter type="QR2" limit="1e-3" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/elastic-tube-3d/precice-config.xml
+++ b/elastic-tube-3d/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="3">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,67 +7,65 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="3">
-    <data:vector name="Force" />
-    <data:vector name="DisplacementDelta" />
+  <data:vector name="Force" />
+  <data:vector name="DisplacementDelta" />
 
-    <mesh name="Fluid-Mesh-Nodes">
-      <use-data name="DisplacementDelta" />
-    </mesh>
+  <mesh name="Fluid-Mesh-Nodes">
+    <use-data name="DisplacementDelta" />
+  </mesh>
 
-    <mesh name="Fluid-Mesh-Faces">
-      <use-data name="Force" />
-    </mesh>
+  <mesh name="Fluid-Mesh-Faces">
+    <use-data name="Force" />
+  </mesh>
 
-    <mesh name="Solid-Mesh">
-      <use-data name="DisplacementDelta" />
-      <use-data name="Force" />
-    </mesh>
+  <mesh name="Solid-Mesh">
+    <use-data name="DisplacementDelta" />
+    <use-data name="Force" />
+  </mesh>
 
-    <participant name="Fluid">
-      <receive-mesh name="Solid-Mesh" from="Solid" safety-factor="1.5" />
-      <provide-mesh name="Fluid-Mesh-Nodes" />
-      <provide-mesh name="Fluid-Mesh-Faces" />
-      <write-data name="Force" mesh="Fluid-Mesh-Faces" />
-      <read-data name="DisplacementDelta" mesh="Fluid-Mesh-Nodes" />
-      <mapping:nearest-projection
-        direction="write"
-        from="Fluid-Mesh-Faces"
-        to="Solid-Mesh"
-        constraint="conservative" />
-      <mapping:nearest-projection
-        direction="read"
-        from="Solid-Mesh"
-        to="Fluid-Mesh-Nodes"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid">
+    <receive-mesh name="Solid-Mesh" from="Solid" safety-factor="1.5" />
+    <provide-mesh name="Fluid-Mesh-Nodes" />
+    <provide-mesh name="Fluid-Mesh-Faces" />
+    <write-data name="Force" mesh="Fluid-Mesh-Faces" />
+    <read-data name="DisplacementDelta" mesh="Fluid-Mesh-Nodes" />
+    <mapping:nearest-projection
+      direction="write"
+      from="Fluid-Mesh-Faces"
+      to="Solid-Mesh"
+      constraint="conservative" />
+    <mapping:nearest-projection
+      direction="read"
+      from="Solid-Mesh"
+      to="Fluid-Mesh-Nodes"
+      constraint="consistent" />
+  </participant>
 
-    <participant name="Solid">
-      <provide-mesh name="Solid-Mesh" />
-      <receive-mesh name="Fluid-Mesh-Faces" from="Fluid" />
-      <write-data name="DisplacementDelta" mesh="Solid-Mesh" />
-      <read-data name="Force" mesh="Solid-Mesh" />
-      <watch-point mesh="Solid-Mesh" name="Tube-Midpoint" coordinate="0.0;0.005;0.025" />
-    </participant>
+  <participant name="Solid">
+    <provide-mesh name="Solid-Mesh" />
+    <receive-mesh name="Fluid-Mesh-Faces" from="Fluid" />
+    <write-data name="DisplacementDelta" mesh="Solid-Mesh" />
+    <read-data name="Force" mesh="Solid-Mesh" />
+    <watch-point mesh="Solid-Mesh" name="Tube-Midpoint" coordinate="0.0;0.005;0.025" />
+  </participant>
 
-    <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
 
-    <coupling-scheme:serial-implicit>
-      <participants first="Fluid" second="Solid" />
-      <max-time-windows value="100" />
-      <time-window-size value="1e-4" />
-      <exchange data="Force" mesh="Solid-Mesh" from="Fluid" to="Solid" />
-      <exchange data="DisplacementDelta" mesh="Solid-Mesh" from="Solid" to="Fluid" />
-      <max-iterations value="30" />
-      <relative-convergence-measure limit="1e-3" data="DisplacementDelta" mesh="Solid-Mesh" />
-      <relative-convergence-measure limit="1e-3" data="Force" mesh="Solid-Mesh" />
-      <acceleration:IQN-IMVJ>
-        <data name="DisplacementDelta" mesh="Solid-Mesh" />
-        <preconditioner type="residual-sum" />
-        <initial-relaxation value="0.1" />
-        <max-used-iterations value="10" />
-        <time-windows-reused value="1" />
-      </acceleration:IQN-IMVJ>
-    </coupling-scheme:serial-implicit>
-  </solver-interface>
+  <coupling-scheme:serial-implicit>
+    <participants first="Fluid" second="Solid" />
+    <max-time-windows value="100" />
+    <time-window-size value="1e-4" />
+    <exchange data="Force" mesh="Solid-Mesh" from="Fluid" to="Solid" />
+    <exchange data="DisplacementDelta" mesh="Solid-Mesh" from="Solid" to="Fluid" />
+    <max-iterations value="30" />
+    <relative-convergence-measure limit="1e-3" data="DisplacementDelta" mesh="Solid-Mesh" />
+    <relative-convergence-measure limit="1e-3" data="Force" mesh="Solid-Mesh" />
+    <acceleration:IQN-IMVJ>
+      <data name="DisplacementDelta" mesh="Solid-Mesh" />
+      <preconditioner type="residual-sum" />
+      <initial-relaxation value="0.1" />
+      <max-used-iterations value="10" />
+      <time-windows-reused value="1" />
+    </acceleration:IQN-IMVJ>
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/flow-over-heated-plate-nearest-projection/precice-config.xml
+++ b/flow-over-heated-plate-nearest-projection/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<precice-configuration>
+<precice-configuration dimensions="3">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,70 +7,68 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="3">
-    <data:scalar name="Temperature" />
-    <data:scalar name="Heat-Flux" />
+  <data:scalar name="Temperature" />
+  <data:scalar name="Heat-Flux" />
 
-    <mesh name="Fluid-Mesh-Centers">
-      <use-data name="Heat-Flux" />
-    </mesh>
+  <mesh name="Fluid-Mesh-Centers">
+    <use-data name="Heat-Flux" />
+  </mesh>
 
-    <mesh name="Fluid-Mesh-Nodes">
-      <use-data name="Temperature" />
-    </mesh>
+  <mesh name="Fluid-Mesh-Nodes">
+    <use-data name="Temperature" />
+  </mesh>
 
-    <mesh name="Solid-Mesh-Centers">
-      <use-data name="Temperature" />
-    </mesh>
+  <mesh name="Solid-Mesh-Centers">
+    <use-data name="Temperature" />
+  </mesh>
 
-    <mesh name="Solid-Mesh-Nodes">
-      <use-data name="Heat-Flux" />
-    </mesh>
+  <mesh name="Solid-Mesh-Nodes">
+    <use-data name="Heat-Flux" />
+  </mesh>
 
-    <participant name="Fluid">
-      <provide-mesh name="Fluid-Mesh-Centers" />
-      <provide-mesh name="Fluid-Mesh-Nodes" />
-      <receive-mesh name="Solid-Mesh-Nodes" from="Solid" />
-      <read-data name="Heat-Flux" mesh="Fluid-Mesh-Centers" />
-      <write-data name="Temperature" mesh="Fluid-Mesh-Nodes" />
-      <mapping:nearest-projection
-        direction="read"
-        from="Solid-Mesh-Nodes"
-        to="Fluid-Mesh-Centers"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid">
+    <provide-mesh name="Fluid-Mesh-Centers" />
+    <provide-mesh name="Fluid-Mesh-Nodes" />
+    <receive-mesh name="Solid-Mesh-Nodes" from="Solid" />
+    <read-data name="Heat-Flux" mesh="Fluid-Mesh-Centers" />
+    <write-data name="Temperature" mesh="Fluid-Mesh-Nodes" />
+    <mapping:nearest-projection
+      direction="read"
+      from="Solid-Mesh-Nodes"
+      to="Fluid-Mesh-Centers"
+      constraint="consistent" />
+  </participant>
 
-    <participant name="Solid">
-      <receive-mesh name="Fluid-Mesh-Nodes" from="Fluid" />
-      <provide-mesh name="Solid-Mesh-Nodes" />
-      <provide-mesh name="Solid-Mesh-Centers" />
-      <read-data name="Temperature" mesh="Solid-Mesh-Centers" />
-      <write-data name="Heat-Flux" mesh="Solid-Mesh-Nodes" />
-      <!-- <export:vtk directory="preCICE-output" /> -->
-      <mapping:nearest-projection
-        direction="read"
-        from="Fluid-Mesh-Nodes"
-        to="Solid-Mesh-Centers"
-        constraint="consistent" />
-    </participant>
+  <participant name="Solid">
+    <receive-mesh name="Fluid-Mesh-Nodes" from="Fluid" />
+    <provide-mesh name="Solid-Mesh-Nodes" />
+    <provide-mesh name="Solid-Mesh-Centers" />
+    <read-data name="Temperature" mesh="Solid-Mesh-Centers" />
+    <write-data name="Heat-Flux" mesh="Solid-Mesh-Nodes" />
+    <!-- <export:vtk directory="preCICE-output" /> -->
+    <mapping:nearest-projection
+      direction="read"
+      from="Fluid-Mesh-Nodes"
+      to="Solid-Mesh-Centers"
+      constraint="consistent" />
+  </participant>
 
-    <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
 
-    <coupling-scheme:serial-implicit>
-      <time-window-size value="0.01" />
-      <max-time value="1" />
-      <participants first="Fluid" second="Solid" />
-      <exchange data="Temperature" mesh="Fluid-Mesh-Nodes" from="Fluid" to="Solid" />
-      <exchange data="Heat-Flux" mesh="Solid-Mesh-Nodes" from="Solid" to="Fluid" />
-      <max-iterations value="200" />
-      <relative-convergence-measure limit="1.0e-6" data="Temperature" mesh="Fluid-Mesh-Nodes" />
-      <acceleration:IQN-ILS>
-        <data mesh="Solid-Mesh-Nodes" name="Heat-Flux" />
-        <initial-relaxation value="0.01" />
-        <max-used-iterations value="80" />
-        <time-windows-reused value="10" />
-        <filter type="QR1" limit="1e-8" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:serial-implicit>
-  </solver-interface>
+  <coupling-scheme:serial-implicit>
+    <time-window-size value="0.01" />
+    <max-time value="1" />
+    <participants first="Fluid" second="Solid" />
+    <exchange data="Temperature" mesh="Fluid-Mesh-Nodes" from="Fluid" to="Solid" />
+    <exchange data="Heat-Flux" mesh="Solid-Mesh-Nodes" from="Solid" to="Fluid" />
+    <max-iterations value="200" />
+    <relative-convergence-measure limit="1.0e-6" data="Temperature" mesh="Fluid-Mesh-Nodes" />
+    <acceleration:IQN-ILS>
+      <data mesh="Solid-Mesh-Nodes" name="Heat-Flux" />
+      <initial-relaxation value="0.01" />
+      <max-used-iterations value="80" />
+      <time-windows-reused value="10" />
+      <filter type="QR1" limit="1e-8" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/flow-over-heated-plate-partitioned-flow/precice-config.xml
+++ b/flow-over-heated-plate-partitioned-flow/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<precice-configuration>
+<precice-configuration dimensions="2">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,129 +7,125 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:scalar name="Temperature-Solid" />
-    <data:scalar name="Heat-Flux" />
-    <data:vector name="VelocityGradient" />
-    <data:scalar name="Pressure" />
-    <data:vector name="Velocity" />
-    <data:scalar name="FlowTemperature-Fluid" />
-    <data:scalar name="FlowTemperatureGradient" />
+  <data:scalar name="Temperature-Solid" />
+  <data:scalar name="Heat-Flux" />
+  <data:vector name="VelocityGradient" />
+  <data:scalar name="Pressure" />
+  <data:vector name="Velocity" />
+  <data:scalar name="FlowTemperature-Fluid" />
+  <data:scalar name="FlowTemperatureGradient" />
 
-    <mesh name="Fluid1-Solid-Mesh">
-      <use-data name="Temperature-Solid" />
-      <use-data name="Heat-Flux" />
-    </mesh>
+  <mesh name="Fluid1-Solid-Mesh">
+    <use-data name="Temperature-Solid" />
+    <use-data name="Heat-Flux" />
+  </mesh>
 
-    <mesh name="Fluid1-Fluid-Mesh">
-      <use-data name="VelocityGradient" />
-      <use-data name="Pressure" />
-      <use-data name="Velocity" />
-      <use-data name="FlowTemperature-Fluid" />
-      <use-data name="FlowTemperatureGradient" />
-    </mesh>
+  <mesh name="Fluid1-Fluid-Mesh">
+    <use-data name="VelocityGradient" />
+    <use-data name="Pressure" />
+    <use-data name="Velocity" />
+    <use-data name="FlowTemperature-Fluid" />
+    <use-data name="FlowTemperatureGradient" />
+  </mesh>
 
-    <mesh name="Fluid2-Mesh">
-      <use-data name="VelocityGradient" />
-      <use-data name="Pressure" />
-      <use-data name="Velocity" />
-      <use-data name="FlowTemperature-Fluid" />
-      <use-data name="FlowTemperatureGradient" />
-    </mesh>
+  <mesh name="Fluid2-Mesh">
+    <use-data name="VelocityGradient" />
+    <use-data name="Pressure" />
+    <use-data name="Velocity" />
+    <use-data name="FlowTemperature-Fluid" />
+    <use-data name="FlowTemperatureGradient" />
+  </mesh>
 
-    <mesh name="Solid-Mesh">
-      <use-data name="Temperature-Solid" />
-      <use-data name="Heat-Flux" />
-    </mesh>
+  <mesh name="Solid-Mesh">
+    <use-data name="Temperature-Solid" />
+    <use-data name="Heat-Flux" />
+  </mesh>
 
-    <participant name="Fluid1">
-      <use-mesh name="Fluid1-Solid-Mesh" provide="yes" />
-      <use-mesh name="Solid-Mesh" from="Solid" />
-      <use-mesh name="Fluid1-Fluid-Mesh" provide="yes" />
-      <use-mesh name="Fluid2-Mesh" from="Fluid2" />      
-      <read-data name="Heat-Flux" mesh="Fluid1-Solid-Mesh" />
-      <write-data name="Temperature-Solid" mesh="Fluid1-Solid-Mesh" />
-      <write-data name="Velocity" mesh="Fluid1-Fluid-Mesh" />
-      <read-data name="Pressure" mesh="Fluid1-Fluid-Mesh" />
-      <read-data name="VelocityGradient" mesh="Fluid1-Fluid-Mesh" />
-      <write-data name="FlowTemperature-Fluid" mesh="Fluid1-Fluid-Mesh" />
-      <read-data name="FlowTemperatureGradient" mesh="Fluid1-Fluid-Mesh" /> 
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Solid-Mesh"
-        to="Fluid1-Solid-Mesh"
-        constraint="consistent" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid2-Mesh"
-        to="Fluid1-Fluid-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid1">
+    <use-mesh name="Fluid1-Solid-Mesh" provide="yes" />
+    <use-mesh name="Solid-Mesh" from="Solid" />
+    <use-mesh name="Fluid1-Fluid-Mesh" provide="yes" />
+    <use-mesh name="Fluid2-Mesh" from="Fluid2" />      
+    <read-data name="Heat-Flux" mesh="Fluid1-Solid-Mesh" />
+    <write-data name="Temperature-Solid" mesh="Fluid1-Solid-Mesh" />
+    <write-data name="Velocity" mesh="Fluid1-Fluid-Mesh" />
+    <read-data name="Pressure" mesh="Fluid1-Fluid-Mesh" />
+    <read-data name="VelocityGradient" mesh="Fluid1-Fluid-Mesh" />
+    <write-data name="FlowTemperature-Fluid" mesh="Fluid1-Fluid-Mesh" />
+    <read-data name="FlowTemperatureGradient" mesh="Fluid1-Fluid-Mesh" /> 
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Solid-Mesh"
+      to="Fluid1-Solid-Mesh"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid2-Mesh"
+      to="Fluid1-Fluid-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <participant name="Solid">
-      <use-mesh name="Fluid1-Solid-Mesh" from="Fluid1" />
-      <use-mesh name="Solid-Mesh" provide="yes" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid1-Solid-Mesh"
-        to="Solid-Mesh"
-        constraint="consistent" />
-      <read-data name="Temperature-Solid" mesh="Solid-Mesh" />
-      <write-data name="Heat-Flux" mesh="Solid-Mesh" />
-    </participant>
+  <participant name="Solid">
+    <use-mesh name="Fluid1-Solid-Mesh" from="Fluid1" />
+    <use-mesh name="Solid-Mesh" provide="yes" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid1-Solid-Mesh"
+      to="Solid-Mesh"
+      constraint="consistent" />
+    <read-data name="Temperature-Solid" mesh="Solid-Mesh" />
+    <write-data name="Heat-Flux" mesh="Solid-Mesh" />
+  </participant>
 
-    <participant name="Fluid2">
-      <use-mesh name="Fluid2-Mesh" provide="yes" />
-      <use-mesh name="Fluid1-Fluid-Mesh" from="Fluid1" />
-      <read-data name="Velocity" mesh="Fluid2-Mesh" />
-      <write-data name="Pressure" mesh="Fluid2-Mesh" />
-      <write-data name="VelocityGradient" mesh="Fluid2-Mesh" />
-      <read-data name="FlowTemperature-Fluid" mesh="Fluid2-Mesh" />
-      <write-data name="FlowTemperatureGradient" mesh="Fluid2-Mesh" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid1-Fluid-Mesh"
-        to="Fluid2-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid2">
+    <use-mesh name="Fluid2-Mesh" provide="yes" />
+    <use-mesh name="Fluid1-Fluid-Mesh" from="Fluid1" />
+    <read-data name="Velocity" mesh="Fluid2-Mesh" />
+    <write-data name="Pressure" mesh="Fluid2-Mesh" />
+    <write-data name="VelocityGradient" mesh="Fluid2-Mesh" />
+    <read-data name="FlowTemperature-Fluid" mesh="Fluid2-Mesh" />
+    <write-data name="FlowTemperatureGradient" mesh="Fluid2-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid1-Fluid-Mesh"
+      to="Fluid2-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <m2n:sockets acceptor="Fluid1" connector="Solid" exchange-directory=".." />
-    <m2n:sockets acceptor="Fluid1" connector="Fluid2" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid1" connector="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid1" connector="Fluid2" exchange-directory=".." />
 
-    <coupling-scheme:serial-explicit>
-      <time-window-size value="0.01" />
-      <max-time value="1" />
-      <participants first="Fluid1" second="Solid" />
-      <exchange data="Temperature-Solid" mesh="Fluid1-Solid-Mesh" from="Fluid1" to="Solid" />
-      <exchange data="Heat-Flux" mesh="Solid-Mesh" from="Solid" to="Fluid1" />
-    </coupling-scheme:serial-explicit>
+  <coupling-scheme:serial-explicit>
+    <time-window-size value="0.01" />
+    <max-time value="1" />
+    <participants first="Fluid1" second="Solid" />
+    <exchange data="Temperature-Solid" mesh="Fluid1-Solid-Mesh" from="Fluid1" to="Solid" />
+    <exchange data="Heat-Flux" mesh="Solid-Mesh" from="Solid" to="Fluid1" />
+  </coupling-scheme:serial-explicit>
 
-    <coupling-scheme:serial-implicit>
-      <time-window-size value="0.01" />
-      <max-time value="1" />
-      <max-iterations value="50" />
-      <participants first="Fluid1" second="Fluid2" />
-      <exchange data="Velocity" mesh="Fluid1-Fluid-Mesh" from="Fluid1" to="Fluid2" />
-      <exchange data="VelocityGradient" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" />
-      <exchange data="Pressure" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" initialize="true"/>
-      <exchange data="FlowTemperature-Fluid" mesh="Fluid1-Fluid-Mesh" from="Fluid1" to="Fluid2" />
-      <exchange data="FlowTemperatureGradient" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" />
-      <relative-convergence-measure limit="1.0e-5" data="Pressure" mesh="Fluid2-Mesh" />
-      <relative-convergence-measure limit="1.0e-5" data="Velocity" mesh="Fluid1-Fluid-Mesh" />
-      <relative-convergence-measure limit="1.0e-5" data="VelocityGradient" mesh="Fluid2-Mesh" />
-      <relative-convergence-measure limit="1.0e-5" data="FlowTemperature-Fluid" mesh="Fluid1-Fluid-Mesh" />
-      <relative-convergence-measure limit="1.0e-5" data="FlowTemperatureGradient" mesh="Fluid2-Mesh" />
-      <acceleration:IQN-ILS>
-        <data mesh="Fluid2-Mesh" name="Pressure" />
-        <data mesh="Fluid2-Mesh" name="VelocityGradient" />
-        <data mesh="Fluid2-Mesh" name="FlowTemperatureGradient" />
-        <initial-relaxation value="1" />
-        <max-used-iterations value="10" />
-        <time-windows-reused value="2" />
-        <filter type="QR1" limit="1e-7" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:serial-implicit>
-
-  </solver-interface>
-
+  <coupling-scheme:serial-implicit>
+    <time-window-size value="0.01" />
+    <max-time value="1" />
+    <max-iterations value="50" />
+    <participants first="Fluid1" second="Fluid2" />
+    <exchange data="Velocity" mesh="Fluid1-Fluid-Mesh" from="Fluid1" to="Fluid2" />
+    <exchange data="VelocityGradient" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" />
+    <exchange data="Pressure" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" initialize="true"/>
+    <exchange data="FlowTemperature-Fluid" mesh="Fluid1-Fluid-Mesh" from="Fluid1" to="Fluid2" />
+    <exchange data="FlowTemperatureGradient" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" />
+    <relative-convergence-measure limit="1.0e-5" data="Pressure" mesh="Fluid2-Mesh" />
+    <relative-convergence-measure limit="1.0e-5" data="Velocity" mesh="Fluid1-Fluid-Mesh" />
+    <relative-convergence-measure limit="1.0e-5" data="VelocityGradient" mesh="Fluid2-Mesh" />
+    <relative-convergence-measure limit="1.0e-5" data="FlowTemperature-Fluid" mesh="Fluid1-Fluid-Mesh" />
+    <relative-convergence-measure limit="1.0e-5" data="FlowTemperatureGradient" mesh="Fluid2-Mesh" />
+    <acceleration:IQN-ILS>
+      <data mesh="Fluid2-Mesh" name="Pressure" />
+      <data mesh="Fluid2-Mesh" name="VelocityGradient" />
+      <data mesh="Fluid2-Mesh" name="FlowTemperatureGradient" />
+      <initial-relaxation value="1" />
+      <max-used-iterations value="10" />
+      <time-windows-reused value="2" />
+      <filter type="QR1" limit="1e-7" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/flow-over-heated-plate-steady-state/precice-config.xml
+++ b/flow-over-heated-plate-steady-state/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="3">
   <log>
     <sink
       filter="%Severity% > debug"
@@ -7,87 +7,85 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="3">
-    <data:scalar name="Heat-Transfer-Coefficient-Solid" />
-    <data:scalar name="Sink-Temperature-Solid" />
-    <data:scalar name="Heat-Transfer-Coefficient-Fluid" />
-    <data:scalar name="Sink-Temperature-Fluid" />
+  <data:scalar name="Heat-Transfer-Coefficient-Solid" />
+  <data:scalar name="Sink-Temperature-Solid" />
+  <data:scalar name="Heat-Transfer-Coefficient-Fluid" />
+  <data:scalar name="Sink-Temperature-Fluid" />
 
-    <mesh name="Solid-Interface-Nodes">
-      <use-data name="Sink-Temperature-Solid" />
-      <use-data name="Heat-Transfer-Coefficient-Solid" />
-    </mesh>
+  <mesh name="Solid-Interface-Nodes">
+    <use-data name="Sink-Temperature-Solid" />
+    <use-data name="Heat-Transfer-Coefficient-Solid" />
+  </mesh>
 
-    <mesh name="Solid-Interface-Faces">
-      <use-data name="Sink-Temperature-Fluid" />
-      <use-data name="Heat-Transfer-Coefficient-Fluid" />
-    </mesh>
+  <mesh name="Solid-Interface-Faces">
+    <use-data name="Sink-Temperature-Fluid" />
+    <use-data name="Heat-Transfer-Coefficient-Fluid" />
+  </mesh>
 
-    <mesh name="Fluid-Interface">
-      <use-data name="Sink-Temperature-Fluid" />
-      <use-data name="Heat-Transfer-Coefficient-Fluid" />
-      <use-data name="Sink-Temperature-Solid" />
-      <use-data name="Heat-Transfer-Coefficient-Solid" />
-    </mesh>
+  <mesh name="Fluid-Interface">
+    <use-data name="Sink-Temperature-Fluid" />
+    <use-data name="Heat-Transfer-Coefficient-Fluid" />
+    <use-data name="Sink-Temperature-Solid" />
+    <use-data name="Heat-Transfer-Coefficient-Solid" />
+  </mesh>
 
-    <participant name="Solid">
-      <provide-mesh name="Solid-Interface-Faces" />
-      <provide-mesh name="Solid-Interface-Nodes" />
-      <receive-mesh name="Fluid-Interface" from="Fluid" />
-      <write-data mesh="Solid-Interface-Nodes" name="Sink-Temperature-Solid" />
-      <write-data mesh="Solid-Interface-Nodes" name="Heat-Transfer-Coefficient-Solid" />
-      <read-data mesh="Solid-Interface-Faces" name="Sink-Temperature-Fluid" />
-      <read-data mesh="Solid-Interface-Faces" name="Heat-Transfer-Coefficient-Fluid" />
-      <mapping:nearest-neighbor
-        constraint="consistent"
-        direction="read"
-        to="Solid-Interface-Faces"
-        from="Fluid-Interface" />
-    </participant>
+  <participant name="Solid">
+    <provide-mesh name="Solid-Interface-Faces" />
+    <provide-mesh name="Solid-Interface-Nodes" />
+    <receive-mesh name="Fluid-Interface" from="Fluid" />
+    <write-data mesh="Solid-Interface-Nodes" name="Sink-Temperature-Solid" />
+    <write-data mesh="Solid-Interface-Nodes" name="Heat-Transfer-Coefficient-Solid" />
+    <read-data mesh="Solid-Interface-Faces" name="Sink-Temperature-Fluid" />
+    <read-data mesh="Solid-Interface-Faces" name="Heat-Transfer-Coefficient-Fluid" />
+    <mapping:nearest-neighbor
+      constraint="consistent"
+      direction="read"
+      to="Solid-Interface-Faces"
+      from="Fluid-Interface" />
+  </participant>
 
-    <participant name="Fluid">
-      <provide-mesh name="Fluid-Interface" />
-      <receive-mesh name="Solid-Interface-Nodes" from="Solid" />
-      <write-data mesh="Fluid-Interface" name="Sink-Temperature-Fluid" />
-      <write-data mesh="Fluid-Interface" name="Heat-Transfer-Coefficient-Fluid" />
-      <read-data mesh="Fluid-Interface" name="Sink-Temperature-Solid" />
-      <read-data mesh="Fluid-Interface" name="Heat-Transfer-Coefficient-Solid" />
-      <mapping:nearest-neighbor
-        constraint="consistent"
-        direction="read"
-        to="Fluid-Interface"
-        from="Solid-Interface-Nodes" />
-    </participant>
+  <participant name="Fluid">
+    <provide-mesh name="Fluid-Interface" />
+    <receive-mesh name="Solid-Interface-Nodes" from="Solid" />
+    <write-data mesh="Fluid-Interface" name="Sink-Temperature-Fluid" />
+    <write-data mesh="Fluid-Interface" name="Heat-Transfer-Coefficient-Fluid" />
+    <read-data mesh="Fluid-Interface" name="Sink-Temperature-Solid" />
+    <read-data mesh="Fluid-Interface" name="Heat-Transfer-Coefficient-Solid" />
+    <mapping:nearest-neighbor
+      constraint="consistent"
+      direction="read"
+      to="Fluid-Interface"
+      from="Solid-Interface-Nodes" />
+  </participant>
 
-    <!-- TODO: Give an absolute path for the exchange-directory, as Code_Aster starts in /tmp/ -->
-    <m2n:sockets connector="Fluid" acceptor="Solid" exchange-directory=".." />
+  <!-- TODO: Give an absolute path for the exchange-directory, as Code_Aster starts in /tmp/ -->
+  <m2n:sockets connector="Fluid" acceptor="Solid" exchange-directory=".." />
 
-    <coupling-scheme:serial-explicit>
-      <time-window-size value="1" />
-      <max-time-windows value="100" />
-      <participants first="Solid" second="Fluid" />
-      <exchange
-        data="Sink-Temperature-Solid"
-        mesh="Solid-Interface-Nodes"
-        from="Solid"
-        to="Fluid" />
-      <exchange
-        data="Heat-Transfer-Coefficient-Solid"
-        mesh="Solid-Interface-Nodes"
-        from="Solid"
-        to="Fluid" />
-      <exchange
-        data="Sink-Temperature-Fluid"
-        mesh="Fluid-Interface"
-        from="Fluid"
-        to="Solid"
-        initialize="yes" />
-      <exchange
-        data="Heat-Transfer-Coefficient-Fluid"
-        mesh="Fluid-Interface"
-        from="Fluid"
-        to="Solid"
-        initialize="yes" />
-    </coupling-scheme:serial-explicit>
-  </solver-interface>
+  <coupling-scheme:serial-explicit>
+    <time-window-size value="1" />
+    <max-time-windows value="100" />
+    <participants first="Solid" second="Fluid" />
+    <exchange
+      data="Sink-Temperature-Solid"
+      mesh="Solid-Interface-Nodes"
+      from="Solid"
+      to="Fluid" />
+    <exchange
+      data="Heat-Transfer-Coefficient-Solid"
+      mesh="Solid-Interface-Nodes"
+      from="Solid"
+      to="Fluid" />
+    <exchange
+      data="Sink-Temperature-Fluid"
+      mesh="Fluid-Interface"
+      from="Fluid"
+      to="Solid"
+      initialize="yes" />
+    <exchange
+      data="Heat-Transfer-Coefficient-Fluid"
+      mesh="Fluid-Interface"
+      from="Fluid"
+      to="Solid"
+      initialize="yes" />
+  </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/flow-over-heated-plate-two-meshes/precice-config.xml
+++ b/flow-over-heated-plate-two-meshes/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<precice-configuration>
+<precice-configuration dimensions="2">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,64 +7,62 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:scalar name="Temperature" />
-    <data:scalar name="Heat-Flux" />
+  <data:scalar name="Temperature" />
+  <data:scalar name="Heat-Flux" />
 
-    <mesh name="Fluid-Mesh">
-      <use-data name="Temperature" />
-      <use-data name="Heat-Flux" />
-    </mesh>
+  <mesh name="Fluid-Mesh">
+    <use-data name="Temperature" />
+    <use-data name="Heat-Flux" />
+  </mesh>
 
-    <mesh name="Solid-Mesh">
-      <use-data name="Heat-Flux" />
-    </mesh>
+  <mesh name="Solid-Mesh">
+    <use-data name="Heat-Flux" />
+  </mesh>
 
-    <mesh name="Solid-Mesh-nodes">
-      <use-data name="Temperature" />
-    </mesh>
+  <mesh name="Solid-Mesh-nodes">
+    <use-data name="Temperature" />
+  </mesh>
 
-    <participant name="Fluid">
-      <provide-mesh name="Fluid-Mesh" />
-      <receive-mesh name="Solid-Mesh" from="Solid" />
-      <receive-mesh name="Solid-Mesh-nodes" from="Solid" />
-      <read-data name="Heat-Flux" mesh="Fluid-Mesh" />
-      <write-data name="Temperature" mesh="Fluid-Mesh" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Solid-Mesh"
-        to="Fluid-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid">
+    <provide-mesh name="Fluid-Mesh" />
+    <receive-mesh name="Solid-Mesh" from="Solid" />
+    <receive-mesh name="Solid-Mesh-nodes" from="Solid" />
+    <read-data name="Heat-Flux" mesh="Fluid-Mesh" />
+    <write-data name="Temperature" mesh="Fluid-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Solid-Mesh"
+      to="Fluid-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <participant name="Solid">
-      <receive-mesh name="Fluid-Mesh" from="Fluid" />
-      <provide-mesh name="Solid-Mesh" />
-      <provide-mesh name="Solid-Mesh-nodes" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid-Mesh"
-        to="Solid-Mesh-nodes"
-        constraint="consistent" />
-      <read-data name="Temperature" mesh="Solid-Mesh-nodes" />
-      <write-data name="Heat-Flux" mesh="Solid-Mesh" />
-    <watch-point mesh="Solid-Mesh" name="MyWatchPoint" coordinate="0.5; 0.0"/>
-    </participant>
+  <participant name="Solid">
+    <receive-mesh name="Fluid-Mesh" from="Fluid" />
+    <provide-mesh name="Solid-Mesh" />
+    <provide-mesh name="Solid-Mesh-nodes" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid-Mesh"
+      to="Solid-Mesh-nodes"
+      constraint="consistent" />
+    <read-data name="Temperature" mesh="Solid-Mesh-nodes" />
+    <write-data name="Heat-Flux" mesh="Solid-Mesh" />
+  <watch-point mesh="Solid-Mesh" name="MyWatchPoint" coordinate="0.5; 0.0"/>
+  </participant>
 
-    <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
 
-    <coupling-scheme:serial-implicit>
-      <time-window-size value="0.01" />
-      <max-time value="1" />
-      <max-iterations value="30" />
-      <participants first="Fluid" second="Solid" />
-      <exchange data="Temperature" mesh="Fluid-Mesh" from="Fluid" to="Solid" />
-      <exchange data="Heat-Flux" mesh="Solid-Mesh" from="Solid" to="Fluid" />
-      <relative-convergence-measure limit="1.0e-5" data="Temperature" mesh="Fluid-Mesh" />
-      <acceleration:aitken>
-        <data mesh="Solid-Mesh" name="Heat-Flux" />
-        <initial-relaxation value="0.5" />
-      </acceleration:aitken>
-    </coupling-scheme:serial-implicit>
-  </solver-interface>
+  <coupling-scheme:serial-implicit>
+    <time-window-size value="0.01" />
+    <max-time value="1" />
+    <max-iterations value="30" />
+    <participants first="Fluid" second="Solid" />
+    <exchange data="Temperature" mesh="Fluid-Mesh" from="Fluid" to="Solid" />
+    <exchange data="Heat-Flux" mesh="Solid-Mesh" from="Solid" to="Fluid" />
+    <relative-convergence-measure limit="1.0e-5" data="Temperature" mesh="Fluid-Mesh" />
+    <acceleration:aitken>
+      <data mesh="Solid-Mesh" name="Heat-Flux" />
+      <initial-relaxation value="0.5" />
+    </acceleration:aitken>
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/flow-over-heated-plate/precice-config.xml
+++ b/flow-over-heated-plate/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<precice-configuration>
+<precice-configuration dimensions="2">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,58 +7,56 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:scalar name="Temperature" />
-    <data:scalar name="Heat-Flux" />
+  <data:scalar name="Temperature" />
+  <data:scalar name="Heat-Flux" />
 
-    <mesh name="Fluid-Mesh">
-      <use-data name="Temperature" />
-      <use-data name="Heat-Flux" />
-    </mesh>
+  <mesh name="Fluid-Mesh">
+    <use-data name="Temperature" />
+    <use-data name="Heat-Flux" />
+  </mesh>
 
-    <mesh name="Solid-Mesh">
-      <use-data name="Temperature" />
-      <use-data name="Heat-Flux" />
-    </mesh>
+  <mesh name="Solid-Mesh">
+    <use-data name="Temperature" />
+    <use-data name="Heat-Flux" />
+  </mesh>
 
-    <participant name="Fluid">
-      <provide-mesh name="Fluid-Mesh" />
-      <receive-mesh name="Solid-Mesh" from="Solid" />
-      <read-data name="Heat-Flux" mesh="Fluid-Mesh" />
-      <write-data name="Temperature" mesh="Fluid-Mesh" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Solid-Mesh"
-        to="Fluid-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid">
+    <provide-mesh name="Fluid-Mesh" />
+    <receive-mesh name="Solid-Mesh" from="Solid" />
+    <read-data name="Heat-Flux" mesh="Fluid-Mesh" />
+    <write-data name="Temperature" mesh="Fluid-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Solid-Mesh"
+      to="Fluid-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <participant name="Solid">
-      <receive-mesh name="Fluid-Mesh" from="Fluid" />
-      <provide-mesh name="Solid-Mesh" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid-Mesh"
-        to="Solid-Mesh"
-        constraint="consistent" />
-      <read-data name="Temperature" mesh="Solid-Mesh" />
-      <write-data name="Heat-Flux" mesh="Solid-Mesh" />
-    </participant>
+  <participant name="Solid">
+    <receive-mesh name="Fluid-Mesh" from="Fluid" />
+    <provide-mesh name="Solid-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid-Mesh"
+      to="Solid-Mesh"
+      constraint="consistent" />
+    <read-data name="Temperature" mesh="Solid-Mesh" />
+    <write-data name="Heat-Flux" mesh="Solid-Mesh" />
+  </participant>
 
-    <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
 
-    <coupling-scheme:serial-implicit>
-      <time-window-size value="0.01" />
-      <max-time value="1" />
-      <max-iterations value="30" />
-      <participants first="Fluid" second="Solid" />
-      <exchange data="Temperature" mesh="Fluid-Mesh" from="Fluid" to="Solid" />
-      <exchange data="Heat-Flux" mesh="Solid-Mesh" from="Solid" to="Fluid" />
-      <relative-convergence-measure limit="1.0e-5" data="Temperature" mesh="Fluid-Mesh" />
-      <acceleration:aitken>
-        <data mesh="Solid-Mesh" name="Heat-Flux" />
-        <initial-relaxation value="0.5" />
-      </acceleration:aitken>
-    </coupling-scheme:serial-implicit>
-  </solver-interface>
+  <coupling-scheme:serial-implicit>
+    <time-window-size value="0.01" />
+    <max-time value="1" />
+    <max-iterations value="30" />
+    <participants first="Fluid" second="Solid" />
+    <exchange data="Temperature" mesh="Fluid-Mesh" from="Fluid" to="Solid" />
+    <exchange data="Heat-Flux" mesh="Solid-Mesh" from="Solid" to="Fluid" />
+    <relative-convergence-measure limit="1.0e-5" data="Temperature" mesh="Fluid-Mesh" />
+    <acceleration:aitken>
+      <data mesh="Solid-Mesh" name="Heat-Flux" />
+      <initial-relaxation value="0.5" />
+    </acceleration:aitken>
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/heat-exchanger-simplified/precice-config.xml
+++ b/heat-exchanger-simplified/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<precice-configuration>
+<precice-configuration dimensions="2">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,117 +7,115 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:scalar name="Temperature-Top" />
-    <data:scalar name="Heat-Flux-Top" />
-    <data:scalar name="Temperature-Bottom" />
-    <data:scalar name="Heat-Flux-Bottom" />
+  <data:scalar name="Temperature-Top" />
+  <data:scalar name="Heat-Flux-Top" />
+  <data:scalar name="Temperature-Bottom" />
+  <data:scalar name="Heat-Flux-Bottom" />
 
-    <mesh name="Fluid-Top-Mesh">
-      <use-data name="Temperature-Top" />
-      <use-data name="Heat-Flux-Top" />
-    </mesh>
+  <mesh name="Fluid-Top-Mesh">
+    <use-data name="Temperature-Top" />
+    <use-data name="Heat-Flux-Top" />
+  </mesh>
 
-    <mesh name="Fluid-Bottom-Mesh">
-      <use-data name="Temperature-Bottom" />
-      <use-data name="Heat-Flux-Bottom" />
-    </mesh>
+  <mesh name="Fluid-Bottom-Mesh">
+    <use-data name="Temperature-Bottom" />
+    <use-data name="Heat-Flux-Bottom" />
+  </mesh>
 
-    <mesh name="Solid-Top-Mesh-Faces">
-      <use-data name="Heat-Flux-Top" />
-    </mesh>
+  <mesh name="Solid-Top-Mesh-Faces">
+    <use-data name="Heat-Flux-Top" />
+  </mesh>
 
-    <mesh name="Solid-Top-Mesh-Nodes">
-      <use-data name="Temperature-Top" />
-    </mesh>
+  <mesh name="Solid-Top-Mesh-Nodes">
+    <use-data name="Temperature-Top" />
+  </mesh>
 
-    <mesh name="Solid-Bottom-Mesh-Faces">
-      <use-data name="Heat-Flux-Bottom" />
-    </mesh>
+  <mesh name="Solid-Bottom-Mesh-Faces">
+    <use-data name="Heat-Flux-Bottom" />
+  </mesh>
 
-    <mesh name="Solid-Bottom-Mesh-Nodes">
-      <use-data name="Temperature-Bottom" />
-    </mesh>
+  <mesh name="Solid-Bottom-Mesh-Nodes">
+    <use-data name="Temperature-Bottom" />
+  </mesh>
 
-    <participant name="Fluid-Top">
-      <provide-mesh name="Fluid-Top-Mesh" />
-      <receive-mesh name="Solid-Top-Mesh-Faces" from="Solid" />
-      <read-data name="Heat-Flux-Top" mesh="Fluid-Top-Mesh" />
-      <write-data name="Temperature-Top" mesh="Fluid-Top-Mesh" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Solid-Top-Mesh-Faces"
-        to="Fluid-Top-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid-Top">
+    <provide-mesh name="Fluid-Top-Mesh" />
+    <receive-mesh name="Solid-Top-Mesh-Faces" from="Solid" />
+    <read-data name="Heat-Flux-Top" mesh="Fluid-Top-Mesh" />
+    <write-data name="Temperature-Top" mesh="Fluid-Top-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Solid-Top-Mesh-Faces"
+      to="Fluid-Top-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <participant name="Solid">
-      <receive-mesh name="Fluid-Top-Mesh" from="Fluid-Top" />
-      <provide-mesh name="Solid-Top-Mesh-Faces" />
-      <provide-mesh name="Solid-Top-Mesh-Nodes" />
-      <provide-mesh name="Solid-Bottom-Mesh-Nodes" />
-      <provide-mesh name="Solid-Bottom-Mesh-Faces" />
-      <receive-mesh name="Fluid-Bottom-Mesh" from="Fluid-Bottom" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid-Top-Mesh"
-        to="Solid-Top-Mesh-Nodes"
-        constraint="consistent" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid-Bottom-Mesh"
-        to="Solid-Bottom-Mesh-Nodes"
-        constraint="consistent" />
-      <read-data name="Temperature-Top" mesh="Solid-Top-Mesh-Nodes" />
-      <write-data name="Heat-Flux-Top" mesh="Solid-Top-Mesh-Faces" />
-      <write-data name="Heat-Flux-Bottom" mesh="Solid-Bottom-Mesh-Faces" />
-      <read-data name="Temperature-Bottom" mesh="Solid-Bottom-Mesh-Nodes" />
-    </participant>
+  <participant name="Solid">
+    <receive-mesh name="Fluid-Top-Mesh" from="Fluid-Top" />
+    <provide-mesh name="Solid-Top-Mesh-Faces" />
+    <provide-mesh name="Solid-Top-Mesh-Nodes" />
+    <provide-mesh name="Solid-Bottom-Mesh-Nodes" />
+    <provide-mesh name="Solid-Bottom-Mesh-Faces" />
+    <receive-mesh name="Fluid-Bottom-Mesh" from="Fluid-Bottom" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid-Top-Mesh"
+      to="Solid-Top-Mesh-Nodes"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid-Bottom-Mesh"
+      to="Solid-Bottom-Mesh-Nodes"
+      constraint="consistent" />
+    <read-data name="Temperature-Top" mesh="Solid-Top-Mesh-Nodes" />
+    <write-data name="Heat-Flux-Top" mesh="Solid-Top-Mesh-Faces" />
+    <write-data name="Heat-Flux-Bottom" mesh="Solid-Bottom-Mesh-Faces" />
+    <read-data name="Temperature-Bottom" mesh="Solid-Bottom-Mesh-Nodes" />
+  </participant>
 
-    <participant name="Fluid-Bottom">
-      <provide-mesh name="Fluid-Bottom-Mesh" />
-      <receive-mesh name="Solid-Bottom-Mesh-Faces" from="Solid" />
-      <read-data name="Heat-Flux-Bottom" mesh="Fluid-Bottom-Mesh" />
-      <write-data name="Temperature-Bottom" mesh="Fluid-Bottom-Mesh" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Solid-Bottom-Mesh-Faces"
-        to="Fluid-Bottom-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid-Bottom">
+    <provide-mesh name="Fluid-Bottom-Mesh" />
+    <receive-mesh name="Solid-Bottom-Mesh-Faces" from="Solid" />
+    <read-data name="Heat-Flux-Bottom" mesh="Fluid-Bottom-Mesh" />
+    <write-data name="Temperature-Bottom" mesh="Fluid-Bottom-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Solid-Bottom-Mesh-Faces"
+      to="Fluid-Bottom-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <m2n:sockets acceptor="Fluid-Top" connector="Solid" exchange-directory=".." />
-    <m2n:sockets acceptor="Fluid-Bottom" connector="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid-Top" connector="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid-Bottom" connector="Solid" exchange-directory=".." />
 
-    <coupling-scheme:multi>
-      <time-window-size value="0.01" />
-      <max-time value="5" />
-      <max-iterations value="30" />
-      <participant name="Fluid-Top" />
-      <participant name="Fluid-Bottom" />
-      <participant name="Solid" control="yes" />
-      <exchange data="Temperature-Top" mesh="Fluid-Top-Mesh" from="Fluid-Top" to="Solid" />
-      <exchange data="Heat-Flux-Top" mesh="Solid-Top-Mesh-Faces" from="Solid" to="Fluid-Top" />
-      <exchange data="Temperature-Bottom" mesh="Fluid-Bottom-Mesh" from="Fluid-Bottom" to="Solid" />
-      <exchange data="Heat-Flux-Bottom" mesh="Solid-Bottom-Mesh-Faces" from="Solid" to="Fluid-Bottom" />
+  <coupling-scheme:multi>
+    <time-window-size value="0.01" />
+    <max-time value="5" />
+    <max-iterations value="30" />
+    <participant name="Fluid-Top" />
+    <participant name="Fluid-Bottom" />
+    <participant name="Solid" control="yes" />
+    <exchange data="Temperature-Top" mesh="Fluid-Top-Mesh" from="Fluid-Top" to="Solid" />
+    <exchange data="Heat-Flux-Top" mesh="Solid-Top-Mesh-Faces" from="Solid" to="Fluid-Top" />
+    <exchange data="Temperature-Bottom" mesh="Fluid-Bottom-Mesh" from="Fluid-Bottom" to="Solid" />
+    <exchange data="Heat-Flux-Bottom" mesh="Solid-Bottom-Mesh-Faces" from="Solid" to="Fluid-Bottom" />
 
-      <relative-convergence-measure limit="1.0e-5" data="Temperature-Top" mesh="Fluid-Top-Mesh" />
-      <relative-convergence-measure limit="1.0e-5" data="Heat-Flux-Top" mesh="Solid-Top-Mesh-Faces" />
-      <relative-convergence-measure limit="1.0e-5" data="Heat-Flux-Bottom" mesh="Solid-Bottom-Mesh-Faces" />
-      <relative-convergence-measure limit="1.0e-5" data="Temperature-Bottom" mesh="Fluid-Bottom-Mesh" />
+    <relative-convergence-measure limit="1.0e-5" data="Temperature-Top" mesh="Fluid-Top-Mesh" />
+    <relative-convergence-measure limit="1.0e-5" data="Heat-Flux-Top" mesh="Solid-Top-Mesh-Faces" />
+    <relative-convergence-measure limit="1.0e-5" data="Heat-Flux-Bottom" mesh="Solid-Bottom-Mesh-Faces" />
+    <relative-convergence-measure limit="1.0e-5" data="Temperature-Bottom" mesh="Fluid-Bottom-Mesh" />
 
-      <acceleration:IQN-ILS>
-        <data name="Temperature-Top" mesh="Fluid-Top-Mesh" />
-        <data name="Heat-Flux-Top" mesh="Solid-Top-Mesh-Faces" />
-        <data name="Heat-Flux-Bottom" mesh="Solid-Bottom-Mesh-Faces" />
-        <data name="Temperature-Bottom" mesh="Fluid-Bottom-Mesh" />
-        <initial-relaxation value="0.5" />
+    <acceleration:IQN-ILS>
+      <data name="Temperature-Top" mesh="Fluid-Top-Mesh" />
+      <data name="Heat-Flux-Top" mesh="Solid-Top-Mesh-Faces" />
+      <data name="Heat-Flux-Bottom" mesh="Solid-Bottom-Mesh-Faces" />
+      <data name="Temperature-Bottom" mesh="Fluid-Bottom-Mesh" />
+      <initial-relaxation value="0.5" />
 
-        <preconditioner type="residual-sum" />
-        <filter type="QR1" limit="1e-6" />
-        <max-used-iterations value="50" />
-        <time-windows-reused value="10" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:multi>
-  </solver-interface>
+      <preconditioner type="residual-sum" />
+      <filter type="QR1" limit="1e-6" />
+      <max-used-iterations value="50" />
+      <time-windows-reused value="10" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:multi>
 </precice-configuration>

--- a/heat-exchanger/precice-config.xml
+++ b/heat-exchanger/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<precice-configuration>
+<precice-configuration dimensions="3">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,157 +7,155 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="3">
-    <data:scalar name="Heat-Transfer-Coefficient-Solid" />
-    <data:scalar name="Sink-Temperature-Solid" />
-    <data:scalar name="Heat-Transfer-Coefficient-Fluid-Inner" />
-    <data:scalar name="Sink-Temperature-Fluid-Inner" />
-    <data:scalar name="Heat-Transfer-Coefficient-Fluid-Outer" />
-    <data:scalar name="Sink-Temperature-Fluid-Outer" />
+  <data:scalar name="Heat-Transfer-Coefficient-Solid" />
+  <data:scalar name="Sink-Temperature-Solid" />
+  <data:scalar name="Heat-Transfer-Coefficient-Fluid-Inner" />
+  <data:scalar name="Sink-Temperature-Fluid-Inner" />
+  <data:scalar name="Heat-Transfer-Coefficient-Fluid-Outer" />
+  <data:scalar name="Sink-Temperature-Fluid-Outer" />
 
-    <mesh name="Solid-to-Fluid-Inner">
-      <use-data name="Sink-Temperature-Solid" />
-      <use-data name="Heat-Transfer-Coefficient-Solid" />
-      <use-data name="Sink-Temperature-Fluid-Inner" />
-      <use-data name="Heat-Transfer-Coefficient-Fluid-Inner" />
-    </mesh>
+  <mesh name="Solid-to-Fluid-Inner">
+    <use-data name="Sink-Temperature-Solid" />
+    <use-data name="Heat-Transfer-Coefficient-Solid" />
+    <use-data name="Sink-Temperature-Fluid-Inner" />
+    <use-data name="Heat-Transfer-Coefficient-Fluid-Inner" />
+  </mesh>
 
-    <mesh name="Solid-to-Fluid-Outer">
-      <use-data name="Sink-Temperature-Solid" />
-      <use-data name="Heat-Transfer-Coefficient-Solid" />
-      <use-data name="Sink-Temperature-Fluid-Outer" />
-      <use-data name="Heat-Transfer-Coefficient-Fluid-Outer" />
-    </mesh>
+  <mesh name="Solid-to-Fluid-Outer">
+    <use-data name="Sink-Temperature-Solid" />
+    <use-data name="Heat-Transfer-Coefficient-Solid" />
+    <use-data name="Sink-Temperature-Fluid-Outer" />
+    <use-data name="Heat-Transfer-Coefficient-Fluid-Outer" />
+  </mesh>
 
-    <mesh name="Fluid-Inner-to-Solid">
-      <use-data name="Sink-Temperature-Fluid-Inner" />
-      <use-data name="Heat-Transfer-Coefficient-Fluid-Inner" />
-      <use-data name="Sink-Temperature-Solid" />
-      <use-data name="Heat-Transfer-Coefficient-Solid" />
-    </mesh>
+  <mesh name="Fluid-Inner-to-Solid">
+    <use-data name="Sink-Temperature-Fluid-Inner" />
+    <use-data name="Heat-Transfer-Coefficient-Fluid-Inner" />
+    <use-data name="Sink-Temperature-Solid" />
+    <use-data name="Heat-Transfer-Coefficient-Solid" />
+  </mesh>
 
-    <mesh name="Fluid-Outer-to-Solid">
-      <use-data name="Sink-Temperature-Fluid-Outer" />
-      <use-data name="Heat-Transfer-Coefficient-Fluid-Outer" />
-      <use-data name="Sink-Temperature-Solid" />
-      <use-data name="Heat-Transfer-Coefficient-Solid" />
-    </mesh>
+  <mesh name="Fluid-Outer-to-Solid">
+    <use-data name="Sink-Temperature-Fluid-Outer" />
+    <use-data name="Heat-Transfer-Coefficient-Fluid-Outer" />
+    <use-data name="Sink-Temperature-Solid" />
+    <use-data name="Heat-Transfer-Coefficient-Solid" />
+  </mesh>
 
-    <participant name="Solid">
-      <provide-mesh name="Solid-to-Fluid-Inner" />
-      <receive-mesh name="Fluid-Inner-to-Solid" from="Fluid-Inner" />
-      <write-data mesh="Solid-to-Fluid-Inner" name="Sink-Temperature-Solid" />
-      <write-data mesh="Solid-to-Fluid-Inner" name="Heat-Transfer-Coefficient-Solid" />
-      <read-data mesh="Solid-to-Fluid-Inner" name="Sink-Temperature-Fluid-Inner" />
-      <read-data mesh="Solid-to-Fluid-Inner" name="Heat-Transfer-Coefficient-Fluid-Inner" />
-      <mapping:nearest-neighbor
-        constraint="consistent"
-        direction="read"
-        to="Solid-to-Fluid-Inner"
-        from="Fluid-Inner-to-Solid" />
-      <provide-mesh name="Solid-to-Fluid-Outer" />
-      <receive-mesh name="Fluid-Outer-to-Solid" from="Fluid-Outer" />
-      <write-data mesh="Solid-to-Fluid-Outer" name="Sink-Temperature-Solid" />
-      <write-data mesh="Solid-to-Fluid-Outer" name="Heat-Transfer-Coefficient-Solid" />
-      <read-data mesh="Solid-to-Fluid-Outer" name="Sink-Temperature-Fluid-Outer" />
-      <read-data mesh="Solid-to-Fluid-Outer" name="Heat-Transfer-Coefficient-Fluid-Outer" />
-      <mapping:nearest-neighbor
-        constraint="consistent"
-        direction="read"
-        to="Solid-to-Fluid-Outer"
-        from="Fluid-Outer-to-Solid" />
-    </participant>
+  <participant name="Solid">
+    <provide-mesh name="Solid-to-Fluid-Inner" />
+    <receive-mesh name="Fluid-Inner-to-Solid" from="Fluid-Inner" />
+    <write-data mesh="Solid-to-Fluid-Inner" name="Sink-Temperature-Solid" />
+    <write-data mesh="Solid-to-Fluid-Inner" name="Heat-Transfer-Coefficient-Solid" />
+    <read-data mesh="Solid-to-Fluid-Inner" name="Sink-Temperature-Fluid-Inner" />
+    <read-data mesh="Solid-to-Fluid-Inner" name="Heat-Transfer-Coefficient-Fluid-Inner" />
+    <mapping:nearest-neighbor
+      constraint="consistent"
+      direction="read"
+      to="Solid-to-Fluid-Inner"
+      from="Fluid-Inner-to-Solid" />
+    <provide-mesh name="Solid-to-Fluid-Outer" />
+    <receive-mesh name="Fluid-Outer-to-Solid" from="Fluid-Outer" />
+    <write-data mesh="Solid-to-Fluid-Outer" name="Sink-Temperature-Solid" />
+    <write-data mesh="Solid-to-Fluid-Outer" name="Heat-Transfer-Coefficient-Solid" />
+    <read-data mesh="Solid-to-Fluid-Outer" name="Sink-Temperature-Fluid-Outer" />
+    <read-data mesh="Solid-to-Fluid-Outer" name="Heat-Transfer-Coefficient-Fluid-Outer" />
+    <mapping:nearest-neighbor
+      constraint="consistent"
+      direction="read"
+      to="Solid-to-Fluid-Outer"
+      from="Fluid-Outer-to-Solid" />
+  </participant>
 
-    <participant name="Fluid-Inner">
-      <provide-mesh name="Fluid-Inner-to-Solid" />
-      <receive-mesh name="Solid-to-Fluid-Inner" from="Solid" />
-      <write-data mesh="Fluid-Inner-to-Solid" name="Sink-Temperature-Fluid-Inner" />
-      <write-data mesh="Fluid-Inner-to-Solid" name="Heat-Transfer-Coefficient-Fluid-Inner" />
-      <read-data mesh="Fluid-Inner-to-Solid" name="Sink-Temperature-Solid" />
-      <read-data mesh="Fluid-Inner-to-Solid" name="Heat-Transfer-Coefficient-Solid" />
-      <mapping:nearest-neighbor
-        constraint="consistent"
-        direction="read"
-        to="Fluid-Inner-to-Solid"
-        from="Solid-to-Fluid-Inner" />
-    </participant>
+  <participant name="Fluid-Inner">
+    <provide-mesh name="Fluid-Inner-to-Solid" />
+    <receive-mesh name="Solid-to-Fluid-Inner" from="Solid" />
+    <write-data mesh="Fluid-Inner-to-Solid" name="Sink-Temperature-Fluid-Inner" />
+    <write-data mesh="Fluid-Inner-to-Solid" name="Heat-Transfer-Coefficient-Fluid-Inner" />
+    <read-data mesh="Fluid-Inner-to-Solid" name="Sink-Temperature-Solid" />
+    <read-data mesh="Fluid-Inner-to-Solid" name="Heat-Transfer-Coefficient-Solid" />
+    <mapping:nearest-neighbor
+      constraint="consistent"
+      direction="read"
+      to="Fluid-Inner-to-Solid"
+      from="Solid-to-Fluid-Inner" />
+  </participant>
 
-    <participant name="Fluid-Outer">
-      <provide-mesh name="Fluid-Outer-to-Solid" />
-      <receive-mesh name="Solid-to-Fluid-Outer" from="Solid" />
-      <write-data mesh="Fluid-Outer-to-Solid" name="Sink-Temperature-Fluid-Outer" />
-      <write-data mesh="Fluid-Outer-to-Solid" name="Heat-Transfer-Coefficient-Fluid-Outer" />
-      <read-data mesh="Fluid-Outer-to-Solid" name="Sink-Temperature-Solid" />
-      <read-data mesh="Fluid-Outer-to-Solid" name="Heat-Transfer-Coefficient-Solid" />
-      <mapping:nearest-neighbor
-        constraint="consistent"
-        direction="read"
-        to="Fluid-Outer-to-Solid"
-        from="Solid-to-Fluid-Outer" />
-    </participant>
+  <participant name="Fluid-Outer">
+    <provide-mesh name="Fluid-Outer-to-Solid" />
+    <receive-mesh name="Solid-to-Fluid-Outer" from="Solid" />
+    <write-data mesh="Fluid-Outer-to-Solid" name="Sink-Temperature-Fluid-Outer" />
+    <write-data mesh="Fluid-Outer-to-Solid" name="Heat-Transfer-Coefficient-Fluid-Outer" />
+    <read-data mesh="Fluid-Outer-to-Solid" name="Sink-Temperature-Solid" />
+    <read-data mesh="Fluid-Outer-to-Solid" name="Heat-Transfer-Coefficient-Solid" />
+    <mapping:nearest-neighbor
+      constraint="consistent"
+      direction="read"
+      to="Fluid-Outer-to-Solid"
+      from="Solid-to-Fluid-Outer" />
+  </participant>
 
-    <m2n:sockets connector="Fluid-Inner" acceptor="Solid" exchange-directory=".." />
+  <m2n:sockets connector="Fluid-Inner" acceptor="Solid" exchange-directory=".." />
 
-    <coupling-scheme:parallel-explicit>
-      <time-window-size value="1" />
-      <max-time value="500" />
-      <participants first="Solid" second="Fluid-Inner" />
-      <exchange
-        data="Sink-Temperature-Solid"
-        mesh="Solid-to-Fluid-Inner"
-        from="Solid"
-        to="Fluid-Inner"
-        initialize="yes" />
-      <exchange
-        data="Heat-Transfer-Coefficient-Solid"
-        mesh="Solid-to-Fluid-Inner"
-        from="Solid"
-        to="Fluid-Inner"
-        initialize="yes" />
-      <exchange
-        data="Sink-Temperature-Fluid-Inner"
-        mesh="Fluid-Inner-to-Solid"
-        from="Fluid-Inner"
-        to="Solid"
-        initialize="yes" />
-      <exchange
-        data="Heat-Transfer-Coefficient-Fluid-Inner"
-        mesh="Fluid-Inner-to-Solid"
-        from="Fluid-Inner"
-        to="Solid"
-        initialize="yes" />
-    </coupling-scheme:parallel-explicit>
+  <coupling-scheme:parallel-explicit>
+    <time-window-size value="1" />
+    <max-time value="500" />
+    <participants first="Solid" second="Fluid-Inner" />
+    <exchange
+      data="Sink-Temperature-Solid"
+      mesh="Solid-to-Fluid-Inner"
+      from="Solid"
+      to="Fluid-Inner"
+      initialize="yes" />
+    <exchange
+      data="Heat-Transfer-Coefficient-Solid"
+      mesh="Solid-to-Fluid-Inner"
+      from="Solid"
+      to="Fluid-Inner"
+      initialize="yes" />
+    <exchange
+      data="Sink-Temperature-Fluid-Inner"
+      mesh="Fluid-Inner-to-Solid"
+      from="Fluid-Inner"
+      to="Solid"
+      initialize="yes" />
+    <exchange
+      data="Heat-Transfer-Coefficient-Fluid-Inner"
+      mesh="Fluid-Inner-to-Solid"
+      from="Fluid-Inner"
+      to="Solid"
+      initialize="yes" />
+  </coupling-scheme:parallel-explicit>
 
-    <m2n:sockets connector="Fluid-Outer" acceptor="Solid" exchange-directory=".." />
+  <m2n:sockets connector="Fluid-Outer" acceptor="Solid" exchange-directory=".." />
 
-    <coupling-scheme:parallel-explicit>
-      <time-window-size value="1" />
-      <max-time value="500" />
-      <participants first="Solid" second="Fluid-Outer" />
-      <exchange
-        data="Sink-Temperature-Solid"
-        mesh="Solid-to-Fluid-Outer"
-        from="Solid"
-        to="Fluid-Outer"
-        initialize="yes" />
-      <exchange
-        data="Heat-Transfer-Coefficient-Solid"
-        mesh="Solid-to-Fluid-Outer"
-        from="Solid"
-        to="Fluid-Outer"
-        initialize="yes" />
-      <exchange
-        data="Sink-Temperature-Fluid-Outer"
-        mesh="Fluid-Outer-to-Solid"
-        from="Fluid-Outer"
-        to="Solid"
-        initialize="yes" />
-      <exchange
-        data="Heat-Transfer-Coefficient-Fluid-Outer"
-        mesh="Fluid-Outer-to-Solid"
-        from="Fluid-Outer"
-        to="Solid"
-        initialize="yes" />
-    </coupling-scheme:parallel-explicit>
-  </solver-interface>
+  <coupling-scheme:parallel-explicit>
+    <time-window-size value="1" />
+    <max-time value="500" />
+    <participants first="Solid" second="Fluid-Outer" />
+    <exchange
+      data="Sink-Temperature-Solid"
+      mesh="Solid-to-Fluid-Outer"
+      from="Solid"
+      to="Fluid-Outer"
+      initialize="yes" />
+    <exchange
+      data="Heat-Transfer-Coefficient-Solid"
+      mesh="Solid-to-Fluid-Outer"
+      from="Solid"
+      to="Fluid-Outer"
+      initialize="yes" />
+    <exchange
+      data="Sink-Temperature-Fluid-Outer"
+      mesh="Fluid-Outer-to-Solid"
+      from="Fluid-Outer"
+      to="Solid"
+      initialize="yes" />
+    <exchange
+      data="Heat-Transfer-Coefficient-Fluid-Outer"
+      mesh="Fluid-Outer-to-Solid"
+      from="Fluid-Outer"
+      to="Solid"
+      initialize="yes" />
+  </coupling-scheme:parallel-explicit>
 </precice-configuration>

--- a/multiple-perpendicular-flaps/precice-config.xml
+++ b/multiple-perpendicular-flaps/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="2">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,117 +7,115 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:vector name="Stress-Upstream" />
-    <data:vector name="Displacement-Upstream" />
-    <data:vector name="Stress-Downstream" />
-    <data:vector name="Displacement-Downstream" />
+  <data:vector name="Stress-Upstream" />
+  <data:vector name="Displacement-Upstream" />
+  <data:vector name="Stress-Downstream" />
+  <data:vector name="Displacement-Downstream" />
 
-    <mesh name="Fluid-Upstream-Mesh-Centers">
-      <use-data name="Stress-Upstream" />
-    </mesh>
+  <mesh name="Fluid-Upstream-Mesh-Centers">
+    <use-data name="Stress-Upstream" />
+  </mesh>
 
-    <mesh name="Fluid-Upstream-Mesh-Nodes">
-      <use-data name="Displacement-Upstream" />
-    </mesh>
+  <mesh name="Fluid-Upstream-Mesh-Nodes">
+    <use-data name="Displacement-Upstream" />
+  </mesh>
 
-    <mesh name="Fluid-Downstream-Mesh-Centers">
-      <use-data name="Stress-Downstream" />
-    </mesh>
+  <mesh name="Fluid-Downstream-Mesh-Centers">
+    <use-data name="Stress-Downstream" />
+  </mesh>
 
-    <mesh name="Fluid-Downstream-Mesh-Nodes">
-      <use-data name="Displacement-Downstream" />
-    </mesh>
+  <mesh name="Fluid-Downstream-Mesh-Nodes">
+    <use-data name="Displacement-Downstream" />
+  </mesh>
 
-    <mesh name="Solid-Upstream-Mesh">
-      <use-data name="Displacement-Upstream" />
-      <use-data name="Stress-Upstream" />
-    </mesh>
+  <mesh name="Solid-Upstream-Mesh">
+    <use-data name="Displacement-Upstream" />
+    <use-data name="Stress-Upstream" />
+  </mesh>
 
-    <mesh name="Solid-Downstream-Mesh">
-      <use-data name="Displacement-Downstream" />
-      <use-data name="Stress-Downstream" />
-    </mesh>
+  <mesh name="Solid-Downstream-Mesh">
+    <use-data name="Displacement-Downstream" />
+    <use-data name="Stress-Downstream" />
+  </mesh>
 
-    <participant name="Fluid">
-      <provide-mesh name="Fluid-Upstream-Mesh-Nodes" />
-      <provide-mesh name="Fluid-Upstream-Mesh-Centers" />
-      <receive-mesh name="Solid-Upstream-Mesh" from="Solid-Upstream" />
-      <provide-mesh name="Fluid-Downstream-Mesh-Nodes" />
-      <provide-mesh name="Fluid-Downstream-Mesh-Centers" />
-      <receive-mesh name="Solid-Downstream-Mesh" from="Solid-Downstream" />
-      <read-data name="Displacement-Upstream" mesh="Fluid-Upstream-Mesh-Nodes" />
-      <write-data name="Stress-Upstream" mesh="Fluid-Upstream-Mesh-Centers" />
-      <read-data name="Displacement-Downstream" mesh="Fluid-Downstream-Mesh-Nodes" />
-      <write-data name="Stress-Downstream" mesh="Fluid-Downstream-Mesh-Centers" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Solid-Upstream-Mesh"
-        to="Fluid-Upstream-Mesh-Nodes"
-        constraint="consistent" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Solid-Downstream-Mesh"
-        to="Fluid-Downstream-Mesh-Nodes"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid">
+    <provide-mesh name="Fluid-Upstream-Mesh-Nodes" />
+    <provide-mesh name="Fluid-Upstream-Mesh-Centers" />
+    <receive-mesh name="Solid-Upstream-Mesh" from="Solid-Upstream" />
+    <provide-mesh name="Fluid-Downstream-Mesh-Nodes" />
+    <provide-mesh name="Fluid-Downstream-Mesh-Centers" />
+    <receive-mesh name="Solid-Downstream-Mesh" from="Solid-Downstream" />
+    <read-data name="Displacement-Upstream" mesh="Fluid-Upstream-Mesh-Nodes" />
+    <write-data name="Stress-Upstream" mesh="Fluid-Upstream-Mesh-Centers" />
+    <read-data name="Displacement-Downstream" mesh="Fluid-Downstream-Mesh-Nodes" />
+    <write-data name="Stress-Downstream" mesh="Fluid-Downstream-Mesh-Centers" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Solid-Upstream-Mesh"
+      to="Fluid-Upstream-Mesh-Nodes"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Solid-Downstream-Mesh"
+      to="Fluid-Downstream-Mesh-Nodes"
+      constraint="consistent" />
+  </participant>
 
-    <participant name="Solid-Upstream">
-      <provide-mesh name="Solid-Upstream-Mesh" />
-      <receive-mesh name="Fluid-Upstream-Mesh-Centers" from="Fluid" />
-      <read-data name="Stress-Upstream" mesh="Solid-Upstream-Mesh" />
-      <write-data name="Displacement-Upstream" mesh="Solid-Upstream-Mesh" />
-      <watch-point mesh="Solid-Upstream-Mesh" name="Flap-Tip" coordinate="-1.05;1" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid-Upstream-Mesh-Centers"
-        to="Solid-Upstream-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Solid-Upstream">
+    <provide-mesh name="Solid-Upstream-Mesh" />
+    <receive-mesh name="Fluid-Upstream-Mesh-Centers" from="Fluid" />
+    <read-data name="Stress-Upstream" mesh="Solid-Upstream-Mesh" />
+    <write-data name="Displacement-Upstream" mesh="Solid-Upstream-Mesh" />
+    <watch-point mesh="Solid-Upstream-Mesh" name="Flap-Tip" coordinate="-1.05;1" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid-Upstream-Mesh-Centers"
+      to="Solid-Upstream-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <participant name="Solid-Downstream">
-      <provide-mesh name="Solid-Downstream-Mesh" />
-      <receive-mesh name="Fluid-Downstream-Mesh-Centers" from="Fluid" />
-      <read-data name="Stress-Downstream" mesh="Solid-Downstream-Mesh" />
-      <write-data name="Displacement-Downstream" mesh="Solid-Downstream-Mesh" />
-      <watch-point mesh="Solid-Downstream-Mesh" name="Flap-Tip" coordinate="0.95;1" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid-Downstream-Mesh-Centers"
-        to="Solid-Downstream-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Solid-Downstream">
+    <provide-mesh name="Solid-Downstream-Mesh" />
+    <receive-mesh name="Fluid-Downstream-Mesh-Centers" from="Fluid" />
+    <read-data name="Stress-Downstream" mesh="Solid-Downstream-Mesh" />
+    <write-data name="Displacement-Downstream" mesh="Solid-Downstream-Mesh" />
+    <watch-point mesh="Solid-Downstream-Mesh" name="Flap-Tip" coordinate="0.95;1" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid-Downstream-Mesh-Centers"
+      to="Solid-Downstream-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <m2n:sockets acceptor="Fluid" connector="Solid-Upstream" exchange-directory=".." />
-    <m2n:sockets acceptor="Fluid" connector="Solid-Downstream" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid" connector="Solid-Upstream" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid" connector="Solid-Downstream" exchange-directory=".." />
 
-    <coupling-scheme:multi>
-      <time-window-size value="0.01" />
-      <max-time value="5" />
-      <participant name="Fluid" control="yes" />
-      <participant name="Solid-Upstream" />
-      <participant name="Solid-Downstream" />
-      <exchange data="Stress-Upstream" mesh="Fluid-Upstream-Mesh-Centers" from="Fluid" to="Solid-Upstream" />
-      <exchange data="Stress-Downstream" mesh="Fluid-Downstream-Mesh-Centers" from="Fluid" to="Solid-Downstream" />
-      <exchange data="Displacement-Upstream" mesh="Solid-Upstream-Mesh" from="Solid-Upstream" to="Fluid" />
-      <exchange data="Displacement-Downstream" mesh="Solid-Downstream-Mesh" from="Solid-Downstream" to="Fluid" />
-      <max-iterations value="50" />
-      <relative-convergence-measure limit="1e-4" data="Stress-Upstream" mesh="Fluid-Upstream-Mesh-Centers" />
-      <relative-convergence-measure limit="1e-4" data="Displacement-Upstream" mesh="Solid-Upstream-Mesh" />
-      <relative-convergence-measure limit="1e-4" data="Stress-Downstream" mesh="Fluid-Downstream-Mesh-Centers" />
-      <relative-convergence-measure limit="1e-4" data="Displacement-Downstream" mesh="Solid-Downstream-Mesh" />
-      <extrapolation-order value="2" />
-      <acceleration:IQN-ILS>
-        <data name="Displacement-Upstream" mesh="Solid-Upstream-Mesh" />
-        <data name="Displacement-Downstream" mesh="Solid-Downstream-Mesh" />
-        <data name="Stress-Upstream" mesh="Fluid-Upstream-Mesh-Centers" />
-        <data name="Stress-Downstream" mesh="Fluid-Downstream-Mesh-Centers" />
-        <preconditioner type="residual-sum" />
-        <filter type="QR1" limit="1e-6" />
-        <initial-relaxation value="0.1" />
-        <max-used-iterations value="50" />
-        <time-windows-reused value="10" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:multi>
-  </solver-interface>
+  <coupling-scheme:multi>
+    <time-window-size value="0.01" />
+    <max-time value="5" />
+    <participant name="Fluid" control="yes" />
+    <participant name="Solid-Upstream" />
+    <participant name="Solid-Downstream" />
+    <exchange data="Stress-Upstream" mesh="Fluid-Upstream-Mesh-Centers" from="Fluid" to="Solid-Upstream" />
+    <exchange data="Stress-Downstream" mesh="Fluid-Downstream-Mesh-Centers" from="Fluid" to="Solid-Downstream" />
+    <exchange data="Displacement-Upstream" mesh="Solid-Upstream-Mesh" from="Solid-Upstream" to="Fluid" />
+    <exchange data="Displacement-Downstream" mesh="Solid-Downstream-Mesh" from="Solid-Downstream" to="Fluid" />
+    <max-iterations value="50" />
+    <relative-convergence-measure limit="1e-4" data="Stress-Upstream" mesh="Fluid-Upstream-Mesh-Centers" />
+    <relative-convergence-measure limit="1e-4" data="Displacement-Upstream" mesh="Solid-Upstream-Mesh" />
+    <relative-convergence-measure limit="1e-4" data="Stress-Downstream" mesh="Fluid-Downstream-Mesh-Centers" />
+    <relative-convergence-measure limit="1e-4" data="Displacement-Downstream" mesh="Solid-Downstream-Mesh" />
+    <extrapolation-order value="2" />
+    <acceleration:IQN-ILS>
+      <data name="Displacement-Upstream" mesh="Solid-Upstream-Mesh" />
+      <data name="Displacement-Downstream" mesh="Solid-Downstream-Mesh" />
+      <data name="Stress-Upstream" mesh="Fluid-Upstream-Mesh-Centers" />
+      <data name="Stress-Downstream" mesh="Fluid-Downstream-Mesh-Centers" />
+      <preconditioner type="residual-sum" />
+      <filter type="QR1" limit="1e-6" />
+      <initial-relaxation value="0.1" />
+      <max-used-iterations value="50" />
+      <time-windows-reused value="10" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:multi>
 </precice-configuration>

--- a/oscillator/precice-config.xml
+++ b/oscillator/precice-config.xml
@@ -1,62 +1,59 @@
 <?xml version="1.0"?>
-<precice-configuration>
+<precice-configuration dimensions="2">
+<!-- Use this to activate waveforms
+<precice-configuration dimensions="2" experimental="true">
+-->
   <log enabled="1">
     <sink filter="%Severity% > debug" />
   </log>
 
-  <solver-interface dimensions="2" >
-  <!-- Use this to activate waveforms
-  <solver-interface dimensions="2" experimental="true">
-  -->
-    <data:scalar name="Force-Left"  />
-    <data:scalar name="Force-Right"  />
+  <data:scalar name="Force-Left"  />
+  <data:scalar name="Force-Right"  />
 
-    <mesh name="Mass-Left-Mesh">
-      <use-data name="Force-Left" />
-      <use-data name="Force-Right" />
-    </mesh>
+  <mesh name="Mass-Left-Mesh">
+    <use-data name="Force-Left" />
+    <use-data name="Force-Right" />
+  </mesh>
 
-    <mesh name="Mass-Right-Mesh">
-      <use-data name="Force-Left" />
-      <use-data name="Force-Right" />
-    </mesh>
+  <mesh name="Mass-Right-Mesh">
+    <use-data name="Force-Left" />
+    <use-data name="Force-Right" />
+  </mesh>
 
-    <participant name="Mass-Left">
-      <provide-mesh name="Mass-Left-Mesh" />
-      <write-data name="Force-Left" mesh="Mass-Left-Mesh" />
-      <read-data  name="Force-Right" mesh="Mass-Left-Mesh" />
-      <!-- Use this to activate first order interpolation
-      <read-data  name="Force-Right" mesh="Mass-Left-Mesh" waveform-order="1" />
-      -->
-    </participant>
+  <participant name="Mass-Left">
+    <provide-mesh name="Mass-Left-Mesh" />
+    <write-data name="Force-Left" mesh="Mass-Left-Mesh" />
+    <read-data  name="Force-Right" mesh="Mass-Left-Mesh" />
+    <!-- Use this to activate first order interpolation
+    <read-data  name="Force-Right" mesh="Mass-Left-Mesh" waveform-order="1" />
+    -->
+  </participant>
 
-    <participant name="Mass-Right">
-      <receive-mesh name="Mass-Left-Mesh" from="Mass-Left"/>
-      <provide-mesh name="Mass-Right-Mesh" />
-      <write-data name="Force-Right" mesh="Mass-Right-Mesh" />
-      <read-data  name="Force-Left" mesh="Mass-Right-Mesh" />
-      <!-- Use this to activate first order interpolation
-      <read-data  name="Force-Left" mesh="Mass-Right-Mesh" waveform-order="1" />
-      -->
-      <mapping:nearest-neighbor direction="write" from="Mass-Right-Mesh" to="Mass-Left-Mesh" constraint="consistent" />
-      <mapping:nearest-neighbor direction="read"  from="Mass-Left-Mesh" to="Mass-Right-Mesh" constraint="consistent" />
-    </participant>
+  <participant name="Mass-Right">
+    <receive-mesh name="Mass-Left-Mesh" from="Mass-Left"/>
+    <provide-mesh name="Mass-Right-Mesh" />
+    <write-data name="Force-Right" mesh="Mass-Right-Mesh" />
+    <read-data  name="Force-Left" mesh="Mass-Right-Mesh" />
+    <!-- Use this to activate first order interpolation
+    <read-data  name="Force-Left" mesh="Mass-Right-Mesh" waveform-order="1" />
+    -->
+    <mapping:nearest-neighbor direction="write" from="Mass-Right-Mesh" to="Mass-Left-Mesh" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read"  from="Mass-Left-Mesh" to="Mass-Right-Mesh" constraint="consistent" />
+  </participant>
 
-    <m2n:sockets acceptor="Mass-Left" connector="Mass-Right" exchange-directory=".." />
+  <m2n:sockets acceptor="Mass-Left" connector="Mass-Right" exchange-directory=".." />
 
-    <coupling-scheme:serial-implicit>
-      <participants first="Mass-Left" second="Mass-Right" />
-      <max-time value="1" />
-      <time-window-size value="0.01" />
-      <max-iterations value="200" />
-      <relative-convergence-measure data="Force-Left" mesh="Mass-Left-Mesh" limit="1e-10"/>
-      <relative-convergence-measure data="Force-Right" mesh="Mass-Left-Mesh" limit="1e-10"/>
-      <exchange data="Force-Left" mesh="Mass-Left-Mesh" from="Mass-Left" to="Mass-Right" />
-      <!-- Use this for higher accuracy with waveforms and preCICE v3
-      <exchange data="Force-Left" mesh="Mass-Left-Mesh" from="Mass-Left" to="Mass-Right" initialize="true" />
-      -->
-      <exchange data="Force-Right" mesh="Mass-Left-Mesh" from="Mass-Right" to="Mass-Left" initialize="true"/>
-    </coupling-scheme:serial-implicit>
-  </solver-interface>
-
+  <coupling-scheme:serial-implicit>
+    <participants first="Mass-Left" second="Mass-Right" />
+    <max-time value="1" />
+    <time-window-size value="0.01" />
+    <max-iterations value="200" />
+    <relative-convergence-measure data="Force-Left" mesh="Mass-Left-Mesh" limit="1e-10"/>
+    <relative-convergence-measure data="Force-Right" mesh="Mass-Left-Mesh" limit="1e-10"/>
+    <exchange data="Force-Left" mesh="Mass-Left-Mesh" from="Mass-Left" to="Mass-Right" />
+    <!-- Use this for higher accuracy with waveforms and preCICE v3
+    <exchange data="Force-Left" mesh="Mass-Left-Mesh" from="Mass-Left" to="Mass-Right" initialize="true" />
+    -->
+    <exchange data="Force-Right" mesh="Mass-Left-Mesh" from="Mass-Right" to="Mass-Left" initialize="true"/>
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/partitioned-backwards-facing-step/precice-config.xml
+++ b/partitioned-backwards-facing-step/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="3">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,94 +7,92 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="3">
-    <data:scalar name="Pressure" />
-    <data:vector name="Velocity" />
-    <data:scalar name="PressureBack" />
-    <data:vector name="VelocityBack" />
-    <data:vector name="VelocityGradient" />
-    <data:vector name="VelocityGradientBack" />
+  <data:scalar name="Pressure" />
+  <data:vector name="Velocity" />
+  <data:scalar name="PressureBack" />
+  <data:vector name="VelocityBack" />
+  <data:vector name="VelocityGradient" />
+  <data:vector name="VelocityGradientBack" />
 
-    <mesh name="Fluid1-Mesh">
-      <use-data name="Pressure" />
-      <use-data name="Velocity" />
-      <use-data name="PressureBack" />
-      <use-data name="VelocityBack" />
-      <use-data name="VelocityGradient" />
-      <use-data name="VelocityGradientBack" />
-    </mesh>
+  <mesh name="Fluid1-Mesh">
+    <use-data name="Pressure" />
+    <use-data name="Velocity" />
+    <use-data name="PressureBack" />
+    <use-data name="VelocityBack" />
+    <use-data name="VelocityGradient" />
+    <use-data name="VelocityGradientBack" />
+  </mesh>
 
-    <mesh name="Fluid2-Mesh">
-      <use-data name="Pressure" />
-      <use-data name="Velocity" />
-      <use-data name="PressureBack" />
-      <use-data name="VelocityBack" />
-      <use-data name="VelocityGradient" />
-      <use-data name="VelocityGradientBack" />
+  <mesh name="Fluid2-Mesh">
+    <use-data name="Pressure" />
+    <use-data name="Velocity" />
+    <use-data name="PressureBack" />
+    <use-data name="VelocityBack" />
+    <use-data name="VelocityGradient" />
+    <use-data name="VelocityGradientBack" />
 
-    </mesh>
+  </mesh>
 
-    <participant name="Fluid1">
-      <use-mesh name="Fluid1-Mesh" provide="yes" />
-      <use-mesh name="Fluid2-Mesh" from="Fluid2" />
-      <write-data name="Velocity" mesh="Fluid1-Mesh" />
-      <write-data name="PressureBack" mesh="Fluid1-Mesh" />
-      <write-data name="VelocityGradientBack" mesh="Fluid1-Mesh" />
-      <read-data name="Pressure" mesh="Fluid1-Mesh" />
-      <read-data name="VelocityBack" mesh="Fluid1-Mesh" />
-      <read-data name="VelocityGradient" mesh="Fluid1-Mesh" />
+  <participant name="Fluid1">
+    <use-mesh name="Fluid1-Mesh" provide="yes" />
+    <use-mesh name="Fluid2-Mesh" from="Fluid2" />
+    <write-data name="Velocity" mesh="Fluid1-Mesh" />
+    <write-data name="PressureBack" mesh="Fluid1-Mesh" />
+    <write-data name="VelocityGradientBack" mesh="Fluid1-Mesh" />
+    <read-data name="Pressure" mesh="Fluid1-Mesh" />
+    <read-data name="VelocityBack" mesh="Fluid1-Mesh" />
+    <read-data name="VelocityGradient" mesh="Fluid1-Mesh" />
 
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid2-Mesh"
-        to="Fluid1-Mesh"
-        constraint="consistent" />
-    </participant>
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid2-Mesh"
+      to="Fluid1-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <participant name="Fluid2">
-      <use-mesh name="Fluid2-Mesh" provide="yes" />
-      <use-mesh name="Fluid1-Mesh" from="Fluid1" />
-      <read-data name="Velocity" mesh="Fluid2-Mesh" />
-      <read-data name="PressureBack" mesh="Fluid2-Mesh" />
-      <read-data name="VelocityGradientBack" mesh="Fluid2-Mesh" />
-      <write-data name="Pressure" mesh="Fluid2-Mesh" />
-      <write-data name="VelocityBack" mesh="Fluid2-Mesh" />
-      <write-data name="VelocityGradient" mesh="Fluid2-Mesh" />
+  <participant name="Fluid2">
+    <use-mesh name="Fluid2-Mesh" provide="yes" />
+    <use-mesh name="Fluid1-Mesh" from="Fluid1" />
+    <read-data name="Velocity" mesh="Fluid2-Mesh" />
+    <read-data name="PressureBack" mesh="Fluid2-Mesh" />
+    <read-data name="VelocityGradientBack" mesh="Fluid2-Mesh" />
+    <write-data name="Pressure" mesh="Fluid2-Mesh" />
+    <write-data name="VelocityBack" mesh="Fluid2-Mesh" />
+    <write-data name="VelocityGradient" mesh="Fluid2-Mesh" />
 
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid1-Mesh"
-        to="Fluid2-Mesh"
-        constraint="consistent" />
-    </participant>
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid1-Mesh"
+      to="Fluid2-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <m2n:sockets acceptor="Fluid1" connector="Fluid2" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid1" connector="Fluid2" exchange-directory=".." />
 
-    <coupling-scheme:serial-implicit>
-      <time-window-size value="0.01" />
-      <max-time value="2.5" />
-      <participants first="Fluid1" second="Fluid2" />
-      <exchange data="Velocity" mesh="Fluid1-Mesh" from="Fluid1" to="Fluid2" />
-      <exchange data="VelocityBack" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" />
-      <exchange data="VelocityGradient" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" />
-      <exchange data="VelocityGradientBack" mesh="Fluid1-Mesh" from="Fluid1" to="Fluid2" />
-      <exchange data="Pressure" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" />
-      <exchange data="PressureBack" mesh="Fluid1-Mesh" from="Fluid1" to="Fluid2" />
-      <max-iterations value="100" />
-      <relative-convergence-measure limit="1.0e-5" data="Pressure" mesh="Fluid2-Mesh" />
-      <relative-convergence-measure limit="1.0e-5" data="PressureBack" mesh="Fluid1-Mesh" />
-      <relative-convergence-measure limit="1.0e-5" data="Velocity" mesh="Fluid1-Mesh" />
-      <relative-convergence-measure limit="1.0e-5" data="VelocityBack" mesh="Fluid2-Mesh" />
-      <relative-convergence-measure limit="1.0e-5" data="VelocityGradient" mesh="Fluid2-Mesh" />
-      <relative-convergence-measure limit="1.0e-5" data="VelocityGradientBack" mesh="Fluid1-Mesh" />
-      <acceleration:IQN-ILS>
-        <data mesh="Fluid2-Mesh" name="VelocityGradient" />
-        <data mesh="Fluid2-Mesh" name="VelocityBack" />
-        <initial-relaxation value="0.01" />
-        <max-used-iterations value="10" />
-        <time-windows-reused value="4" />
-        <filter type="QR1" limit="1e-7" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:serial-implicit>
-  </solver-interface>
+  <coupling-scheme:serial-implicit>
+    <time-window-size value="0.01" />
+    <max-time value="2.5" />
+    <participants first="Fluid1" second="Fluid2" />
+    <exchange data="Velocity" mesh="Fluid1-Mesh" from="Fluid1" to="Fluid2" />
+    <exchange data="VelocityBack" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" />
+    <exchange data="VelocityGradient" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" />
+    <exchange data="VelocityGradientBack" mesh="Fluid1-Mesh" from="Fluid1" to="Fluid2" />
+    <exchange data="Pressure" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" />
+    <exchange data="PressureBack" mesh="Fluid1-Mesh" from="Fluid1" to="Fluid2" />
+    <max-iterations value="100" />
+    <relative-convergence-measure limit="1.0e-5" data="Pressure" mesh="Fluid2-Mesh" />
+    <relative-convergence-measure limit="1.0e-5" data="PressureBack" mesh="Fluid1-Mesh" />
+    <relative-convergence-measure limit="1.0e-5" data="Velocity" mesh="Fluid1-Mesh" />
+    <relative-convergence-measure limit="1.0e-5" data="VelocityBack" mesh="Fluid2-Mesh" />
+    <relative-convergence-measure limit="1.0e-5" data="VelocityGradient" mesh="Fluid2-Mesh" />
+    <relative-convergence-measure limit="1.0e-5" data="VelocityGradientBack" mesh="Fluid1-Mesh" />
+    <acceleration:IQN-ILS>
+      <data mesh="Fluid2-Mesh" name="VelocityGradient" />
+      <data mesh="Fluid2-Mesh" name="VelocityBack" />
+      <initial-relaxation value="0.01" />
+      <max-used-iterations value="10" />
+      <time-windows-reused value="4" />
+      <filter type="QR1" limit="1e-7" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/partitioned-elastic-beam/precice-config.xml
+++ b/partitioned-elastic-beam/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="3">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,64 +7,62 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="3">
-    <data:vector name="Force0" />
-    <data:vector name="Displacement0" />
+  <data:vector name="Force0" />
+  <data:vector name="Displacement0" />
 
-    <mesh name="Calculix-Mesh1">
-      <use-data name="Force0" />
-      <use-data name="Displacement0" />
-    </mesh>
+  <mesh name="Calculix-Mesh1">
+    <use-data name="Force0" />
+    <use-data name="Displacement0" />
+  </mesh>
 
-    <mesh name="Calculix-Mesh2">
-      <use-data name="Displacement0" />
-      <use-data name="Force0" />
-    </mesh>
+  <mesh name="Calculix-Mesh2">
+    <use-data name="Displacement0" />
+    <use-data name="Force0" />
+  </mesh>
 
-    <participant name="Calculix1">
-      <provide-mesh name="Calculix-Mesh1" />
-      <receive-mesh name="Calculix-Mesh2" from="Calculix2" />
-      <write-data name="Force0" mesh="Calculix-Mesh1" />
-      <read-data name="Displacement0" mesh="Calculix-Mesh1" />
-      <mapping:nearest-neighbor
-        direction="write"
-        from="Calculix-Mesh1"
-        to="Calculix-Mesh2"
-        constraint="conservative" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Calculix-Mesh2"
-        to="Calculix-Mesh1"
-        constraint="consistent" />
-    </participant>
+  <participant name="Calculix1">
+    <provide-mesh name="Calculix-Mesh1" />
+    <receive-mesh name="Calculix-Mesh2" from="Calculix2" />
+    <write-data name="Force0" mesh="Calculix-Mesh1" />
+    <read-data name="Displacement0" mesh="Calculix-Mesh1" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="Calculix-Mesh1"
+      to="Calculix-Mesh2"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Calculix-Mesh2"
+      to="Calculix-Mesh1"
+      constraint="consistent" />
+  </participant>
 
-    <participant name="Calculix2">
-      <provide-mesh name="Calculix-Mesh2" />
-      <write-data name="Displacement0" mesh="Calculix-Mesh2" />
-      <read-data name="Force0" mesh="Calculix-Mesh2" />
-    </participant>
+  <participant name="Calculix2">
+    <provide-mesh name="Calculix-Mesh2" />
+    <write-data name="Displacement0" mesh="Calculix-Mesh2" />
+    <read-data name="Force0" mesh="Calculix-Mesh2" />
+  </participant>
 
-    <m2n:sockets acceptor="Calculix1" connector="Calculix2" exchange-directory="../" />
+  <m2n:sockets acceptor="Calculix1" connector="Calculix2" exchange-directory="../" />
 
-    <coupling-scheme:parallel-implicit>
-      <participants first="Calculix1" second="Calculix2" />
-      <max-time-windows value="50" />
-      <time-window-size value="1e-2" />
-      <exchange data="Displacement0" mesh="Calculix-Mesh2" from="Calculix2" to="Calculix1" />
-      <exchange data="Force0" mesh="Calculix-Mesh2" from="Calculix1" to="Calculix2" />
-      <max-iterations value="50" />
-      <!--      	   <min-iteration-convergence-measure min-iterations="5" data="Displacement0" mesh="Calculix-Mesh2"/>-->
-      <relative-convergence-measure limit="1e-4" data="Displacement0" mesh="Calculix-Mesh2" />
-      <relative-convergence-measure limit="1e-4" data="Force0" mesh="Calculix-Mesh2" />
-      <acceleration:IQN-ILS>
-        <data name="Displacement0" mesh="Calculix-Mesh2" />
-        <data name="Force0" mesh="Calculix-Mesh2" />
-        <preconditioner type="residual-sum" />
-        <filter type="QR2" limit="1e-3" />
-        <initial-relaxation value="0.1" />
-        <max-used-iterations value="60" />
-        <time-windows-reused value="10" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  <coupling-scheme:parallel-implicit>
+    <participants first="Calculix1" second="Calculix2" />
+    <max-time-windows value="50" />
+    <time-window-size value="1e-2" />
+    <exchange data="Displacement0" mesh="Calculix-Mesh2" from="Calculix2" to="Calculix1" />
+    <exchange data="Force0" mesh="Calculix-Mesh2" from="Calculix1" to="Calculix2" />
+    <max-iterations value="50" />
+    <!--      	   <min-iteration-convergence-measure min-iterations="5" data="Displacement0" mesh="Calculix-Mesh2"/>-->
+    <relative-convergence-measure limit="1e-4" data="Displacement0" mesh="Calculix-Mesh2" />
+    <relative-convergence-measure limit="1e-4" data="Force0" mesh="Calculix-Mesh2" />
+    <acceleration:IQN-ILS>
+      <data name="Displacement0" mesh="Calculix-Mesh2" />
+      <data name="Force0" mesh="Calculix-Mesh2" />
+      <preconditioner type="residual-sum" />
+      <filter type="QR2" limit="1e-3" />
+      <initial-relaxation value="0.1" />
+      <max-used-iterations value="60" />
+      <time-windows-reused value="10" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:parallel-implicit>
 </precice-configuration>

--- a/partitioned-heat-conduction-complex/precice-config.xml
+++ b/partitioned-heat-conduction-complex/precice-config.xml
@@ -1,61 +1,56 @@
 <?xml version="1.0"?>
 
-<precice-configuration>
-
+<precice-configuration dimensions="2">
   <log>
     <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
   </log>
 
-  <solver-interface dimensions="2">
+  <data:scalar name="Temperature"/>
+  <data:vector name="Flux"/>
 
-    <data:scalar name="Temperature"/>
-    <data:vector name="Flux"/>
+  <mesh name="Dirichlet-Mesh">
+    <use-data name="Temperature"/>
+    <use-data name="Flux"/>
+  </mesh>
 
-    <mesh name="Dirichlet-Mesh">
-      <use-data name="Temperature"/>
-      <use-data name="Flux"/>
-    </mesh>
+  <mesh name="Neumann-Mesh">
+    <use-data name="Temperature"/>
+    <use-data name="Flux"/>
+  </mesh>
 
-    <mesh name="Neumann-Mesh">
-      <use-data name="Temperature"/>
-      <use-data name="Flux"/>
-    </mesh>
+  <participant name="Dirichlet">
+    <provide-mesh name="Dirichlet-Mesh" />
+    <receive-mesh name="Neumann-Mesh" from="Neumann" />
+    <write-data name="Flux" mesh="Dirichlet-Mesh" />
+    <read-data name="Temperature" mesh="Dirichlet-Mesh" />
+    <mapping:nearest-projection direction="read" from="Neumann-Mesh" to="Dirichlet-Mesh" constraint="consistent" />
+  </participant>
 
-    <participant name="Dirichlet">
-      <provide-mesh name="Dirichlet-Mesh" />
-      <receive-mesh name="Neumann-Mesh" from="Neumann" />
-      <write-data name="Flux" mesh="Dirichlet-Mesh" />
-      <read-data name="Temperature" mesh="Dirichlet-Mesh" />
-      <mapping:nearest-projection direction="read" from="Neumann-Mesh" to="Dirichlet-Mesh" constraint="consistent" />
-    </participant>
+  <participant name="Neumann">
+    <provide-mesh name="Neumann-Mesh" />
+    <receive-mesh name="Dirichlet-Mesh" from="Dirichlet"/>
+    <write-data name="Temperature" mesh="Neumann-Mesh"/>
+    <read-data name="Flux" mesh="Neumann-Mesh"/>
+    <mapping:nearest-projection direction="read" from="Dirichlet-Mesh" to="Neumann-Mesh" constraint="consistent" />
+  </participant>
 
-    <participant name="Neumann">
-      <provide-mesh name="Neumann-Mesh" />
-      <receive-mesh name="Dirichlet-Mesh" from="Dirichlet"/>
-      <write-data name="Temperature" mesh="Neumann-Mesh"/>
-      <read-data name="Flux" mesh="Neumann-Mesh"/>
-      <mapping:nearest-projection direction="read" from="Dirichlet-Mesh" to="Neumann-Mesh" constraint="consistent" />
-    </participant>
+  <m2n:sockets acceptor="Dirichlet" connector="Neumann" exchange-directory=".."/>
 
-    <m2n:sockets acceptor="Dirichlet" connector="Neumann" exchange-directory=".."/>
-
-    <coupling-scheme:serial-implicit>
-      <participants first="Dirichlet" second="Neumann"/>
-      <max-time value="1.0"/>
-      <time-window-size value="0.1"/>
-      <max-iterations value="100"/>
-      <exchange data="Flux" mesh="Dirichlet-Mesh" from="Dirichlet" to="Neumann" />
-      <exchange data="Temperature" mesh="Neumann-Mesh" from="Neumann" to="Dirichlet" initialize="true"/>
-      <relative-convergence-measure data="Flux" mesh="Dirichlet-Mesh" limit="1e-5"/>
-      <relative-convergence-measure data="Temperature" mesh="Neumann-Mesh" limit="1e-5"/>
-      <acceleration:IQN-ILS>
-        <data name="Temperature" mesh="Neumann-Mesh"/>
-        <initial-relaxation value="0.1"/>
-        <max-used-iterations value="10"/>
-        <time-windows-reused value="5"/>
-        <filter type="QR2" limit="1e-3"/>
-      </acceleration:IQN-ILS>
-    </coupling-scheme:serial-implicit>
-
-  </solver-interface>
+  <coupling-scheme:serial-implicit>
+    <participants first="Dirichlet" second="Neumann"/>
+    <max-time value="1.0"/>
+    <time-window-size value="0.1"/>
+    <max-iterations value="100"/>
+    <exchange data="Flux" mesh="Dirichlet-Mesh" from="Dirichlet" to="Neumann" />
+    <exchange data="Temperature" mesh="Neumann-Mesh" from="Neumann" to="Dirichlet" initialize="true"/>
+    <relative-convergence-measure data="Flux" mesh="Dirichlet-Mesh" limit="1e-5"/>
+    <relative-convergence-measure data="Temperature" mesh="Neumann-Mesh" limit="1e-5"/>
+    <acceleration:IQN-ILS>
+      <data name="Temperature" mesh="Neumann-Mesh"/>
+      <initial-relaxation value="0.1"/>
+      <max-used-iterations value="10"/>
+      <time-windows-reused value="5"/>
+      <filter type="QR2" limit="1e-3"/>
+    </acceleration:IQN-ILS>
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/partitioned-heat-conduction-direct/precice-config.xml
+++ b/partitioned-heat-conduction-direct/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="2" experimental="yes">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,54 +7,52 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2" experimental="yes">
-    <data:scalar name="Temperature" />
-    <data:scalar name="Heat-Flux" />
+  <data:scalar name="Temperature" />
+  <data:scalar name="Heat-Flux" />
 
-    <mesh name="Dirichlet-Mesh">
-      <use-data name="Temperature" />
-      <use-data name="Heat-Flux" />
-    </mesh>
+  <mesh name="Dirichlet-Mesh">
+    <use-data name="Temperature" />
+    <use-data name="Heat-Flux" />
+  </mesh>
 
-    <mesh name="Neumann-Mesh">
-      <use-data name="Temperature" />
-      <use-data name="Heat-Flux" />
-    </mesh>
+  <mesh name="Neumann-Mesh">
+    <use-data name="Temperature" />
+    <use-data name="Heat-Flux" />
+  </mesh>
 
-    <participant name="Dirichlet">
-      <provide-mesh name="Dirichlet-Mesh" />
-      <receive-mesh name="Neumann-Mesh" from="Neumann" direct-access="true" />
-      <write-data name="Heat-Flux" mesh="Neumann-Mesh" />
-      <read-data name="Temperature" mesh="Dirichlet-Mesh" />
-    </participant>
+  <participant name="Dirichlet">
+    <provide-mesh name="Dirichlet-Mesh" />
+    <receive-mesh name="Neumann-Mesh" from="Neumann" direct-access="true" />
+    <write-data name="Heat-Flux" mesh="Neumann-Mesh" />
+    <read-data name="Temperature" mesh="Dirichlet-Mesh" />
+  </participant>
 
-    <participant name="Neumann">
-      <provide-mesh name="Neumann-Mesh" />
-      <receive-mesh name="Dirichlet-Mesh" from="Dirichlet" direct-access="true" />
-      <write-data name="Temperature" mesh="Dirichlet-Mesh" />
-      <read-data name="Heat-Flux" mesh="Neumann-Mesh" />
-    </participant>
+  <participant name="Neumann">
+    <provide-mesh name="Neumann-Mesh" />
+    <receive-mesh name="Dirichlet-Mesh" from="Dirichlet" direct-access="true" />
+    <write-data name="Temperature" mesh="Dirichlet-Mesh" />
+    <read-data name="Heat-Flux" mesh="Neumann-Mesh" />
+  </participant>
 
-    <m2n:sockets acceptor="Dirichlet" connector="Neumann" exchange-directory=".." />
+  <m2n:sockets acceptor="Dirichlet" connector="Neumann" exchange-directory=".." />
 
-    <coupling-scheme:parallel-implicit>
-      <participants first="Dirichlet" second="Neumann" />
-      <max-time value="1.0" />
-      <time-window-size value="0.1" />
-      <max-iterations value="100" />
-      <exchange data="Heat-Flux" mesh="Neumann-Mesh" from="Dirichlet" to="Neumann" />
-      <exchange data="Temperature" mesh="Dirichlet-Mesh" from="Neumann" to="Dirichlet" />
-      <relative-convergence-measure data="Heat-Flux" mesh="Neumann-Mesh" limit="1e-5" />
-      <relative-convergence-measure data="Temperature" mesh="Dirichlet-Mesh" limit="1e-5" />
-      <acceleration:IQN-ILS>
-        <data name="Temperature" mesh="Dirichlet-Mesh" />
-        <data name="Heat-Flux" mesh="Neumann-Mesh" />
-        <initial-relaxation value="0.1" />
-        <max-used-iterations value="10" />
-        <time-windows-reused value="5" />
-        <preconditioner type="residual-sum" />
-        <filter type="QR2" limit="1e-3" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  <coupling-scheme:parallel-implicit>
+    <participants first="Dirichlet" second="Neumann" />
+    <max-time value="1.0" />
+    <time-window-size value="0.1" />
+    <max-iterations value="100" />
+    <exchange data="Heat-Flux" mesh="Neumann-Mesh" from="Dirichlet" to="Neumann" />
+    <exchange data="Temperature" mesh="Dirichlet-Mesh" from="Neumann" to="Dirichlet" />
+    <relative-convergence-measure data="Heat-Flux" mesh="Neumann-Mesh" limit="1e-5" />
+    <relative-convergence-measure data="Temperature" mesh="Dirichlet-Mesh" limit="1e-5" />
+    <acceleration:IQN-ILS>
+      <data name="Temperature" mesh="Dirichlet-Mesh" />
+      <data name="Heat-Flux" mesh="Neumann-Mesh" />
+      <initial-relaxation value="0.1" />
+      <max-used-iterations value="10" />
+      <time-windows-reused value="5" />
+      <preconditioner type="residual-sum" />
+      <filter type="QR2" limit="1e-3" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:parallel-implicit>
 </precice-configuration>

--- a/partitioned-heat-conduction/precice-config.xml
+++ b/partitioned-heat-conduction/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="2">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,73 +7,71 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:scalar name="Temperature" />
-    <data:scalar name="Heat-Flux" />
+  <data:scalar name="Temperature" />
+  <data:scalar name="Heat-Flux" />
 
-    <mesh name="Dirichlet-Mesh">
-      <use-data name="Temperature" />
-      <use-data name="Heat-Flux" />
-    </mesh>
+  <mesh name="Dirichlet-Mesh">
+    <use-data name="Temperature" />
+    <use-data name="Heat-Flux" />
+  </mesh>
 
-    <mesh name="Neumann-Mesh">
-      <use-data name="Temperature" />
-      <use-data name="Heat-Flux" />
-    </mesh>
+  <mesh name="Neumann-Mesh">
+    <use-data name="Temperature" />
+    <use-data name="Heat-Flux" />
+  </mesh>
 
-    <participant name="Dirichlet">
-      <provide-mesh name="Dirichlet-Mesh" />
-      <receive-mesh name="Neumann-Mesh" from="Neumann" />
-      <write-data name="Heat-Flux" mesh="Dirichlet-Mesh" />
-      <read-data name="Temperature" mesh="Dirichlet-Mesh" />
-      <mapping:rbf
-        direction="read"
-        from="Neumann-Mesh"
-        to="Dirichlet-Mesh"
-        constraint="consistent"
-        x-dead="true">
-        <basis-function:thin-plate-splines />
-      </mapping-rbf>
-    </participant>
+  <participant name="Dirichlet">
+    <provide-mesh name="Dirichlet-Mesh" />
+    <receive-mesh name="Neumann-Mesh" from="Neumann" />
+    <write-data name="Heat-Flux" mesh="Dirichlet-Mesh" />
+    <read-data name="Temperature" mesh="Dirichlet-Mesh" />
+    <mapping:rbf
+      direction="read"
+      from="Neumann-Mesh"
+      to="Dirichlet-Mesh"
+      constraint="consistent"
+      x-dead="true">
+      <basis-function:thin-plate-splines />
+    </mapping-rbf>
+  </participant>
 
-    <participant name="Neumann">
-      <provide-mesh name="Neumann-Mesh" />
-      <receive-mesh name="Dirichlet-Mesh" from="Dirichlet" />
-      <write-data name="Temperature" mesh="Neumann-Mesh" />
-      <read-data name="Heat-Flux" mesh="Neumann-Mesh" />
-      <mapping:rbf
-        direction="read"
-        from="Dirichlet-Mesh"
-        to="Neumann-Mesh"
-        constraint="consistent"
-        x-dead="true" >
-        <basis-function:thin-plate-splines />
-      </mapping:rbf>
-    </participant>
+  <participant name="Neumann">
+    <provide-mesh name="Neumann-Mesh" />
+    <receive-mesh name="Dirichlet-Mesh" from="Dirichlet" />
+    <write-data name="Temperature" mesh="Neumann-Mesh" />
+    <read-data name="Heat-Flux" mesh="Neumann-Mesh" />
+    <mapping:rbf
+      direction="read"
+      from="Dirichlet-Mesh"
+      to="Neumann-Mesh"
+      constraint="consistent"
+      x-dead="true" >
+      <basis-function:thin-plate-splines />
+    </mapping:rbf>
+  </participant>
 
-    <m2n:sockets acceptor="Dirichlet" connector="Neumann" exchange-directory=".." />
+  <m2n:sockets acceptor="Dirichlet" connector="Neumann" exchange-directory=".." />
 
-    <coupling-scheme:serial-implicit>
-      <participants first="Dirichlet" second="Neumann" />
-      <max-time value="1.0" />
-      <time-window-size value="0.1" />
-      <max-iterations value="100" />
-      <exchange data="Heat-Flux" mesh="Dirichlet-Mesh" from="Dirichlet" to="Neumann" />
-      <exchange
-        data="Temperature"
-        mesh="Neumann-Mesh"
-        from="Neumann"
-        to="Dirichlet"
-        initialize="true" />
-      <relative-convergence-measure data="Heat-Flux" mesh="Dirichlet-Mesh" limit="1e-5" />
-      <relative-convergence-measure data="Temperature" mesh="Neumann-Mesh" limit="1e-5" />
-      <acceleration:IQN-ILS>
-        <data name="Temperature" mesh="Neumann-Mesh" />
-        <initial-relaxation value="0.1" />
-        <max-used-iterations value="10" />
-        <time-windows-reused value="5" />
-        <filter type="QR2" limit="1e-3" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:serial-implicit>
-  </solver-interface>
+  <coupling-scheme:serial-implicit>
+    <participants first="Dirichlet" second="Neumann" />
+    <max-time value="1.0" />
+    <time-window-size value="0.1" />
+    <max-iterations value="100" />
+    <exchange data="Heat-Flux" mesh="Dirichlet-Mesh" from="Dirichlet" to="Neumann" />
+    <exchange
+      data="Temperature"
+      mesh="Neumann-Mesh"
+      from="Neumann"
+      to="Dirichlet"
+      initialize="true" />
+    <relative-convergence-measure data="Heat-Flux" mesh="Dirichlet-Mesh" limit="1e-5" />
+    <relative-convergence-measure data="Temperature" mesh="Neumann-Mesh" limit="1e-5" />
+    <acceleration:IQN-ILS>
+      <data name="Temperature" mesh="Neumann-Mesh" />
+      <initial-relaxation value="0.1" />
+      <max-used-iterations value="10" />
+      <time-windows-reused value="5" />
+      <filter type="QR2" limit="1e-3" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/partitioned-pipe/precice-config.xml
+++ b/partitioned-pipe/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="3">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,73 +7,71 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="3">
-    <data:vector name="VelocityGradient" />
-    <data:scalar name="Pressure" />
-    <data:vector name="Velocity" />
-    <data:scalar name="PressureGradient" />
+  <data:vector name="VelocityGradient" />
+  <data:scalar name="Pressure" />
+  <data:vector name="Velocity" />
+  <data:scalar name="PressureGradient" />
 
-    <mesh name="Fluid1-Mesh">
-      <use-data name="VelocityGradient" />
-      <use-data name="Pressure" />
-      <use-data name="Velocity" />
-      <use-data name="PressureGradient" />
-    </mesh>
+  <mesh name="Fluid1-Mesh">
+    <use-data name="VelocityGradient" />
+    <use-data name="Pressure" />
+    <use-data name="Velocity" />
+    <use-data name="PressureGradient" />
+  </mesh>
 
-    <mesh name="Fluid2-Mesh">
-      <use-data name="VelocityGradient" />
-      <use-data name="Pressure" />
-      <use-data name="Velocity" />
-      <use-data name="PressureGradient" />
-    </mesh>
+  <mesh name="Fluid2-Mesh">
+    <use-data name="VelocityGradient" />
+    <use-data name="Pressure" />
+    <use-data name="Velocity" />
+    <use-data name="PressureGradient" />
+  </mesh>
 
-    <participant name="Fluid1">
-      <provide-mesh name="Fluid1-Mesh" />
-      <receive-mesh name="Fluid2-Mesh" from="Fluid2" />
-      <write-data name="Velocity" mesh="Fluid1-Mesh" />
-      <write-data name="PressureGradient" mesh="Fluid1-Mesh" />
-      <read-data name="Pressure" mesh="Fluid1-Mesh" />
-      <read-data name="VelocityGradient" mesh="Fluid1-Mesh" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid2-Mesh"
-        to="Fluid1-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid1">
+    <provide-mesh name="Fluid1-Mesh" />
+    <receive-mesh name="Fluid2-Mesh" from="Fluid2" />
+    <write-data name="Velocity" mesh="Fluid1-Mesh" />
+    <write-data name="PressureGradient" mesh="Fluid1-Mesh" />
+    <read-data name="Pressure" mesh="Fluid1-Mesh" />
+    <read-data name="VelocityGradient" mesh="Fluid1-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid2-Mesh"
+      to="Fluid1-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <participant name="Fluid2">
-      <provide-mesh name="Fluid2-Mesh" />
-      <receive-mesh name="Fluid1-Mesh" from="Fluid1" />
-      <read-data name="Velocity" mesh="Fluid2-Mesh" />
-      <read-data name="PressureGradient" mesh="Fluid2-Mesh" />
-      <write-data name="Pressure" mesh="Fluid2-Mesh" />
-      <write-data name="VelocityGradient" mesh="Fluid2-Mesh" />
-      <mapping:nearest-neighbor
-        direction="read"
-        from="Fluid1-Mesh"
-        to="Fluid2-Mesh"
-        constraint="consistent" />
-    </participant>
+  <participant name="Fluid2">
+    <provide-mesh name="Fluid2-Mesh" />
+    <receive-mesh name="Fluid1-Mesh" from="Fluid1" />
+    <read-data name="Velocity" mesh="Fluid2-Mesh" />
+    <read-data name="PressureGradient" mesh="Fluid2-Mesh" />
+    <write-data name="Pressure" mesh="Fluid2-Mesh" />
+    <write-data name="VelocityGradient" mesh="Fluid2-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="Fluid1-Mesh"
+      to="Fluid2-Mesh"
+      constraint="consistent" />
+  </participant>
 
-    <m2n:sockets acceptor="Fluid1" connector="Fluid2" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid1" connector="Fluid2" exchange-directory=".." />
 
-    <coupling-scheme:serial-implicit>
-      <time-window-size value="0.01" />
-      <max-time value="1.0" />
-      <participants first="Fluid1" second="Fluid2" />
-      <exchange data="Velocity" mesh="Fluid1-Mesh" from="Fluid1" to="Fluid2" />
-      <!-- <exchange data="PressureGradient" mesh="Fluid1-Mesh" from="Fluid1" to="Fluid2" /> -->
-      <exchange data="Pressure" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" />
-      <max-iterations value="100" />
-      <relative-convergence-measure limit="1.0e-6" data="Pressure" mesh="Fluid2-Mesh" />
-      <relative-convergence-measure limit="1.0e-6" data="Velocity" mesh="Fluid1-Mesh" />
-      <acceleration:IQN-ILS>
-        <data mesh="Fluid2-Mesh" name="Pressure" />
-        <initial-relaxation value="0.01" />
-        <max-used-iterations value="80" />
-        <time-windows-reused value="10" />
-        <filter type="QR1" limit="1e-8" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:serial-implicit>
-  </solver-interface>
+  <coupling-scheme:serial-implicit>
+    <time-window-size value="0.01" />
+    <max-time value="1.0" />
+    <participants first="Fluid1" second="Fluid2" />
+    <exchange data="Velocity" mesh="Fluid1-Mesh" from="Fluid1" to="Fluid2" />
+    <!-- <exchange data="PressureGradient" mesh="Fluid1-Mesh" from="Fluid1" to="Fluid2" /> -->
+    <exchange data="Pressure" mesh="Fluid2-Mesh" from="Fluid2" to="Fluid1" />
+    <max-iterations value="100" />
+    <relative-convergence-measure limit="1.0e-6" data="Pressure" mesh="Fluid2-Mesh" />
+    <relative-convergence-measure limit="1.0e-6" data="Velocity" mesh="Fluid1-Mesh" />
+    <acceleration:IQN-ILS>
+      <data mesh="Fluid2-Mesh" name="Pressure" />
+      <initial-relaxation value="0.01" />
+      <max-used-iterations value="80" />
+      <time-windows-reused value="10" />
+      <filter type="QR1" limit="1e-8" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/perpendicular-flap/precice-config.xml
+++ b/perpendicular-flap/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<precice-configuration>
+<precice-configuration dimensions="2">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,60 +7,58 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:vector name="Force" />
-    <data:vector name="Displacement" />
+  <data:vector name="Force" />
+  <data:vector name="Displacement" />
 
-    <mesh name="Fluid-Mesh">
-      <use-data name="Force" />
-      <use-data name="Displacement" />
-    </mesh>
+  <mesh name="Fluid-Mesh">
+    <use-data name="Force" />
+    <use-data name="Displacement" />
+  </mesh>
 
-    <mesh name="Solid-Mesh">
-      <use-data name="Displacement" />
-      <use-data name="Force" />
-    </mesh>
+  <mesh name="Solid-Mesh">
+    <use-data name="Displacement" />
+    <use-data name="Force" />
+  </mesh>
 
-    <participant name="Fluid">
-      <provide-mesh name="Fluid-Mesh" />
-      <receive-mesh name="Solid-Mesh" from="Solid" />
-      <write-data name="Force" mesh="Fluid-Mesh" />
-      <read-data name="Displacement" mesh="Fluid-Mesh" />
-      <mapping:rbf direction="write" from="Fluid-Mesh" to="Solid-Mesh" constraint="conservative">
-        <basis-function:compact-polynomial-c6 support-radius="1." />
-      </mapping:rbf>
-      <mapping:rbf direction="read" from="Solid-Mesh" to="Fluid-Mesh" constraint="consistent">
-        <basis-function:compact-polynomial-c6 support-radius="1." />
-      </mapping:rbf>
-    </participant>
+  <participant name="Fluid">
+    <provide-mesh name="Fluid-Mesh" />
+    <receive-mesh name="Solid-Mesh" from="Solid" />
+    <write-data name="Force" mesh="Fluid-Mesh" />
+    <read-data name="Displacement" mesh="Fluid-Mesh" />
+    <mapping:rbf direction="write" from="Fluid-Mesh" to="Solid-Mesh" constraint="conservative">
+      <basis-function:compact-polynomial-c6 support-radius="1." />
+    </mapping:rbf>
+    <mapping:rbf direction="read" from="Solid-Mesh" to="Fluid-Mesh" constraint="consistent">
+      <basis-function:compact-polynomial-c6 support-radius="1." />
+    </mapping:rbf>
+  </participant>
 
-    <participant name="Solid">
-      <provide-mesh name="Solid-Mesh" />
-      <write-data name="Displacement" mesh="Solid-Mesh" />
-      <read-data name="Force" mesh="Solid-Mesh" />
-      <watch-point mesh="Solid-Mesh" name="Flap-Tip" coordinate="0.0;1" />
-    </participant>
+  <participant name="Solid">
+    <provide-mesh name="Solid-Mesh" />
+    <write-data name="Displacement" mesh="Solid-Mesh" />
+    <read-data name="Force" mesh="Solid-Mesh" />
+    <watch-point mesh="Solid-Mesh" name="Flap-Tip" coordinate="0.0;1" />
+  </participant>
 
-    <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
 
-    <coupling-scheme:parallel-implicit>
-      <time-window-size value="0.01" />
-      <max-time value="5" />
-      <participants first="Fluid" second="Solid" />
-      <exchange data="Force" mesh="Solid-Mesh" from="Fluid" to="Solid" />
-      <exchange data="Displacement" mesh="Solid-Mesh" from="Solid" to="Fluid" />
-      <max-iterations value="50" />
-      <relative-convergence-measure limit="5e-3" data="Displacement" mesh="Solid-Mesh" />
-      <relative-convergence-measure limit="5e-3" data="Force" mesh="Solid-Mesh" />
-      <acceleration:IQN-ILS>
-        <data name="Displacement" mesh="Solid-Mesh" />
-        <data name="Force" mesh="Solid-Mesh" />
-        <preconditioner type="residual-sum" />
-        <filter type="QR2" limit="1e-2" />
-        <initial-relaxation value="0.5" />
-        <max-used-iterations value="100" />
-        <time-windows-reused value="15" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  <coupling-scheme:parallel-implicit>
+    <time-window-size value="0.01" />
+    <max-time value="5" />
+    <participants first="Fluid" second="Solid" />
+    <exchange data="Force" mesh="Solid-Mesh" from="Fluid" to="Solid" />
+    <exchange data="Displacement" mesh="Solid-Mesh" from="Solid" to="Fluid" />
+    <max-iterations value="50" />
+    <relative-convergence-measure limit="5e-3" data="Displacement" mesh="Solid-Mesh" />
+    <relative-convergence-measure limit="5e-3" data="Force" mesh="Solid-Mesh" />
+    <acceleration:IQN-ILS>
+      <data name="Displacement" mesh="Solid-Mesh" />
+      <data name="Force" mesh="Solid-Mesh" />
+      <preconditioner type="residual-sum" />
+      <filter type="QR2" limit="1e-2" />
+      <initial-relaxation value="0.5" />
+      <max-used-iterations value="100" />
+      <time-windows-reused value="15" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:parallel-implicit>
 </precice-configuration>

--- a/quickstart/precice-config.xml
+++ b/quickstart/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<precice-configuration>
+<precice-configuration dimensions="2">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,59 +7,57 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:vector name="Force" />
-    <data:vector name="Displacement" />
+  <data:vector name="Force" />
+  <data:vector name="Displacement" />
 
-    <mesh name="Fluid-Mesh">
-      <use-data name="Force" />
-      <use-data name="Displacement" />
-    </mesh>
+  <mesh name="Fluid-Mesh">
+    <use-data name="Force" />
+    <use-data name="Displacement" />
+  </mesh>
 
-    <mesh name="Solid-Mesh">
-      <use-data name="Displacement" />
-      <use-data name="Force" />
-    </mesh>
+  <mesh name="Solid-Mesh">
+    <use-data name="Displacement" />
+    <use-data name="Force" />
+  </mesh>
 
-    <participant name="Fluid">
-      <provide-mesh name="Fluid-Mesh" />
-      <receive-mesh name="Solid-Mesh" from="Solid" />
-      <read-data name="Displacement" mesh="Fluid-Mesh" />
-      <write-data name="Force" mesh="Fluid-Mesh" />
-      <mapping:rbf direction="read" from="Solid-Mesh" to="Fluid-Mesh" constraint="consistent">
-        <basis-function:thin-plate-splines />
-      </mapping:rbf>
-      <mapping:rbf direction="write" from="Fluid-Mesh" to="Solid-Mesh" constraint="conservative">
-        <basis-function:thin-plate-splines />
-      </mapping:rbf>
-    </participant>
+  <participant name="Fluid">
+    <provide-mesh name="Fluid-Mesh" />
+    <receive-mesh name="Solid-Mesh" from="Solid" />
+    <read-data name="Displacement" mesh="Fluid-Mesh" />
+    <write-data name="Force" mesh="Fluid-Mesh" />
+    <mapping:rbf direction="read" from="Solid-Mesh" to="Fluid-Mesh" constraint="consistent">
+      <basis-function:thin-plate-splines />
+    </mapping:rbf>
+    <mapping:rbf direction="write" from="Fluid-Mesh" to="Solid-Mesh" constraint="conservative">
+      <basis-function:thin-plate-splines />
+    </mapping:rbf>
+  </participant>
 
-    <participant name="Solid">
-      <provide-mesh name="Solid-Mesh" />
-      <read-data name="Force" mesh="Solid-Mesh" />
-      <write-data name="Displacement" mesh="Solid-Mesh" />
-      <watch-point mesh="Solid-Mesh" name="Flap-Tip" coordinate="0.25;0.0" />
-      <export:vtk directory="coupling-meshes" />
-    </participant>
+  <participant name="Solid">
+    <provide-mesh name="Solid-Mesh" />
+    <read-data name="Force" mesh="Solid-Mesh" />
+    <write-data name="Displacement" mesh="Solid-Mesh" />
+    <watch-point mesh="Solid-Mesh" name="Flap-Tip" coordinate="0.25;0.0" />
+    <export:vtk directory="coupling-meshes" />
+  </participant>
 
-    <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
 
-    <coupling-scheme:serial-implicit>
-      <time-window-size value="2.5e-2" />
-      <max-time value="2.5" />
-      <participants first="Fluid" second="Solid" />
-      <exchange data="Force" mesh="Solid-Mesh" from="Fluid" to="Solid" />
-      <exchange data="Displacement" mesh="Solid-Mesh" from="Solid" to="Fluid" />
-      <max-iterations value="10" />
-      <relative-convergence-measure limit="1e-3" data="Displacement" mesh="Solid-Mesh" />
-      <acceleration:IQN-ILS>
-        <data name="Displacement" mesh="Solid-Mesh" />
-        <preconditioner type="residual-sum" />
-        <filter type="QR2" limit="5.0e-5" />
-        <initial-relaxation value="0.3" />
-        <max-used-iterations value="15" />
-        <time-windows-reused value="2" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:serial-implicit>
-  </solver-interface>
+  <coupling-scheme:serial-implicit>
+    <time-window-size value="2.5e-2" />
+    <max-time value="2.5" />
+    <participants first="Fluid" second="Solid" />
+    <exchange data="Force" mesh="Solid-Mesh" from="Fluid" to="Solid" />
+    <exchange data="Displacement" mesh="Solid-Mesh" from="Solid" to="Fluid" />
+    <max-iterations value="10" />
+    <relative-convergence-measure limit="1e-3" data="Displacement" mesh="Solid-Mesh" />
+    <acceleration:IQN-ILS>
+      <data name="Displacement" mesh="Solid-Mesh" />
+      <preconditioner type="residual-sum" />
+      <filter type="QR2" limit="5.0e-5" />
+      <initial-relaxation value="0.3" />
+      <max-used-iterations value="15" />
+      <time-windows-reused value="2" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/turek-hron-fsi3/precice-config.xml
+++ b/turek-hron-fsi3/precice-config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<precice-configuration>
+<precice-configuration dimensions="2">
   <log>
     <sink
       filter="%Severity% > debug and %Rank% = 0"
@@ -7,70 +7,68 @@
       enabled="true" />
   </log>
 
-  <solver-interface dimensions="2">
-    <data:vector name="Stress" />
-    <data:vector name="Displacement" />
+  <data:vector name="Stress" />
+  <data:vector name="Displacement" />
 
-    <mesh name="Fluid-Mesh-Centers">
-      <use-data name="Stress" />
-    </mesh>
+  <mesh name="Fluid-Mesh-Centers">
+    <use-data name="Stress" />
+  </mesh>
 
-    <mesh name="Fluid-Mesh-Nodes">
-      <use-data name="Displacement" />
-    </mesh>
+  <mesh name="Fluid-Mesh-Nodes">
+    <use-data name="Displacement" />
+  </mesh>
 
-    <mesh name="Solid-Mesh">
-      <use-data name="Displacement" />
-      <use-data name="Stress" />
-    </mesh>
+  <mesh name="Solid-Mesh">
+    <use-data name="Displacement" />
+    <use-data name="Stress" />
+  </mesh>
 
-    <participant name="Fluid">
-      <provide-mesh name="Fluid-Mesh-Nodes" />
-      <provide-mesh name="Fluid-Mesh-Centers" />
-      <receive-mesh name="Solid-Mesh" from="Solid" />
-      <read-data name="Displacement" mesh="Fluid-Mesh-Nodes" />
-      <write-data name="Stress" mesh="Fluid-Mesh-Centers" />
-      <mapping:rbf direction="read" from="Solid-Mesh" to="Fluid-Mesh-Nodes" constraint="consistent">
-        <basis-function:compact-polynomial-c6 support-radius="0.35" />
-      </mapping:rbf>
-    </participant>
+  <participant name="Fluid">
+    <provide-mesh name="Fluid-Mesh-Nodes" />
+    <provide-mesh name="Fluid-Mesh-Centers" />
+    <receive-mesh name="Solid-Mesh" from="Solid" />
+    <read-data name="Displacement" mesh="Fluid-Mesh-Nodes" />
+    <write-data name="Stress" mesh="Fluid-Mesh-Centers" />
+    <mapping:rbf direction="read" from="Solid-Mesh" to="Fluid-Mesh-Nodes" constraint="consistent">
+      <basis-function:compact-polynomial-c6 support-radius="0.35" />
+    </mapping:rbf>
+  </participant>
 
-    <participant name="Solid">
-      <provide-mesh name="Solid-Mesh" />
-      <receive-mesh name="Fluid-Mesh-Centers" from="Fluid" />
-      <read-data name="Stress" mesh="Solid-Mesh" />
-      <write-data name="Displacement" mesh="Solid-Mesh" />
-      <watch-point mesh="Solid-Mesh" name="Flap-Tip" coordinate="0.6;0.2" />
-      <mapping:rbf
-        direction="read"
-        from="Fluid-Mesh-Centers"
-        to="Solid-Mesh"
-        constraint="consistent">
-        <basis-function:compact-polynomial-c6 support-radius="0.35" />
-      </mapping:rbf>
-    </participant>
+  <participant name="Solid">
+    <provide-mesh name="Solid-Mesh" />
+    <receive-mesh name="Fluid-Mesh-Centers" from="Fluid" />
+    <read-data name="Stress" mesh="Solid-Mesh" />
+    <write-data name="Displacement" mesh="Solid-Mesh" />
+    <watch-point mesh="Solid-Mesh" name="Flap-Tip" coordinate="0.6;0.2" />
+    <mapping:rbf
+      direction="read"
+      from="Fluid-Mesh-Centers"
+      to="Solid-Mesh"
+      constraint="consistent">
+      <basis-function:compact-polynomial-c6 support-radius="0.35" />
+    </mapping:rbf>
+  </participant>
 
-    <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />
 
-    <coupling-scheme:parallel-implicit>
-      <time-window-size value="1e-3" />
-      <max-time value="15" />
-      <participants first="Fluid" second="Solid" />
-      <exchange data="Stress" mesh="Fluid-Mesh-Centers" from="Fluid" to="Solid" />
-      <exchange data="Displacement" mesh="Solid-Mesh" from="Solid" to="Fluid" />
-      <max-iterations value="100" />
-      <relative-convergence-measure limit="1e-4" data="Stress" mesh="Fluid-Mesh-Centers" />
-      <relative-convergence-measure limit="1e-4" data="Displacement" mesh="Solid-Mesh" />
-      <extrapolation-order value="2" />
-      <acceleration:IQN-ILS>
-        <data name="Displacement" mesh="Solid-Mesh" />
-        <data name="Stress" mesh="Fluid-Mesh-Centers" />
-        <preconditioner type="residual-sum" />
-        <filter type="QR2" limit="1.2e-3" />
-        <initial-relaxation value="0.1" />
-        <max-used-iterations value="60" />
-        <time-windows-reused value="15" />
-      </acceleration:IQN-ILS>
-    </coupling-scheme:parallel-implicit>
-  </solver-interface>
+  <coupling-scheme:parallel-implicit>
+    <time-window-size value="1e-3" />
+    <max-time value="15" />
+    <participants first="Fluid" second="Solid" />
+    <exchange data="Stress" mesh="Fluid-Mesh-Centers" from="Fluid" to="Solid" />
+    <exchange data="Displacement" mesh="Solid-Mesh" from="Solid" to="Fluid" />
+    <max-iterations value="100" />
+    <relative-convergence-measure limit="1e-4" data="Stress" mesh="Fluid-Mesh-Centers" />
+    <relative-convergence-measure limit="1e-4" data="Displacement" mesh="Solid-Mesh" />
+    <extrapolation-order value="2" />
+    <acceleration:IQN-ILS>
+      <data name="Displacement" mesh="Solid-Mesh" />
+      <data name="Stress" mesh="Fluid-Mesh-Centers" />
+      <preconditioner type="residual-sum" />
+      <filter type="QR2" limit="1.2e-3" />
+      <initial-relaxation value="0.1" />
+      <max-used-iterations value="60" />
+      <time-windows-reused value="15" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:parallel-implicit>
 </precice-configuration>

--- a/volume-coupled-diffusion/precice-config.xml
+++ b/volume-coupled-diffusion/precice-config.xml
@@ -1,69 +1,64 @@
 <?xml version="1.0"?>
 
-<precice-configuration>
-
+<precice-configuration dimensions="2">
   <log>
     <sink filter="%Severity% > debug and %Rank% = 0" format="---[precice] %ColorizedSeverity% %Message%" enabled="true"/>
   </log>
 
-  <solver-interface dimensions="2">
+  <data:scalar name="Drain-Data"/>
+  <data:scalar name="Source-Data"/>
 
-    <data:scalar name="Drain-Data"/>
-    <data:scalar name="Source-Data"/>
+  <mesh name="Source-Mesh">
+    <use-data name="Drain-Data"/>
+    <use-data name="Source-Data"/>
+  </mesh>
 
-    <mesh name="Source-Mesh">
-      <use-data name="Drain-Data"/>
-      <use-data name="Source-Data"/>
-    </mesh>
+  <mesh name="Drain-Mesh">
+    <use-data name="Drain-Data"/>
+    <use-data name="Source-Data"/>
+  </mesh>
 
-    <mesh name="Drain-Mesh">
-      <use-data name="Drain-Data"/>
-      <use-data name="Source-Data"/>
-    </mesh>
+  <participant name="Source">
+    <provide-mesh name="Source-Mesh" />
+    <receive-mesh name="Drain-Mesh" from="Drain"/>
+    <write-data name="Source-Data" mesh="Source-Mesh"/>
+    <read-data name="Drain-Data" mesh="Source-Mesh"/>
+    <mapping:rbf direction="read" from="Drain-Mesh" to="Source-Mesh" constraint="consistent" >
+      <basis-function:compact-polynomial-c6 support-radius="1" />
+    </mapping:rbf>
+  </participant>
 
-    <participant name="Source">
-      <provide-mesh name="Source-Mesh" />
-      <receive-mesh name="Drain-Mesh" from="Drain"/>
-      <write-data name="Source-Data" mesh="Source-Mesh"/>
-      <read-data name="Drain-Data" mesh="Source-Mesh"/>
-      <mapping:rbf direction="read" from="Drain-Mesh" to="Source-Mesh" constraint="consistent" >
-        <basis-function:compact-polynomial-c6 support-radius="1" />
-      </mapping:rbf>
-    </participant>
+  <participant name="Drain">
+    <provide-mesh name="Drain-Mesh" />
+    <receive-mesh name="Source-Mesh" from="Source"/>
+    <write-data name="Drain-Data" mesh="Drain-Mesh"/>
+    <read-data name="Source-Data" mesh="Drain-Mesh"/>
+    <mapping:rbf
+      direction="read"
+      from="Source-Mesh"
+      to="Drain-Mesh"
+      constraint="consistent">
+      <basis-function:compact-polynomial-c6 support-radius="1" />
+    </mapping:rbf>
+  </participant>
 
-    <participant name="Drain">
-      <provide-mesh name="Drain-Mesh" />
-      <receive-mesh name="Source-Mesh" from="Source"/>
-      <write-data name="Drain-Data" mesh="Drain-Mesh"/>
-      <read-data name="Source-Data" mesh="Drain-Mesh"/>
-      <mapping:rbf
-        direction="read"
-        from="Source-Mesh"
-        to="Drain-Mesh"
-        constraint="consistent">
-        <basis-function:compact-polynomial-c6 support-radius="1" />
-      </mapping:rbf>
-    </participant>
+  <m2n:sockets acceptor="Source" connector="Drain" exchange-directory=".."/>
 
-    <m2n:sockets acceptor="Source" connector="Drain" exchange-directory=".."/>
-
-    <coupling-scheme:serial-implicit>
-      <participants first="Source" second="Drain"/>
-      <max-time value="10.0"/>
-      <time-window-size value="0.1"/>
-      <max-iterations value="100"/>
-      <exchange data="Source-Data" mesh="Source-Mesh" from="Source" to="Drain" />
-      <exchange data="Drain-Data" mesh="Drain-Mesh" from="Drain" to="Source" initialize="true"/>
-      <relative-convergence-measure data="Source-Data" mesh="Source-Mesh" limit="1e-5"/>
-      <relative-convergence-measure data="Drain-Data" mesh="Drain-Mesh" limit="1e-5"/>
-      <acceleration:IQN-ILS>
-        <data name="Drain-Data" mesh="Drain-Mesh"/>
-        <initial-relaxation value="0.1"/>
-        <max-used-iterations value="10"/>
-        <time-windows-reused value="5"/>
-        <filter type="QR2" limit="1e-3"/>
-      </acceleration:IQN-ILS>
-    </coupling-scheme:serial-implicit>
-
-  </solver-interface>
+  <coupling-scheme:serial-implicit>
+    <participants first="Source" second="Drain"/>
+    <max-time value="10.0"/>
+    <time-window-size value="0.1"/>
+    <max-iterations value="100"/>
+    <exchange data="Source-Data" mesh="Source-Mesh" from="Source" to="Drain" />
+    <exchange data="Drain-Data" mesh="Drain-Mesh" from="Drain" to="Source" initialize="true"/>
+    <relative-convergence-measure data="Source-Data" mesh="Source-Mesh" limit="1e-5"/>
+    <relative-convergence-measure data="Drain-Data" mesh="Drain-Mesh" limit="1e-5"/>
+    <acceleration:IQN-ILS>
+      <data name="Drain-Data" mesh="Drain-Mesh"/>
+      <initial-relaxation value="0.1"/>
+      <max-used-iterations value="10"/>
+      <time-windows-reused value="5"/>
+      <filter type="QR2" limit="1e-3"/>
+    </acceleration:IQN-ILS>
+  </coupling-scheme:serial-implicit>
 </precice-configuration>


### PR DESCRIPTION
Following https://github.com/precice/precice/pull/1662

@davidscn please do a quick sanity check. I think that all other changes (that have already been merged in preCICE - the location of dimensions should follow) have been ported already.
