### PR TITLE
Use `mapping:nearest-neighbor` in partitioned heat conduction

### DIFF
--- a/partitioned-heat-conduction/precice-config.xml
+++ b/partitioned-heat-conduction/precice-config.xml
@@ -25,14 +25,7 @@
     <receive-mesh name="Neumann-Mesh" from="Neumann" />
     <write-data name="Heat-Flux" mesh="Dirichlet-Mesh" />
     <read-data name="Temperature" mesh="Dirichlet-Mesh" />
-    <mapping:rbf
-      direction="read"
-      from="Neumann-Mesh"
-      to="Dirichlet-Mesh"
-      constraint="consistent"
-      x-dead="true">
-      <basis-function:thin-plate-splines />
-    </mapping:rbf>
+    <mapping:nearest-neighbor direction="read" from="Neumann-Mesh" to="Dirichlet-Mesh" constraint="consistent" />
   </participant>
 
   <participant name="Neumann">
@@ -40,14 +33,7 @@
     <receive-mesh name="Dirichlet-Mesh" from="Dirichlet" />
     <write-data name="Temperature" mesh="Neumann-Mesh" />
     <read-data name="Heat-Flux" mesh="Neumann-Mesh" />
-    <mapping:rbf
-      direction="read"
-      from="Dirichlet-Mesh"
-      to="Neumann-Mesh"
-      constraint="consistent"
-      x-dead="true" >
-      <basis-function:thin-plate-splines />
-    </mapping:rbf>
+    <mapping:nearest-neighbor direction="read" from="Dirichlet-Mesh" to="Neumann-Mesh" constraint="consistent" />
   </participant>
 
   <m2n:sockets acceptor="Dirichlet" connector="Neumann" exchange-directory=".." />


### PR DESCRIPTION
<!-- Please submit your Pull Request to the `develop` branch.

It may help to have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

We should use nearest neighbor mapping here, because this is sufficient for this simple case with matching meshes. Also consistent with the description in the OpenFOAM adapter paper:

> Figure 6. ... The coupled scenario uses a nearest-neighbor mapping with matching interface nodes.


