### PR TITLE
Use overlapping schwarz for oscillator tutorial

### DIFF
--- a/oscillator/README.md
+++ b/oscillator/README.md
@@ -15,7 +15,7 @@ This tutorial solves a simple mass-spring oscillator with two masses and three s
 
 ![Schematic drawing of oscillator example](images/tutorials-oscillator-schematic-drawing.png)
 
-Note that this case applies a Schwarz-type coupling method and not (like most other tutorials in this repository) a Dirichlet-Neumann coupling. This results in a symmetric setup of the solvers. We will refer to the solver computing the trajectory of $m_1$ as `Mass-Left` and to the solver computing the trajectory of $m_2$ as `Mass-Right`. For more information, please refer to [1].
+Note that this case applies an overlapping Schwarz-type coupling method and not (like most other tutorials in this repository) a Dirichlet-Neumann coupling. This results in a symmetric setup of the solvers. We will refer to the solver computing the trajectory of $m_1$ as `Mass-Left` and to the solver computing the trajectory of $m_2$ as `Mass-Right`. For more information, please refer to [1].
 
 ## Available solvers
 

--- a/oscillator/precice-config.xml
+++ b/oscillator/precice-config.xml
@@ -7,30 +7,30 @@
     <sink filter="%Severity% > debug" />
   </log>
 
-  <data:scalar name="Force-Left"  />
-  <data:scalar name="Force-Right"  />
+  <data:scalar name="Displacement-Left"  />
+  <data:scalar name="Displacement-Right"  />
 
   <mesh name="Mass-Left-Mesh" dimensions="2">
-    <use-data name="Force-Left" />
-    <use-data name="Force-Right" />
+    <use-data name="Displacement-Left" />
+    <use-data name="Displacement-Right" />
   </mesh>
 
   <mesh name="Mass-Right-Mesh" dimensions="2">
-    <use-data name="Force-Left" />
-    <use-data name="Force-Right" />
+    <use-data name="Displacement-Left" />
+    <use-data name="Displacement-Right" />
   </mesh>
 
   <participant name="Mass-Left">
     <provide-mesh name="Mass-Left-Mesh" />
-    <write-data name="Force-Left" mesh="Mass-Left-Mesh" />
-    <read-data  name="Force-Right" mesh="Mass-Left-Mesh" />
+    <write-data name="Displacement-Left" mesh="Mass-Left-Mesh" />
+    <read-data  name="Displacement-Right" mesh="Mass-Left-Mesh" />
   </participant>
 
   <participant name="Mass-Right">
     <receive-mesh name="Mass-Left-Mesh" from="Mass-Left"/>
     <provide-mesh name="Mass-Right-Mesh" />
-    <write-data name="Force-Right" mesh="Mass-Right-Mesh" />
-    <read-data  name="Force-Left" mesh="Mass-Right-Mesh" />
+    <write-data name="Displacement-Right" mesh="Mass-Right-Mesh" />
+    <read-data  name="Displacement-Left" mesh="Mass-Right-Mesh" />
     <mapping:nearest-neighbor direction="write" from="Mass-Right-Mesh" to="Mass-Left-Mesh" constraint="consistent" />
     <mapping:nearest-neighbor direction="read"  from="Mass-Left-Mesh" to="Mass-Right-Mesh" constraint="consistent" />
   </participant>
@@ -42,9 +42,9 @@
     <max-time value="1" />
     <time-window-size value="0.01" />
     <max-iterations value="200" />
-    <relative-convergence-measure data="Force-Left" mesh="Mass-Left-Mesh" limit="1e-10"/>
-    <relative-convergence-measure data="Force-Right" mesh="Mass-Left-Mesh" limit="1e-10"/>
-    <exchange data="Force-Left" mesh="Mass-Left-Mesh" from="Mass-Left" to="Mass-Right" initialize="true"/>
-    <exchange data="Force-Right" mesh="Mass-Left-Mesh" from="Mass-Right" to="Mass-Left" initialize="true"/>
+    <relative-convergence-measure data="Displacement-Left" mesh="Mass-Left-Mesh" limit="1e-10"/>
+    <relative-convergence-measure data="Displacement-Right" mesh="Mass-Left-Mesh" limit="1e-10"/>
+    <exchange data="Displacement-Left" mesh="Mass-Left-Mesh" from="Mass-Left" to="Mass-Right" initialize="true"/>
+    <exchange data="Displacement-Right" mesh="Mass-Left-Mesh" from="Mass-Right" to="Mass-Left" initialize="true"/>
   </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/oscillator/python/oscillator.py
+++ b/oscillator/python/oscillator.py
@@ -30,8 +30,8 @@ args = parser.parse_args()
 participant_name = args.participantName
 
 if participant_name == Participant.MASS_LEFT.value:
-    write_data_name = 'Force-Left'
-    read_data_name = 'Force-Right'
+    write_data_name = 'Displacement-Left'
+    read_data_name = 'Displacement-Right'
     mesh_name = 'Mass-Left-Mesh'
 
     this_mass = problemDefinition.MassLeft
@@ -40,8 +40,8 @@ if participant_name == Participant.MASS_LEFT.value:
     other_mass = problemDefinition.MassRight
 
 elif participant_name == Participant.MASS_RIGHT.value:
-    read_data_name = 'Force-Left'
-    write_data_name = 'Force-Right'
+    read_data_name = 'Displacement-Left'
+    write_data_name = 'Displacement-Right'
     mesh_name = 'Mass-Right-Mesh'
 
     this_mass = problemDefinition.MassRight
@@ -122,7 +122,7 @@ while participant.is_coupling_ongoing():
     dt = np.min([precice_dt, my_dt])
     read_time = (1 - alpha_f) * dt
     read_data = participant.read_data(mesh_name, read_data_name, vertex_ids, read_time)
-    f = read_data[0]
+    f = connecting_spring.k * read_data[0]
 
     # do generalized alpha step
     m[0] = (1 - alpha_m) / (beta * dt**2)
@@ -134,7 +134,7 @@ while participant.is_coupling_ongoing():
     v_new = v + dt * ((1 - gamma) * a + gamma * a_new)
     t_new = t + dt
 
-    write_data = [connecting_spring.k * u_new]
+    write_data = [u_new]
 
     participant.write_data(mesh_name, write_data_name, vertex_ids, write_data)
 


### PR DESCRIPTION
Exchange displacement instead of forces. This leads to identical results, but makes the modelling a bit clearer and fits better into the domain decomposition framework.

What we did before:

![Screenshot from 2023-11-15 22-01-49](https://github.com/precice/tutorials/assets/5740604/2954fb5f-d3cd-4a77-a462-cb693420052e)

What we do now:

![Screenshot from 2023-11-15 22-02-31](https://github.com/precice/tutorials/assets/5740604/00b14ee1-33d4-442b-976d-271b9becca8f)

Inside of each participant, we still translate the displacement of the other participant to a force, because this fits better into the generalized alpha framework. This, however, is an implementation detail of the solver and does not really interfere with the coupling scheme.