### PR TITLE
Reduce verbosity in openfoam-remove-empty-dirs.sh

### DIFF
--- a/tools/openfoam-remove-empty-dirs.sh
+++ b/tools/openfoam-remove-empty-dirs.sh
@@ -1,13 +1,14 @@
 #! /bin/sh
 
+# Cleaning up stray functionObjectProperties files, see https://github.com/precice/openfoam-adapter/issues/26
 openfoam_remove_empty_dirs() {
 	(
 		set -e -u
-		echo "Looking for any time directories without results (e.g. stray functionObjectProperties files, see openfoam-adapter issue #26 on GitHub)..."
+		echo "Cleaning up any time directories without results"
 
 		for f in [0-9]* [0-9]*.[0-9]*; do
                         if ! [ -f "${f}/U" ] && ! [ -f "${f}/T" ] && ! [ -f "${f}/U.gz" ] && ! [ -f "${f}/T.gz" ] && ! [ -f "${f}/D" ] && ! [ -f "${f}/pointD" ] && ! [ -f "${f}/DD" ] && ! [ -f "${f}/pointDD" ] && ! [ -f "${f}/D.gz" ] && ! [ -f "${f}/pointD.gz" ] && ! [ -f "${f}/DD.gz" ] && ! [ -f "${f}/pointDD.gz" ]; then
-				rm -rfv "${f}"
+				rm -rf "${f}"
 			fi
 		done
 		if [ -d processor0 ]; then
@@ -15,11 +16,12 @@ openfoam_remove_empty_dirs() {
 				cd "${d}"
 				for f in [0-9]* [0-9]*.[0-9]*; do
                                         if ! [ -f "${f}/U" ] && ! [ -f "${f}/T" ] && ! [ -f "${f}/U.gz" ] && ! [ -f "${f}/T.gz" ] && ! [ -f "${f}/D" ] && ! [ -f "${f}/pointD" ] && ! [ -f "${f}/DD" ] && ! [ -f "${f}/pointDD" ] && ! [ -f "${f}/D.gz" ] && ! [ -f "${f}/pointD.gz" ] && ! [ -f "${f}/DD.gz" ] && ! [ -f "${f}/pointDD.gz" ]; then
-						rm -rfv "${f}"
+						rm -rf "${f}"
 					fi
 				done
 				cd ..
 			done
 		fi
+                echo "Done."
 	)
 }


### PR DESCRIPTION
At the moment, at the end of each OpenFOAM simulation, one gets a long list of deleted directories. This is not only confusing, but it also makes the log less readable (as we often just look at the tail). In the system tests, we want to include only the tail of the logs in the GitHub Actions screen output, which means we need to make the tail more useful.

This PR:

- Removes the `-v` option from the `rm` command when removing such empty dirs
- Moves the "see OpenFOAM adapter issue" in a comment, with a proper URL, since this is something that users typically should not need to see. It is also strange seeing it all the time, it makes it more important than it is.
- Adds a `Done.` message at the end.

@valentin-seitz maybe that would be something for you to quickly review. Do the changes make sense? How is the output now?