### PR TITLE
Fix broken autopep8 Pipeline

### DIFF
--- a/perpendicular-flap/solid-fenics/solid.py
+++ b/perpendicular-flap/solid-fenics/solid.py
@@ -1,7 +1,10 @@
 """
-This source code is based on https://gitlab.enpc.fr/jeremy.bleyer/comet-fenics/-/blob/master/examples/elastodynamics/demo_elastodynamics.py.rst
+This source code is based on:
+https://gitlab.enpc.fr/jeremy.bleyer/comet-fenics/-/blob/master/examples/elastodynamics/demo_elastodynamics.py.rst
+
 See also: 
-    Jeremy Bleyer. (2018). Numerical Tours of Computational Mechanics with FEniCS. Zenodo. https://doi.org/10.5281/zenodo.1287832
+    Jeremy Bleyer. (2018). Numerical Tours of Computational Mechanics with FEniCS. 
+    Zenodo. https://doi.org/10.5281/zenodo.1287832
 """
 
 # Import required libs

--- a/perpendicular-flap/solid-fenics/solid.py
+++ b/perpendicular-flap/solid-fenics/solid.py
@@ -1,10 +1,9 @@
 """
-This source code is based on:
-https://gitlab.enpc.fr/jeremy.bleyer/comet-fenics/-/blob/master/examples/elastodynamics/demo_elastodynamics.py.rst
+This source code is based on: https://gitlab.enpc.fr/jeremy.bleyer/comet-fenics/-/blob/master/examples/elastodynamics/demo_elastodynamics.py.rst
 
 See also:
     Jeremy Bleyer. (2018). Numerical Tours of Computational Mechanics with FEniCS.
-     Zenodo. https://doi.org/10.5281/zenodo.1287832
+    Zenodo. https://doi.org/10.5281/zenodo.1287832
 """
 
 # Import required libs

--- a/perpendicular-flap/solid-fenics/solid.py
+++ b/perpendicular-flap/solid-fenics/solid.py
@@ -1,9 +1,8 @@
 """
-This source code is based on: https://gitlab.enpc.fr/jeremy.bleyer/comet-fenics/-/blob/master/examples/elastodynamics/demo_elastodynamics.py.rst
+This source code is based on https://gitlab.enpc.fr/jeremy.bleyer/comet-fenics/-/blob/master/examples/elastodynamics/demo_elastodynamics.py.rst
 
 See also:
-    Jeremy Bleyer. (2018). Numerical Tours of Computational Mechanics with FEniCS.
-    Zenodo. https://doi.org/10.5281/zenodo.1287832
+    Jeremy Bleyer. (2018). Numerical Tours of Computational Mechanics with FEniCS. Zenodo. https://doi.org/10.5281/zenodo.1287832
 """
 
 # Import required libs

--- a/perpendicular-flap/solid-fenics/solid.py
+++ b/perpendicular-flap/solid-fenics/solid.py
@@ -1,6 +1,5 @@
 """
 This source code is based on https://gitlab.enpc.fr/jeremy.bleyer/comet-fenics/-/blob/master/examples/elastodynamics/demo_elastodynamics.py.rst
-
 See also: 
     Jeremy Bleyer. (2018). Numerical Tours of Computational Mechanics with FEniCS. Zenodo. https://doi.org/10.5281/zenodo.1287832
 """

--- a/perpendicular-flap/solid-fenics/solid.py
+++ b/perpendicular-flap/solid-fenics/solid.py
@@ -2,9 +2,9 @@
 This source code is based on:
 https://gitlab.enpc.fr/jeremy.bleyer/comet-fenics/-/blob/master/examples/elastodynamics/demo_elastodynamics.py.rst
 
-See also: 
-    Jeremy Bleyer. (2018). Numerical Tours of Computational Mechanics with FEniCS. 
-    Zenodo. https://doi.org/10.5281/zenodo.1287832
+See also:
+    Jeremy Bleyer. (2018). Numerical Tours of Computational Mechanics with FEniCS.
+     Zenodo. https://doi.org/10.5281/zenodo.1287832
 """
 
 # Import required libs


### PR DESCRIPTION
This PR fixes the broken autopep8 Pipeline, which broke overnight :)
Apparently some illegal character placed itself there in the whitespace, which needed to be removed :)
