### PR TITLE
Fixed Docker compose root user problem #354

### DIFF
--- a/tools/tests/component-templates/fenics-adapter.yaml
+++ b/tools/tests/component-templates/fenics-adapter.yaml
@@ -1,5 +1,5 @@
 image: precice/fenics-adapter:{{ params["FENICS_ADAPTER_REF"] }}
-user: ${UID}:${UID}
+user: ${UID}:${GID}
 depends_on:    
   prepare:
     condition: service_completed_successfully

--- a/tools/tests/component-templates/nutils-adapter.yaml
+++ b/tools/tests/component-templates/nutils-adapter.yaml
@@ -1,5 +1,5 @@
 image: "ghcr.io/precice/openfoam-adapter:{{ params["openfoam-adapter-ref"] }}" # TODO: Update
-user: ${MY_UID}:${MY_GID}
+user: ${UID}:${GID}
 depends_on:    
   prepare:
     condition: service_completed_successfully

--- a/tools/tests/component-templates/openfoam-adapter.yaml
+++ b/tools/tests/component-templates/openfoam-adapter.yaml
@@ -3,8 +3,8 @@ build:
   args:
     {% for key, value in build_args.items() %}
       - {{key}}={{value}}
-   {% endfor %}
-user: ${UID}:${UID}
+    {% endfor %}
+user: ${UID}:${GID}
 depends_on:    
   prepare:
     condition: service_completed_successfully

--- a/tools/tests/docker-compose.template.yaml
+++ b/tools/tests/docker-compose.template.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 services:
   prepare:
     image: ubuntu:latest
-    user: ${MY_UID}:${MY_GID}
+    user: ${UID}:${GID}
     volumes:
       - /etc/passwd:/etc/passwd:ro #TODO: Maybe move those into a more general section ? 
       - /etc/group:/etc/group:ro
@@ -15,7 +15,7 @@ services:
       sed -i 's|m2n:sockets from|m2n:sockets network=\"eth0\" from|g' precice-config.xml &&
       cat precice-config.xml"
 
-  
+
   {% for service in services %}
   {{ service }}:
     {{ services[service] |indent(4) }}


### PR DESCRIPTION
This solves #354

Solution: 
- first get the User & Group ID of the current user via a subprocess call
- write out a .env file 
- docker compose will then use this and substitute ${UID} and ${GID}

It did not break the action:  see https://github.com/precice/tutorials/actions/runs/5740269267 