### PR TITLE
Remove unnecessary `clean_aste` call from base cleaning

### DIFF
--- a/aste-turbine/clean.sh
+++ b/aste-turbine/clean.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e -u
+
+. ../tools/cleaning-tools.sh
+
+clean_aste .

--- a/tools/clean-tutorial-base.sh
+++ b/tools/clean-tutorial-base.sh
@@ -5,7 +5,6 @@ set -e -u
 . ../tools/cleaning-tools.sh
 
 clean_tutorial .
-clean_aste 
 clean_precice_logs .
 rm -fv ./*.log
 rm -fv ./*.vtu

--- a/tools/cleaning-tools.sh
+++ b/tools/cleaning-tools.sh
@@ -121,7 +121,7 @@ clean_aste() {
     (
         set -e -u
         cd "$1"
-        echo "--- Cleaning up ASTE results in $(pwd)"
+        echo "--- Looking for and cleaning up any potential ASTE results in $(pwd)"
         rm -fv result.vtk result.stats.json
         rm -fvr fine_mesh coarse_mesh mapped
     )

--- a/tools/cleaning-tools.sh
+++ b/tools/cleaning-tools.sh
@@ -120,7 +120,8 @@ clean_su2() {
 clean_aste() {
     (
         set -e -u
-        echo "--- Cleaning up ASTE results"
+        cd "$1"
+        echo "--- Cleaning up ASTE results in $(pwd)"
         rm -fv result.vtk result.stats.json
         rm -fvr fine_mesh coarse_mesh mapped
     )

--- a/tools/cleaning-tools.sh
+++ b/tools/cleaning-tools.sh
@@ -121,7 +121,7 @@ clean_aste() {
     (
         set -e -u
         cd "$1"
-        echo "--- Looking for and cleaning up any potential ASTE results in $(pwd)"
+        echo "--- Cleaning up ASTE results in $(pwd)"
         rm -fv result.vtk result.stats.json
         rm -fvr fine_mesh coarse_mesh mapped
     )

--- a/tools/cleaning-tools.sh
+++ b/tools/cleaning-tools.sh
@@ -12,6 +12,10 @@ clean_tutorial() {
         echo "-- Cleaning up all cases in $(pwd)..."
         rm -rfv ./precice-run/
 
+        if test "clean.sh"; then
+            ./clean.sh
+        fi
+
         for case in */; do
             if [ "${case}" = images/ ]; then
                 continue

--- a/tools/cleaning-tools.sh
+++ b/tools/cleaning-tools.sh
@@ -12,6 +12,7 @@ clean_tutorial() {
         echo "-- Cleaning up all cases in $(pwd)..."
         rm -rfv ./precice-run/
 
+        # Run clean.sh if it exists in the base tutorial directory
         if test "clean.sh"; then
             ./clean.sh
         fi


### PR DESCRIPTION
As mentioned in the title. I noticed this in the cleaning logs while creating a new tutorial. 