### PR TITLE
System tests docs: Add metadata for the website

### DIFF
--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -1,6 +1,7 @@
 ---
 title: preCICE system tests
 permalink: dev-docs-system-tests.html
+sidebar: docs_sidebar
 keywords: pages, development, tests
 summary: "Test complete simulations combining preCICE components of specific versions."
 ---

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -1,4 +1,9 @@
-# preCICE system tests
+---
+title: preCICE system tests
+permalink: dev-docs-system-tests.html
+keywords: pages, development, tests
+summary: "Test complete simulations combining preCICE components of specific versions."
+---
 
 The tutorials repository hosts cases that need multiple components from the preCICE ecosystem to run. This directory provides tools that can automatically run complete simulations, using different versions of each component, and compare the results to references. While the main purpose is to run complete tests in the continuous integration workflows of preCICE, you can also run these tests on your laptop.
 


### PR DESCRIPTION
Adds metadata on the beginning of the page, to be able to render it on the website.

Related to https://github.com/precice/precice.github.io/pull/304

See also https://precice.org/docs-meta-overview.html#rendering-content-from-external-repositories