### PR TITLE
Bugfix: Remove stray mesh from flow-over-heated-plate-two-meshes

### DIFF
--- a/flow-over-heated-plate-two-meshes/precice-config.xml
+++ b/flow-over-heated-plate-two-meshes/precice-config.xml
@@ -26,7 +26,6 @@
   <participant name="Fluid">
     <provide-mesh name="Fluid-Mesh" />
     <receive-mesh name="Solid-Mesh" from="Solid" />
-    <receive-mesh name="Solid-Mesh-nodes" from="Solid" />
     <read-data name="Heat-Flux" mesh="Fluid-Mesh" />
     <write-data name="Temperature" mesh="Fluid-Mesh" />
     <mapping:nearest-neighbor


### PR DESCRIPTION
This was making preCICE complain when the Fluid participant was running in parallel.

See https://precice.discourse.group/t/problem-to-run-openfoam-in-parallel/1652

Previously:

![precice-config](https://github.com/precice/tutorials/assets/4943683/ffaa6beb-485a-46bd-bfc0-14b198a961d1)
