### PR TITLE
Add test elastic-tube-1d tests

### DIFF
--- a/elastic-tube-1d/metadata.yaml
+++ b/elastic-tube-1d/metadata.yaml
@@ -10,13 +10,13 @@ cases:
   fluid-cpp:
     participant: Fluid
     directory: ./fluid-cpp
-    run: ./run.sh
+    run: mkdir build && cmake -S . -B build && cmake --build build && ./run.sh
     component: bare
   
   solid-cpp:
     participant: Solid
     directory: ./solid-cpp
-    run: ./run.sh
+    run: mkdir build && cmake -S . -B build && cmake --build build && ./run.sh
     component: bare
   
   fluid-python:

--- a/elastic-tube-1d/metadata.yaml
+++ b/elastic-tube-1d/metadata.yaml
@@ -1,0 +1,32 @@
+name: Elastic tube 1D
+path: elastic-tube-1d
+url: https://precice.org/tutorials-elastic-tube-1d.html
+
+participants:
+  - Fluid
+  - Solid
+
+cases:
+  fluid-cpp:
+    participant: Fluid
+    directory: ./fluid-cpp
+    run: ./run.sh
+    component: bare
+  
+  solid-cpp:
+    participant: Solid
+    directory: ./solid-cpp
+    run: ./run.sh
+    component: bare
+  
+  fluid-python:
+    participant: Fluid
+    directory: ./fluid-python
+    run: ./run.sh
+    component: python-bindings
+  
+  solid-python:
+    participant: Solid
+    directory: ./solid-python
+    run: ./run.sh
+    component: python-bindings

--- a/elastic-tube-1d/reference-data/fluid-cpp_solid-cpp.tar.gz
+++ b/elastic-tube-1d/reference-data/fluid-cpp_solid-cpp.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7a857fcd5ce4b624c6ee45f698d3777ada63973499776b8d6edd927377502bb
+size 345364

--- a/elastic-tube-1d/reference-data/fluid-cpp_solid-python.tar.gz
+++ b/elastic-tube-1d/reference-data/fluid-cpp_solid-python.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b51e59cb65eaf303683e43f2337e3b97e9f94f840ac94f290e99f976929e5477
+size 705114

--- a/elastic-tube-1d/reference-data/fluid-python_solid-python.tar.gz
+++ b/elastic-tube-1d/reference-data/fluid-python_solid-python.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8dc48beb874a14236278fddd90528e66a27f6ae5270f74c69b1d2323e5d1bdcd
+size 705322

--- a/elastic-tube-1d/reference_results.metadata
+++ b/elastic-tube-1d/reference_results.metadata
@@ -11,9 +11,9 @@ We also include some information on the machine used to generate them
 
 | name | time | sha256 |
 |------|------|-------|
-| fluid-openfoam_solid-nutils.tar.gz | 2023-12-14 16:20:26 | bb432426dc3a737fd79704a0baf5dab405478cdc4ee160b12520c8f8368c5231 |
-| fluid-openfoam_solid-fenics.tar.gz | 2023-12-14 16:20:26 | 6e204c5ef1ed001981d0b432c12fd93920ecef053fdac644c98118323eb25d91 |
-| fluid-openfoam_solid-openfoam.tar.gz | 2023-12-14 16:20:26 | cb0212291630004bdc9acf0cdbaed4e952fb1155cc4175f22bac714fb16f5130 |
+| fluid-python_solid-python.tar.gz | 2023-12-14 16:20:26 | 8dc48beb874a14236278fddd90528e66a27f6ae5270f74c69b1d2323e5d1bdcd |
+| fluid-cpp_solid-python.tar.gz | 2023-12-14 16:20:26 | b51e59cb65eaf303683e43f2337e3b97e9f94f840ac94f290e99f976929e5477 |
+| fluid-cpp_solid-cpp.tar.gz | 2023-12-14 16:20:26 | d7a857fcd5ce4b624c6ee45f698d3777ada63973499776b8d6edd927377502bb |
 
 ## List of arguments used to generate the files
 

--- a/flow-over-heated-plate/reference-results/fluid-openfoam_solid-fenics.tar.gz
+++ b/flow-over-heated-plate/reference-results/fluid-openfoam_solid-fenics.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65d4c461e3f6167846730de14b0778b004a02f2db740f2c263aee4e2bd8b86a6
-size 778312
+oid sha256:6e204c5ef1ed001981d0b432c12fd93920ecef053fdac644c98118323eb25d91
+size 778409

--- a/flow-over-heated-plate/reference-results/fluid-openfoam_solid-nutils.tar.gz
+++ b/flow-over-heated-plate/reference-results/fluid-openfoam_solid-nutils.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d790bf8a032b1f155699b5a63287124be202d45bcb59cab9b320c3fef86ba56
-size 533210
+oid sha256:bb432426dc3a737fd79704a0baf5dab405478cdc4ee160b12520c8f8368c5231
+size 533356

--- a/flow-over-heated-plate/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+++ b/flow-over-heated-plate/reference-results/fluid-openfoam_solid-openfoam.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ab9f3f762beec987e0a90ce99e5e3b85f406e4738599fd4b1ad68942ed7f516
-size 498933
+oid sha256:cb0212291630004bdc9acf0cdbaed4e952fb1155cc4175f22bac714fb16f5130
+size 499028

--- a/perpendicular-flap/reference-results/fluid-openfoam_solid-calculix.tar.gz
+++ b/perpendicular-flap/reference-results/fluid-openfoam_solid-calculix.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:905c90f4f5c7776c5822b9235e435ae25b9097d2f8bc6392865402b21a525194
-size 13559914
+oid sha256:6a2eb8eaa81763f2d3b353984deac5c260ecb206f90af93635ccf84e8e4fadb2
+size 13560146

--- a/perpendicular-flap/reference_results.metadata
+++ b/perpendicular-flap/reference_results.metadata
@@ -11,7 +11,7 @@ We also include some information on the machine used to generate them
 
 | name | time | sha256 |
 |------|------|-------|
-| fluid-openfoam_solid-calculix.tar.gz | 2023-12-13 22:22:18 | 905c90f4f5c7776c5822b9235e435ae25b9097d2f8bc6392865402b21a525194 |
+| fluid-openfoam_solid-calculix.tar.gz | 2023-12-14 16:20:26 | 6a2eb8eaa81763f2d3b353984deac5c260ecb206f90af93635ccf84e8e4fadb2 |
 
 ## List of arguments used to generate the files
 

--- a/tools/tests/component-templates/bare.yaml
+++ b/tools/tests/component-templates/bare.yaml
@@ -5,10 +5,6 @@ build:
       - {{key}}={{value}}
     {% endfor %}
   target: precice
-  cache_from:
-  - type=gha
-  cache_to:
-  - type=gha,mode=min,scope=precice
 depends_on:    
   prepare:
     condition: service_completed_successfully

--- a/tools/tests/component-templates/bare.yaml
+++ b/tools/tests/component-templates/bare.yaml
@@ -1,0 +1,20 @@
+build: 
+  context: {{ dockerfile_context }}
+  args:
+    {% for key, value in build_arguments.items() %}
+      - {{key}}={{value}}
+    {% endfor %}
+  target: precice
+  cache_from:
+  - type=gha
+  cache_to:
+  - type=gha,mode=min,scope=precice
+depends_on:    
+  prepare:
+    condition: service_completed_successfully
+volumes:
+  - {{ run_directory }}:/runs
+command: >
+  /bin/bash -c "id && 
+  cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
+  {{ run }} | tee {{ case_folder }}.log 2>&1"

--- a/tools/tests/component-templates/python-bindings.yaml
+++ b/tools/tests/component-templates/python-bindings.yaml
@@ -5,10 +5,6 @@ build:
       - {{key}}={{value}}
     {% endfor %}
   target: python_bindings
-  cache_from:
-  - type=gha
-  cache_to:
-  - type=gha,mode=min,scope=python_bindings
 depends_on:    
   prepare:
     condition: service_completed_successfully

--- a/tools/tests/component-templates/python-bindings.yaml
+++ b/tools/tests/component-templates/python-bindings.yaml
@@ -1,0 +1,20 @@
+build: 
+  context: {{ dockerfile_context }}
+  args:
+    {% for key, value in build_arguments.items() %}
+      - {{key}}={{value}}
+    {% endfor %}
+  target: python_bindings
+  cache_from:
+  - type=gha
+  cache_to:
+  - type=gha,mode=min,scope=python_bindings
+depends_on:    
+  prepare:
+    condition: service_completed_successfully
+volumes:
+  - {{ run_directory }}:/runs
+command: >
+  /bin/bash -c "id && 
+  cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
+  {{ run }} | tee {{ case_folder }}.log 2>&1"

--- a/tools/tests/components.yaml
+++ b/tools/tests/components.yaml
@@ -8,6 +8,9 @@ bare: # A default component used when the solver does not have any dependencies 
     PLATFORM:
       description: Dockerfile platform used
       default: "ubuntu_2204"
+    TUTORIALS_REF:
+      description: Tutorial git reference to use
+      default: "master"
 
 python-bindings:
   repository: https://github.com/precice/python-bindings
@@ -19,6 +22,9 @@ python-bindings:
     PLATFORM:
       description: Dockerfile platform used
       default: "ubuntu_2204"
+    TUTORIALS_REF:
+      description: Tutorial git reference to use
+      default: "master"
     PYTHON_BINDINGS_REF:
       semnantic: Git ref of the pythonbindings to use
       default: "master"

--- a/tools/tests/components.yaml
+++ b/tools/tests/components.yaml
@@ -1,7 +1,32 @@
+bare: # A default component used when the solver does not have any dependencies apart from preCICE itself
+  repository: https://github.com/precice/precice
+  template: component-templates/bare.yaml
+  build_arguments: # these things mean something to the docker-service
+    PRECICE_REF:
+      description: Version of preCICE to use
+      default: "main"
+    PLATFORM:
+      description: Dockerfile platform used
+      default: "ubuntu_2204"
+
+python-bindings:
+  repository: https://github.com/precice/python-bindings
+  template: component-templates/python-bindings.yaml
+  build_arguments:
+    PRECICE_REF:
+      description: Version of preCICE to use
+      default: "main"
+    PLATFORM:
+      description: Dockerfile platform used
+      default: "ubuntu_2204"
+    PYTHON_BINDINGS_REF:
+      semnantic: Git ref of the pythonbindings to use
+      default: "master"
+
 openfoam-adapter:
   repository: https://github.com/precice/openfoam-adapter
   template: component-templates/openfoam-adapter.yaml
-  build_arguments: # these things mean something to the docker-service
+  build_arguments:
     PRECICE_REF:
       description: Version of preCICE to use
       default: "main"

--- a/tools/tests/dockerfiles/ubuntu_2204/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2204/Dockerfile
@@ -82,8 +82,9 @@ ARG PYTHON_BINDINGS_REF
 USER precice
 WORKDIR /home/precice
 # Builds the precice python bindings for python3
-RUN pip3 install --user git+https://github.com/precice/python-bindings.git@${PYTHON_BINDINGS_REF}
-
+# Installs also matplotlib as its needed for the elastic-tube 1d fluid-python participant.
+RUN pip3 install --user git+https://github.com/precice/python-bindings.git@${PYTHON_BINDINGS_REF} && \
+    pip3 install --user matplotlib 
 
 FROM precice_dependecies as fenics_adapter
 COPY --from=python_bindings /home/precice/.local /home/precice/.local

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -34,3 +34,20 @@ test_suites:
           - fluid-openfoam
           - solid-calculix
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-calculix.tar.gz
+  elastic_tube_1d_test:
+    tutorials:
+      - path: elastic-tube-1d
+        case_combination:
+          - fluid-cpp
+          - solid-cpp
+        reference_result: ./elastic-tube-1d/reference-data/fluid-cpp_solid-cpp.tar.gz
+      - path: elastic-tube-1d
+        case_combination:
+          - fluid-python
+          - solid-python
+        reference_result: ./elastic-tube-1d/reference-data/fluid-python_solid-python.tar.gz
+      - path: elastic-tube-1d
+        case_combination:
+          - fluid-cpp
+          - solid-python
+        reference_result: ./elastic-tube-1d/reference-data/fluid-cpp_solid-python.tar.gz


### PR DESCRIPTION
Adds a test suite for `elastic-tube-1d`, which is a special case, since it does not rely on any adapter (but relies partially on the python-bindings).

Overview of changes:

- New component `bare`, which essentially only relies on the `precice` Docker image.
- New component `python-bindings`
- Adds a `metadata.yml` into the `elastic-tube-1d` tutorial
- Defines the test suite `elastic_tube_1d_test`, with the tests:
  - fluid-cpp x solid-cpp: Test the C++ API
  - fluid-python x solid-python: Test the Python API
  - fluid-cpp x solid-python: Test the interoperability between C++ and Python


However, only the last test is being executed: https://github.com/precice/tutorials/issues/394

## Further observations

This test correctly fails to build the code and run the simulation when executing `generate_reference_data.py`, since the tutorial is not yet ported to preCICE v3 (https://github.com/precice/tutorials/issues/395). However, running the system tests only complains at the stage of comparing the results:

```shell
~/repos/precice/tutorials/tools/tests [develop]$ python3 generate_reference_data.py --log-level=DEBUG
Using log-level: DEBUG
INFO: About to run the following tests {Elastic tube 1D (fluid-cpp, solid-python), Flow over heated plate (fluid-openfoam, solid-openfoam), Flow over heated plate (fluid-openfoam, solid-fenics), Perpendicular flap (fluid-openfoam, solid-calculix), Flow over heated plate (fluid-openfoam, solid-nutils)}
INFO: Started running Elastic tube 1D (fluid-cpp, solid-python),  0/5
DEBUG: tools are already copied: [Errno 17] File exists: '/home/gc/repos/precice/tutorials/runs/tools' 
DEBUG: Building docker image for Elastic tube 1D (fluid-cpp, solid-python)
DEBUG: Running tutorial Elastic tube 1D (fluid-cpp, solid-python)
INFO: Running Elastic tube 1D (fluid-cpp, solid-python) took 378.1042361170039 seconds
INFO: Started running Flow over heated plate (fluid-openfoam, solid-openfoam),  1/5
...
Traceback (most recent call last):
  File "/home/gc/repos/precice/tutorials/tools/tests/generate_reference_data.py", line 118, in <module>
    main()
  File "/home/gc/repos/precice/tutorials/tools/tests/generate_reference_data.py", line 104, in main
    raise RuntimeError(
RuntimeError: Error executing: 
 Elastic tube 1D (fluid-cpp, solid-python) 
 Could not find result folder /home/gc/repos/precice/tutorials/runs/elastic-tube-1d_fluid-cpp-solid-python_2023-11-18-125138/precice_exports
 Probably the tutorial did not run through properly. Please check corresponding logs
```

```
~/repos/precice/tutorials/tools/tests [develop]$ python3 systemtests.py --suites=elastic_tube_1d_test --log-level=DEBUG
Using log-level: DEBUG
INFO: About to run the following systemtest in the directory /home/gc/repos/precice/tutorials/runs:
 [Elastic tube 1D (fluid-cpp, solid-python)]
INFO: Started running Elastic tube 1D (fluid-cpp, solid-python),  0/1
DEBUG: tools are already copied: [Errno 17] File exists: '/home/gc/repos/precice/tutorials/runs/tools' 
DEBUG: Building docker image for Elastic tube 1D (fluid-cpp, solid-python)
DEBUG: Running tutorial Elastic tube 1D (fluid-cpp, solid-python)
DEBUG: Running fieldcompare for Elastic tube 1D (fluid-cpp, solid-python)
Traceback (most recent call last):
  File "/home/gc/repos/precice/tutorials/tools/tests/systemtests.py", line 96, in <module>
    main()
  File "/home/gc/repos/precice/tutorials/tools/tests/systemtests.py", line 75, in main
    result = systemtest.run(run_directory)
  File "/home/gc/repos/precice/tutorials/tools/tests/systemtests/Systemtest.py", line 524, in run
    fieldcompare_result = self._run_field_compare()
  File "/home/gc/repos/precice/tutorials/tools/tests/systemtests/Systemtest.py", line 334, in _run_field_compare
    self.__unpack_reference_results()
  File "/home/gc/repos/precice/tutorials/tools/tests/systemtests/Systemtest.py", line 316, in __unpack_reference_results
    with tarfile.open(self.reference_result.path) as reference_results_tared:
  File "/usr/lib/python3.10/tarfile.py", line 1797, in open
    return func(name, "r", fileobj, **kwargs)
  File "/usr/lib/python3.10/tarfile.py", line 1863, in gzopen
    fileobj = GzipFile(name, mode + "b", compresslevel, fileobj)
  File "/usr/lib/python3.10/gzip.py", line 174, in __init__
    fileobj = self.myfileobj = builtins.open(filename, mode or 'rb')
FileNotFoundError: [Errno 2] No such file or directory: '/home/gc/repos/precice/tutorials/elastic-tube-1d/reference-data/fluid-cpp_solid-python.tar.gz'
```