### PR TITLE
Run checks for markdown linting, pep8, and scripts only once for push and pull requests

### DIFF
--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -4,10 +4,10 @@ on:
     branches:
       - master
       - develop
-    pull_request:
-      branches:
-        - master
-        - develop
+  pull_request:
+    branches:
+      - master
+      - develop
 jobs:
   check_md:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -1,5 +1,13 @@
 name: Lint docs
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - develop
+    pull_request:
+      branches:
+        - master
+        - develop
 jobs:
   check_md:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pep8.yml
+++ b/.github/workflows/check-pep8.yml
@@ -4,10 +4,10 @@ on:
     branches:
       - master
       - develop
-    pull_request:
-      branches:
-        - master
-        - develop
+  pull_request:
+    branches:
+      - master
+      - develop
 jobs:
   autopep8:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pep8.yml
+++ b/.github/workflows/check-pep8.yml
@@ -1,5 +1,13 @@
 name: autopep8
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - develop
+    pull_request:
+      branches:
+        - master
+        - develop
 jobs:
   autopep8:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-scripts.yaml
+++ b/.github/workflows/check-scripts.yaml
@@ -1,5 +1,13 @@
 name: Check scripts
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - develop
+    pull_request:
+      branches:
+        - master
+        - develop
 jobs:
   check_scripts:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-scripts.yaml
+++ b/.github/workflows/check-scripts.yaml
@@ -4,10 +4,10 @@ on:
     branches:
       - master
       - develop
-    pull_request:
-      branches:
-        - master
-        - develop
+  pull_request:
+    branches:
+      - master
+      - develop
 jobs:
   check_scripts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently the checks for markdown linting, pep8, and scripts are run twice for every push or pull requests to the master or develop branch. For example:

![image](https://github.com/precice/tutorials/assets/44898158/d0041d74-a969-4ccf-aa9c-b9f07961458f)

By setting the branches explicitly in the workflows, we can ensure that the workflows are run only once.