### PR TITLE
Add precice-events to the cleaning scripts

### DIFF
--- a/tools/cleaning-tools.sh
+++ b/tools/cleaning-tools.sh
@@ -30,6 +30,7 @@ clean_precice_logs() {
             ./precice-*-convergence.log \
             ./precice-*-watchpoint-*.log \
             ./precice-*-watchintegral-*.log \
+            ./events.json \
             ./core
         rm -rfv ./precice-events/
     )

--- a/tools/cleaning-tools.sh
+++ b/tools/cleaning-tools.sh
@@ -28,9 +28,6 @@ clean_precice_logs() {
         echo "---- Cleaning up preCICE logs in $(pwd)"
         rm -fv ./precice-*-iterations.log \
             ./precice-*-convergence.log \
-            ./precice-*-events.json \
-            ./precice-*-events-summary.log \
-            ./precice-postProcessingInfo.log \
             ./precice-*-watchpoint-*.log \
             ./precice-*-watchintegral-*.log \
             ./core

--- a/tools/cleaning-tools.sh
+++ b/tools/cleaning-tools.sh
@@ -34,6 +34,7 @@ clean_precice_logs() {
             ./precice-*-watchpoint-*.log \
             ./precice-*-watchintegral-*.log \
             ./core
+        rm -rfv ./precice-events/
     )
 }
 


### PR DESCRIPTION
Deletes the `./precice-events/` directory in each case.

Also removes the previously specified `precice-*-events.json` and `precice-*-events-summary.log`, as well as the relic `precice-postProcessingInfo.log`.