### PR TITLE
Update tests docs

### DIFF
--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -29,6 +29,60 @@ After bringing these changes to `master`, the manual triggering option should be
 gh workflow run run_testsuite_manual.yml -f suites=fenics_test --ref=develop
 ```
 
+Another example, to use the latest develop branches and enable debug information of the tests:
+
+```shell
+gh workflow run run_testsuite_manual.yml -f suites=fenics_test -f build_args="PRECICE_REF:develop,OPENFOAM_ADAPTER_REF:develop,PYTHON_BINDINGS_REF:develop,FENICS_ADAPTER_REF:develop" -f loglevel=DEBUG --ref=develop
+```
+
+where the `*_REF` can also be specific Git commits.
+
+Example output:
+
+```
+Run cd tools/tests
+  cd tools/tests
+  python systemtests.py --build_args=PRECICE_REF:develop,OPENFOAM_ADAPTER_REF:develop,PYTHON_BINDINGS_REF:develop,FENICS_ADAPTER_REF:develop --suites=fenics_test --log-level=DEBUG
+  cd ../../
+  shell: /usr/bin/bash -e {0}
+INFO: About to run the following systemtest in the directory /home/precice/runners_root/actions-runner-tutorial/_work/tutorials/tutorials/runs:
+ [Flow over heated plate (fluid-openfoam, solid-fenics)]
+INFO: Started running Flow over heated plate (fluid-openfoam, solid-fenics),  0/1
+DEBUG: Checking out tutorials master before copying
+From https://github.com/precice/tutorials
+ * [new branch]      master     -> master
+DEBUG: Building docker image for Flow over heated plate (fluid-openfoam, solid-fenics)
+DEBUG: Running tutorial Flow over heated plate (fluid-openfoam, solid-fenics)
+DEBUG: Running fieldcompare for Flow over heated plate (fluid-openfoam, solid-fenics)
+DEBUG: extracting /home/precice/runners_root/actions-runner-tutorial/_work/tutorials/tutorials/flow-over-heated-plate/reference-data/fluid-openfoam_solid-fenics.tar.gz into /home/precice/runners_root/actions-runner-tutorial/_work/tutorials/tutorials/runs/flow-over-heated-plate_fluid-openfoam-solid-fenics_2023-11-19-211723/reference_results
+Using log-level: DEBUG
++---------------------------------------------------------+---------+-------------------+-----------------+-----------------------+
+| systemtest                                              | success | building time [s] | solver time [s] | fieldcompare time [s] |
+CRITICAL: Fieldcompare returned non zero exit code, therefore Flow over heated plate (fluid-openfoam, solid-fenics) failed
+INFO: Running Flow over heated plate (fluid-openfoam, solid-fenics) took 280.5861554039875 seconds
+ERROR: Failed to run Flow over heated plate (fluid-openfoam, solid-fenics)
++---------------------------------------------------------+---------+-------------------+-----------------+-----------------------+
+| Flow over heated plate (fluid-openfoam, solid-fenics)   |    0    |      271.80       |      5.60       |         2.42          |
++---------------------------------------------------------+---------+-------------------+-----------------+-----------------------+
+```
+
+In this case, building and running seems to work out, but the tests fail because the results differ from the reference results. This may be incorrect, as the previous step may have silently failed.
+
+## Understanding what went wrong
+
+Let's first see how the workflow was triggered. If we expand the `Set up job` step, we can see the inputs provided:
+
+```
+ Inputs
+    build_args: PRECICE_REF:develop,OPENFOAM_ADAPTER_REF:develop,PYTHON_BINDINGS_REF:develop,FENICS_ADAPTER_REF:develop
+    loglevel: DEBUG
+    suites: fenics_test
+    systests_branch: develop
+    upload_artifacts: FALSE
+```
+
+In the summary, we can find the results and more logs as a build artifact. This includes two interesting files: `stdout.log` and `stderr.log`. These include all Docker build steps and the simulation output, as well as the exact git clone command.
+
 ## Adding new tests
 
 ### Adding tutorials

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -111,7 +111,7 @@ Implementation scripts:
   - `systemtests/`: Main implementation classes
     - `Systemtest.py`
     - `SystemtestArguments.py`
-    - `TestSuite.py` 
+    - `TestSuite.py`
 
 ### Metadata
 

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -19,6 +19,16 @@ python3 systemtests.py --suites=openfoam-adapter-release,<someothersuite>
 To discover all tests, use `python print_test_suites.py`.
 To be able to fill in the right case tuple into the `tests.yaml`, you can use the `python3 print_case_combinations.py` script.
 
+## Running the system tests on GitHub Actions
+
+Go to Actions > [Run Testsuite (manual)](https://github.com/precice/tutorials/actions/workflows/run_testsuite_manual.yml) to see this workflow.
+
+After bringing these changes to `master`, the manual triggering option should be visible on the top right. Until that happens, we can only trigger this workflow manually from the [GitHub CLI](https://github.blog/changelog/2021-04-15-github-cli-1-9-enables-you-to-work-with-github-actions-from-your-terminal/):
+
+```shell
+gh workflow run run_testsuite_manual.yml -f suites=fenics_test --ref=develop
+```
+
 ## Adding new tests
 
 ### Adding tutorials

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -39,7 +39,7 @@ where the `*_REF` can also be specific Git commits.
 
 Example output:
 
-```
+```text
 Run cd tools/tests
   cd tools/tests
   python systemtests.py --build_args=PRECICE_REF:develop,OPENFOAM_ADAPTER_REF:develop,PYTHON_BINDINGS_REF:develop,FENICS_ADAPTER_REF:develop --suites=fenics_test --log-level=DEBUG
@@ -72,7 +72,7 @@ In this case, building and running seems to work out, but the tests fail because
 
 Let's first see how the workflow was triggered. If we expand the `Set up job` step, we can see the inputs provided:
 
-```
+```text
  Inputs
     build_args: PRECICE_REF:develop,OPENFOAM_ADAPTER_REF:develop,PYTHON_BINDINGS_REF:develop,FENICS_ADAPTER_REF:develop
     loglevel: DEBUG

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -95,13 +95,19 @@ openfoam-adapter:
   repository: https://github.com/precice/openfoam-adapter
   template: component-templates/openfoam-adapter.yaml
   build_arguments: # these things mean something to the docker-service
-    OPENFOAM_EXECUTABLE:
-      options: ["openfoam2112"]
-      description: exectuable of openfoam to use
-      default: "openfoam2112"
-    PRECICE_TAG:
+    PRECICE_REF:
       description: Version of preCICE to use
-      default: "latest"
+      default: "main"
+    PLATFORM:
+      description: Dockerfile platform used
+      default: "ubuntu_2204"
+    TUTORIALS_REF:
+      description: Tutorial git reference to use
+      default: "master"
+    OPENFOAM_EXECUTABLE:
+      options: ["openfoam2306","openfoam2212","openfoam2112"]
+      description: exectuable of openfoam to use
+      default: "openfoam2306"
     OPENFOAM_ADAPTER_REF:
       description: Reference/tag of the actual OpenFOAM adapter
       default: "master"
@@ -117,7 +123,6 @@ This `openfoam-adapter` component has the following attributes:
 
 Since the docker containers are still a bit mixed in terms of capabilities and support for different build_argument combinations the following rules apply:
 
-- A build_argument ending in **_TAG** means that an image of some kind needs to be available with that tag.
 - A build_argument ending in **_REF** means that it refers to a git reference (like a branch or commit) beeing used to build the image.
 - All other build_arguments are free of rules and up to the container maintainer.
 


### PR DESCRIPTION
Some more information:

- How to trigger the test manually from the GitHub CLI
- General architecture (first draft)
- What each relevant file is doing

Also removes the mention about `_TAG` naming rule, as I understand it is not used anywhere.

@valentin-seitz I would still like to add (but I am not yet sure how):

- [x] How to specify which git reference of each component to test?
- [ ] How to find out which versions (git references) were used for the test? -> needs https://github.com/precice/tutorials/issues/401
- [x] Which files to read when things go wrong?
- [x] How to increase the verbosity of the tests? How to increase the verbosity of Docker?
- [ ] How to generate reference results for specific tests? -> needs https://github.com/precice/tutorials/issues/405

Maybe some of these need to go to separate issues.