### PR TITLE
Clean precice-profiling/

### DIFF
--- a/tools/cleaning-tools.sh
+++ b/tools/cleaning-tools.sh
@@ -32,7 +32,7 @@ clean_precice_logs() {
             ./precice-*-watchintegral-*.log \
             ./events.json \
             ./core
-        rm -rfv ./precice-events/
+        rm -rfv ./precice-events/ ./precice-profiling/
     )
 }
 


### PR DESCRIPTION
Removes the `precice-profiling/` directory from every case directory.

@davidscn any other new files we should clean up?