### PR TITLE
Add FEniCS adapter

### DIFF
--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -101,8 +101,8 @@ This `openfoam-adapter` component has the following attributes:
 
 Since the docker containers are still a bit mixed in terms of capabilities and support for different build_argument combinations the following rules apply:
 
-- A build_argument ending in **_TAG** means that a image of some kind needs to be available with that tag.
-- A build_argument ending in **_REF** means that it refers to a git reference (like a branch or commit) beeing used to built.
+- A build_argument ending in **_TAG** means that an image of some kind needs to be available with that tag.
+- A build_argument ending in **_REF** means that it refers to a git reference (like a branch or commit) beeing used to build the image.
 - All other build_arguments are free of rules and up to the container maintainer.
 
 ### Component templates

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -78,17 +78,17 @@ The components mentioned in the Metadata are defined in the central `components.
 openfoam-adapter:
   repository: https://github.com/precice/openfoam-adapter
   template: component-templates/openfoam-adapter.yaml
-  build-arguments: # these things mean something to the docker-service
+  build_arguments: # these things mean something to the docker-service
     OPENFOAM_EXECUTABLE:
-      options: ["openfoam2306"]
-      description: exectuable of OpenFOAM to use
-      default: "openfoam2306"
+      options: ["openfoam2112"]
+      description: exectuable of openfoam to use
+      default: "openfoam2112"
     PRECICE_TAG:
-      description: Version of precice to use
+      description: Version of preCICE to use
       default: "latest"
-    OPENFOAM_ADAPTER_TAG:
-      description: Ref of the actual OpenFOAM adapter
-      default: "latest"
+    OPENFOAM_ADAPTER_REF:
+      description: Reference/tag of the actual OpenFOAM adapter
+      default: "master"
 ```
 
 This `openfoam-adapter` component has the following attributes:
@@ -97,13 +97,21 @@ This `openfoam-adapter` component has the following attributes:
 - `template`: A template for a Docker Compose service of this component
 - `build-arguments`: Arguments passed to the Docker Compose service (arbitrary)
 
+#### Naming schema for build_arguments
+
+Since the docker containers are still a bit mixed in terms of capabilities and support for different build_argument combinations the following rules apply:
+
+- A build_argument ending in **_TAG** means that a image of some kind needs to be available with that tag.
+- A build_argument ending in **_REF** means that it refers to a git reference (like a branch or commit) beeing used to built.
+- All other build_arguments are free of rules and up to the container maintainer.
+
 ### Component templates
 
 Templates for defining a Docker Compose service for each component are available in `component-templates/`. For example:
 
 ```yaml
-image: "ghcr.io/precice/openfoam-adapter:{{ params["openfoam-adapter-ref"] }}"
-user: ${MY_UID}:${MY_GID}
+image: precice/fenics-adapter:{{ params["FENICS_ADAPTER_REF"] }}
+user: ${UID}:${GID}
 depends_on:    
   prepare:
     condition: service_completed_successfully
@@ -114,7 +122,7 @@ volumes:
 command: >
   /bin/bash -c "id && 
   cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
-  {{ params["openfoam-exectuable"] }} {{ run }} | tee {{ case_folder }}.log 2>&1"
+  {{ run }} | tee {{ case_folder }}.log 2>&1"
 ```
 
 This template defines:

--- a/tools/tests/component-templates/fenics-adapter.yaml
+++ b/tools/tests/component-templates/fenics-adapter.yaml
@@ -1,4 +1,4 @@
-image: precice/fenics-adapter:{{ params["FENICS_ADAPTER_REF"] }}
+image: precice/fenics-adapter:{{ build_arguments["FENICS_ADAPTER_TAG"] }}
 user: ${UID}:${GID}
 depends_on:    
   prepare:

--- a/tools/tests/component-templates/nutils-adapter.yaml
+++ b/tools/tests/component-templates/nutils-adapter.yaml
@@ -1,4 +1,4 @@
-image: "ghcr.io/precice/openfoam-adapter:{{ params["openfoam-adapter-ref"] }}" # TODO: Update
+image: "ghcr.io/precice/openfoam-adapter:{{ build_arguments["openfoam-adapter-ref"] }}" # TODO: Update
 user: ${UID}:${GID}
 depends_on:    
   prepare:

--- a/tools/tests/component-templates/openfoam-adapter.yaml
+++ b/tools/tests/component-templates/openfoam-adapter.yaml
@@ -1,7 +1,7 @@
 build: 
   context: https://github.com/precice/openfoam-adapter.git#add-ci-docker:tools/docker
   args:
-    {% for key, value in build_args.items() %}
+    {% for key, value in build_arguments.items() %}
       - {{key}}={{value}}
     {% endfor %}
 user: ${UID}:${GID}

--- a/tools/tests/components.yaml
+++ b/tools/tests/components.yaml
@@ -1,7 +1,7 @@
 openfoam-adapter:
   repository: https://github.com/precice/openfoam-adapter
   template: component-templates/openfoam-adapter.yaml
-  build-arguments: # these things mean something to the docker-service
+  build_arguments: # these things mean something to the docker-service
     OPENFOAM_EXECUTABLE:
       options: ["openfoam2112"]
       description: exectuable of openfoam to use
@@ -16,21 +16,15 @@ openfoam-adapter:
 fenics-adapter:
   repository: https://github.com/precice/fenics-adapter
   template: component-templates/fenics-adapter.yaml
-  build-arguments:
-    PYTHON_BINDINGS_REF:
-      semnantic: Version of the Python bindings to use
-      default: "latest"
-    FENICS_ADAPTER_REF:
-      semnantic: Version of the fenics adapter to use
-      default: "latest"
-    PRECICE_TAG:
-      description: Version of preCICE to use
+  build_arguments:
+    FENICS_ADAPTER_TAG:
+      semnantic: Version of the fenics adapter image to use
       default: "latest"
 
 calculix-adapter:
   repository: https://github.com/precice/calculix-adapter
   template: component-templates/calculix-adapter.yaml
-  build-arguments:
+  build_arguments:
     PRECICE_TAG:
       description: Version of preCICE to use
       default: "latest"
@@ -40,7 +34,7 @@ calculix-adapter:
 nutils-adapter:
   repository: https://github.com/precice/nutils-adapter
   template: component-templates/nutils-adapter.yaml
-  build-arguments:
+  build_arguments:
     PRECICE_TAG:
       description: Version of preCICE to use
       default: "latest"

--- a/tools/tests/metadata_parser/metdata.py
+++ b/tools/tests/metadata_parser/metdata.py
@@ -60,7 +60,7 @@ class BuildArguments:
             data: The components YAML data.
         """
         arguments = []
-        for param_name, params in data['build-arguments'].items():
+        for param_name, params in data['build_arguments'].items():
             # TODO maybe **params
             description = params.get(
                 'description', f"No description provided for {param_name}")

--- a/tools/tests/systemtests/Systemtest.py
+++ b/tools/tests/systemtests/Systemtest.py
@@ -116,7 +116,7 @@ class Systemtest:
             render_dict = {
                 'run_directory': self.run_directory.resolve(),
                 'tutorial_folder': self.tutorial_folder,
-                'build_args': params_to_use,
+                'build_arguments': params_to_use,
                 'params': params_to_use,
                 'case_folder': case.path,
                 'run': case.run_cmd


### PR DESCRIPTION
In this PR i added preliminary support for the fenics adapter by using only the docker images published on docker hub. 
To execute it you can run the newly added fenics-test suite like: 
`python systemtests.py --suites=fenics-test`

I also renamed the build_arguments to be only called `build_arguments` and removed variations like `params` or `build_args` etc. 

This PR solves #352 
