### PR TITLE
nutils additions for the perpendicular flap example

### DIFF
--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -7,11 +7,7 @@ import precice
 
 # for details on this solver see https://doi.org/10.1002/nme.6443
 
-def main(inflow: 'inflow velocity' = 10,
-         viscosity: 'kinematic viscosity' = 1.0,
-         density: 'density' = 1.0,
-         theta=0.5,
-         timestepsize=0.01):
+def main(inflow=10., viscosity=1., density=1., theta=.5, timestepsize=.01):
 
     # mesh and geometry definition
     topo, geom = mesh.rectilinear([

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -99,12 +99,7 @@ def main(inflow: 'inflow velocity' = 10,
     res += tθ(domain.integral('rho ubasis_ni u_i,j urel_j d:x' @ ns, degree=4))
 
     # weak form for force computation
-    resF = domain.integral('(ubasis_ni,j (u_i,j + u_j,i) rho nu d:x)' @ ns, degree=4)
-    resF += tp(domain.integral('-ubasis_ni,j p δ_ij d:x' @ ns, degree=4))
-    resF += domain.integral('pbasis_n u_k,k d:x' @ ns, degree=4)
-    resF += tt(domain.integral('rho ubasis_ni u_i d:x' @ ns, degree=4))
-    resF += domain.integral('rho ubasis_ni (u_i,j urel_j d:x)' @ ns, degree=4)
-    resF += couplinginterface.sample('gauss', 4).integral('ubasis_ni F_i d:x' @ ns)
+    resF = res + couplinginterface.sample('gauss', 4).integral('ubasis_ni F_i d:x' @ ns)
     consF = couplingsample.integrate((ns.ubasis**2).sum(1)) == 0
 
     # boundary conditions mesh displacements

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -138,6 +138,7 @@ def main(inflow: 'inflow velocity' = 10,
     t = 0
 
     while interface.is_coupling_ongoing():
+      with treelog.context(f'timestep {timestep}'):
 
         # read displacements from interface
         if interface.is_read_data_available():

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -14,25 +14,19 @@ def main(inflow: 'inflow velocity' = 10,
          timestepsize=0.01):
 
     # mesh and geometry definition
-    grid_x_1 = numpy.linspace(-3, -1, 7)
-    grid_x_1 = grid_x_1[:-1]
-    grid_x_2 = numpy.linspace(-1, -0.3, 8)
-    grid_x_2 = grid_x_2[:-1]
-    grid_x_3 = numpy.linspace(-0.3, 0.3, 13)
-    grid_x_3 = grid_x_3[:-1]
-    grid_x_4 = numpy.linspace(0.3, 1, 8)
-    grid_x_4 = grid_x_4[:-1]
-    grid_x_5 = numpy.linspace(1, 3, 7)
-    grid_x = numpy.concatenate((grid_x_1, grid_x_2, grid_x_3, grid_x_4, grid_x_5), axis=None)
-    grid_y_1 = numpy.linspace(0, 1.5, 16)
-    grid_y_1 = grid_y_1[:-1]
-    grid_y_2 = numpy.linspace(1.5, 2, 4)
-    grid_y_2 = grid_y_2[:-1]
-    grid_y_3 = numpy.linspace(2, 4, 7)
-    grid_y = numpy.concatenate((grid_y_1, grid_y_2, grid_y_3), axis=None)
-    grid = [grid_x, grid_y]
+    topo, geom = mesh.rectilinear([
+        numpy.concatenate((
+            numpy.linspace(-3, -1, 6, endpoint=False),
+            numpy.linspace(-1, -0.3, 7, endpoint=False),
+            numpy.linspace(-0.3, 0.3, 12, endpoint=False),
+            numpy.linspace(0.3, 1, 7, endpoint=False),
+            numpy.linspace(1, 3, 7))),
+        numpy.concatenate((
+            numpy.linspace(0, 1.5, 15, endpoint=False),
+            numpy.linspace(1.5, 2, 3, endpoint=False),
+            numpy.linspace(2, 4, 7))),
+    ])
 
-    topo, geom = mesh.rectilinear(grid)
     domain = topo.withboundary(inflow='left', wall='top,bottom', outflow='right') - \
         topo[18:20, :10].withboundary(flap='left,right,top')
 

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -7,11 +7,6 @@ import precice
 
 # for details on this solver see https://doi.org/10.1002/nme.6443
 
-def subs0(f):
-    'helper function to shift variables by one timestep'
-    return function.replace_arguments(f, {arg: function.Argument(arg+'0', shape=shape, dtype=dtype) for arg, (shape, dtype) in f.arguments.items() if arg != 'dt'})
-
-
 def main(inflow: 'inflow velocity' = 10,
          viscosity: 'kinematic viscosity' = 1.0,
          density: 'density' = 1.0,
@@ -42,14 +37,16 @@ def main(inflow: 'inflow velocity' = 10,
         topo[18:20, :10].withboundary(flap='left,right,top')
 
     # time approximations
+    t0 = lambda f: function.replace_arguments(f, {arg: function.Argument(arg+'0', shape=shape, dtype=dtype)
+                        for arg, (shape, dtype) in f.arguments.items() if arg != 'dt'})
     # TR interpolation
-    tθ = lambda f: theta * f + (1 - theta) * subs0(f)
+    tθ = lambda f: theta * f + (1 - theta) * t0(f)
     # 1st order FD
-    δt = lambda f: (f - subs0(f)) / dt
+    δt = lambda f: (f - t0(f)) / dt
     # 2nd order FD
-    tt = lambda f: (1.5 * f - 2 * subs0(f) + 0.5 * subs0(subs0(f))) / dt
+    tt = lambda f: (1.5 * f - 2 * t0(f) + 0.5 * t0(t0(f))) / dt
     # extrapolation for pressure
-    tp = lambda f: (1.5 * f - 0.5 * subs0(f))
+    tp = lambda f: (1.5 * f - 0.5 * t0(f))
 
     # Nutils namespace
     ns = function.Namespace()

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -56,7 +56,7 @@ def main(inflow: 'inflow velocity' = 10,
     ns.x0 = geom  # reference geometry
     ns.dbasis = domain.basis('std', degree=1).vector(2)
     ns.d_i = 'dbasis_ni ?meshdofs_n'
-    ns.umesh_i = 'dbasis_ni (1.5 ?meshdofs_n - 2 ?meshdofs0_n + 0.5 ?meshdofs00_n ) / ?dt'
+    ns.umesh = tt(ns.d) # mesh velocity
     ns.x_i = 'x0_i + d_i'  # moving geometry
     ns.ubasis, ns.pbasis = function.chain([domain.basis('std', degree=2).vector(2), domain.basis('std', degree=1), ])
     ns.F_i = 'ubasis_ni ?F_n'  # stress field

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -174,13 +174,7 @@ def main(inflow: 'inflow velocity' = 10,
 
         # save checkpoint
         if interface.is_action_required(precice.action_write_iteration_checkpoint()):
-            lhs_checkpoint = lhs0
-            lhs00_checkpoint = lhs00
-            t_checkpoint = t
-            timestep_checkpoint = timestep
-            oldmeshdofs_checkpoint = oldmeshdofs
-            oldoldmeshdofs_checkpoint = oldoldmeshdofs
-            oldoldoldmeshdofs_checkpoint = oldoldoldmeshdofs
+            checkpoint = lhs0, lhs00, t, timestep, oldmeshdofs, oldoldmeshdofs, oldoldoldmeshdofs
             interface.mark_action_fulfilled(precice.action_write_iteration_checkpoint())
 
         # solve fluid equations
@@ -215,13 +209,7 @@ def main(inflow: 'inflow velocity' = 10,
 
         # read checkpoint if required
         if interface.is_action_required(precice.action_read_iteration_checkpoint()):
-            lhs0 = lhs_checkpoint
-            lhs00 = lhs00_checkpoint
-            t = t_checkpoint
-            timestep = timestep_checkpoint
-            oldmeshdofs = oldmeshdofs_checkpoint
-            oldoldmeshdofs = oldoldmeshdofs_checkpoint
-            oldoldoldmeshdofs = oldoldoldmeshdofs_checkpoint
+            lhs0, lhs00, t, timestep, oldmeshdofs, oldoldmeshdofs, oldoldoldmeshdofs = checkpoint
             interface.mark_action_fulfilled(precice.action_read_iteration_checkpoint())
 
         if interface.is_time_window_complete():

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -43,10 +43,10 @@ def main(inflow: 'inflow velocity' = 10,
     tθ = lambda f: theta * f + (1 - theta) * t0(f)
     # 1st order FD
     δt = lambda f: (f - t0(f)) / function.Argument('dt', ())
-    # 2nd order FD
-    tt = lambda f: (1.5 * f - 2 * t0(f) + 0.5 * t0(t0(f))) / function.Argument('dt', ())
     # extrapolation for pressure
     tp = lambda f: (1.5 * f - 0.5 * t0(f))
+    # 2nd order FD
+    tt = lambda f: tp(δt(f))
 
     # Nutils namespace
     ns = function.Namespace()

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -7,7 +7,7 @@ import precice
 
 # for details on this solver see https://doi.org/10.1002/nme.6443
 
-def main(inflow=10., viscosity=1., density=1., theta=.5, timestepsize=.01):
+def main(inflow=10., viscosity=1., density=1., theta=.5, timestepsize=.01, npoints_per_elem=3):
 
     # mesh and geometry definition
     topo, geom = mesh.rectilinear([
@@ -54,7 +54,7 @@ def main(inflow=10., viscosity=1., density=1., theta=.5, timestepsize=.01):
     ns.urel_i = 'ubasis_ni ?lhs_n'  # relative velocity
     ns.u_i = 'umesh_i + urel_i'  # total velocity
     ns.p = 'pbasis_n ?lhs_n'  # pressure
-    ns.qw = couplingsample.asfunction(numpy.concatenate([p.weights for p in couplingsample.points]))
+    ns.qw = 1 / npoints_per_elem
 
     # boundary conditions for fluid equations
     sqr = domain.boundary['wall,flap'].integral('urel_k urel_k d:x0' @ ns, degree=4)

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -42,9 +42,9 @@ def main(inflow: 'inflow velocity' = 10,
     # TR interpolation
     tθ = lambda f: theta * f + (1 - theta) * t0(f)
     # 1st order FD
-    δt = lambda f: (f - t0(f)) / dt
+    δt = lambda f: (f - t0(f)) / function.Argument('dt', ())
     # 2nd order FD
-    tt = lambda f: (1.5 * f - 2 * t0(f) + 0.5 * t0(t0(f))) / dt
+    tt = lambda f: (1.5 * f - 2 * t0(f) + 0.5 * t0(t0(f))) / function.Argument('dt', ())
     # extrapolation for pressure
     tp = lambda f: (1.5 * f - 0.5 * t0(f))
 

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -135,7 +135,6 @@ def main(inflow: 'inflow velocity' = 10,
     lhs00 = lhs0
 
     timestep = 0
-    t = 0
 
     while interface.is_coupling_ongoing():
       with treelog.context(f'timestep {timestep}'):
@@ -150,7 +149,7 @@ def main(inflow: 'inflow velocity' = 10,
 
         # save checkpoint
         if interface.is_action_required(precice.action_write_iteration_checkpoint()):
-            checkpoint = lhs0, lhs00, t, timestep, meshdofs0, meshdofs00, meshdofs000, meshdofs0000
+            checkpoint = lhs0, lhs00, timestep, meshdofs0, meshdofs00, meshdofs000, meshdofs0000
             interface.mark_action_fulfilled(precice.action_write_iteration_checkpoint())
 
         # solve fluid equations
@@ -176,7 +175,6 @@ def main(inflow: 'inflow velocity' = 10,
 
         # advance variables
         timestep += 1
-        t += dt
         lhs00 = lhs0
         lhs0 = lhs1
         meshdofs0000 = meshdofs000
@@ -186,7 +184,7 @@ def main(inflow: 'inflow velocity' = 10,
 
         # read checkpoint if required
         if interface.is_action_required(precice.action_read_iteration_checkpoint()):
-            lhs0, lhs00, t, timestep, meshdofs0, meshdofs00, meshdofs000, meshdofs0000 = checkpoint
+            lhs0, lhs00, timestep, meshdofs0, meshdofs00, meshdofs000, meshdofs0000 = checkpoint
             interface.mark_action_fulfilled(precice.action_read_iteration_checkpoint())
 
         if interface.is_time_window_complete():

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -40,10 +40,6 @@ def main(inflow: 'inflow velocity' = 10,
     tθ = lambda f: theta * f + (1 - theta) * t0(f)
     # 1st order FD
     δt = lambda f: (f - t0(f)) / function.Argument('dt', ())
-    # extrapolation for pressure
-    tp = lambda f: (1.5 * f - 0.5 * t0(f))
-    # 2nd order FD
-    tt = lambda f: tp(δt(f))
 
     # Nutils namespace
     ns = function.Namespace()
@@ -53,7 +49,7 @@ def main(inflow: 'inflow velocity' = 10,
     ns.x0 = geom  # reference geometry
     ns.dbasis = domain.basis('std', degree=1).vector(2)
     ns.d_i = 'dbasis_ni ?meshdofs_n'
-    ns.umesh = tt(ns.d) # mesh velocity
+    ns.umesh = δt(ns.d) # mesh velocity
     ns.x_i = 'x0_i + d_i'  # moving geometry
     ns.ubasis, ns.pbasis = function.chain([domain.basis('std', degree=2).vector(2), domain.basis('std', degree=1), ])
     ns.F_i = 'ubasis_ni ?F_n'  # stress field
@@ -118,7 +114,7 @@ def main(inflow: 'inflow velocity' = 10,
     timestep = 0
     arguments = dict(lhs=numpy.zeros(len(ns.ubasis)), meshdofs=numpy.zeros(len(ns.dbasis)), dt=timestepsize)
 
-    nhist = 4 # history length required by the formulation
+    nhist = 2 # history length required by the formulation
     arguments.update((k+'0'*i, v) for k, v in tuple(arguments.items()) for i in range(nhist))
 
     while interface.is_coupling_ongoing():

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -153,7 +153,7 @@ def main(inflow: 'inflow velocity' = 10,
             interface.mark_action_fulfilled(precice.action_write_iteration_checkpoint())
 
         # solve fluid equations
-        lhs1 = solver.newton('lhs', res, lhs0=lhs0, constrain=cons,
+        lhs = solver.newton('lhs', res, lhs0=lhs0, constrain=cons,
                              arguments=dict(lhs0=lhs0, dt=dt, meshdofs=meshdofs, meshdofs0=meshdofs0,
                                             meshdofs00=meshdofs00, meshdofs000=meshdofs000, meshdofs0000=meshdofs0000)
                              ).solve(tol=1e-6)
@@ -161,7 +161,7 @@ def main(inflow: 'inflow velocity' = 10,
         # write forces to interface
         if interface.is_write_data_required(dt):
             F = solver.solve_linear('F', resF, constrain=consF,
-                                    arguments=dict(lhs00=lhs00, lhs0=lhs0, lhs=lhs1, dt=dt, meshdofs=meshdofs,
+                                    arguments=dict(lhs00=lhs00, lhs0=lhs0, lhs=lhs, dt=dt, meshdofs=meshdofs,
                                                    meshdofs0=meshdofs0, meshdofs00=meshdofs00,
                                                    meshdofs000=meshdofs000, meshdofs0000=meshdofs0000))
             # writedata = couplingsample.eval(ns.F, F=F) # for stresses
@@ -176,7 +176,7 @@ def main(inflow: 'inflow velocity' = 10,
         # advance variables
         timestep += 1
         lhs00 = lhs0
-        lhs0 = lhs1
+        lhs0 = lhs
         meshdofs0000 = meshdofs000
         meshdofs000 = meshdofs00
         meshdofs00 = meshdofs0
@@ -188,7 +188,7 @@ def main(inflow: 'inflow velocity' = 10,
             interface.mark_action_fulfilled(precice.action_read_iteration_checkpoint())
 
         if interface.is_time_window_complete():
-            x, u, p = bezier.eval(['x_i', 'u_i', 'p'] @ ns, lhs=lhs1, meshdofs=meshdofs, meshdofs0=meshdofs0,
+            x, u, p = bezier.eval(['x_i', 'u_i', 'p'] @ ns, lhs=lhs, meshdofs=meshdofs, meshdofs0=meshdofs0,
                                   meshdofs00=meshdofs00, meshdofs000=meshdofs000, meshdofs0000=meshdofs0000, dt=dt)
             export.triplot('velocity.jpg', x, numpy.linalg.norm(u, axis=1), tri=bezier.tri, cmap='jet')
             export.triplot('pressure.jpg', x, p, tri=bezier.tri, cmap='jet')

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -105,8 +105,7 @@ def main(inflow: 'inflow velocity' = 10,
     resF += tt(domain.integral('rho ubasis_ni u_i d:x' @ ns, degree=4))
     resF += domain.integral('rho ubasis_ni (u_i,j urel_j d:x)' @ ns, degree=4)
     resF += couplinginterface.sample('gauss', 4).integral('ubasis_ni F_i d:x' @ ns)
-    consF = numpy.isnan(solver.optimize('F', couplinginterface.sample('gauss', 4).integral('F_i F_i' @ ns),
-                                        droptol=1e-10))
+    consF = couplingsample.integrate((ns.ubasis**2).sum(1)) == 0
 
     # boundary conditions mesh displacements
     sqr = domain.boundary['inflow,outflow,wall'].integral('d_i d_i' @ ns, degree=2)

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -192,6 +192,8 @@ def main(inflow: 'inflow velocity' = 10,
         if interface.is_time_window_complete():
             x, u, p = bezier.eval(['x_i', 'u_i', 'p'] @ ns, lhs=lhs1, meshdofs=meshdofs, meshdofs0=meshdofs0,
                                   meshdofs00=meshdofs00, meshdofs000=meshdofs000, meshdofs0000=meshdofs0000, dt=dt)
+            export.triplot('velocity.jpg', x, numpy.linalg.norm(u, axis=1), tri=bezier.tri, cmap='jet')
+            export.triplot('pressure.jpg', x, p, tri=bezier.tri, cmap='jet')
             with treelog.add(treelog.DataLog()):
                 export.vtk('Fluid_' + str(timestep), bezier.tri, x, u=u, p=p)
 

--- a/perpendicular-flap/fluid-nutils/fluid.py
+++ b/perpendicular-flap/fluid-nutils/fluid.py
@@ -21,14 +21,6 @@ def subs0(f):
     if isinstance(f, function.Argument) and f._name == 'meshdofs00':
         return function.Argument(name='meshdofs000', shape=f.shape, nderiv=f._nderiv)
 
-# some helper function to shift variables by two timesteps
-
-
-@function.replace
-def subs00(f):
-    if isinstance(f, function.Argument) and f._name == 'lhs':
-        return function.Argument(name='lhs00', shape=f.shape, nderiv=f._nderiv)
-
 
 def main(inflow: 'inflow velocity' = 10,
          viscosity: 'kinematic viscosity' = 1.0,
@@ -65,7 +57,7 @@ def main(inflow: 'inflow velocity' = 10,
     # 1st order FD
     δt = lambda f: (f - subs0(f)) / dt
     # 2nd order FD
-    tt = lambda f: (1.5 * f - 2 * subs0(f) + 0.5 * subs00(f)) / dt
+    tt = lambda f: (1.5 * f - 2 * subs0(f) + 0.5 * subs0(subs0(f))) / dt
     # extrapolation for pressure
     tp = lambda f: (1.5 * f - 0.5 * subs0(f))
 

--- a/perpendicular-flap/fluid-nutils/run.sh
+++ b/perpendicular-flap/fluid-nutils/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e -u
 
-python3 fluid.py
+python3 fluid.py richoutput=no


### PR DESCRIPTION
This PR reworks the Nutils fluid participant to make the code cleaner and compatible with Nutils 8, while remaining compatible with Nutils 7. It also adds a solid participant compatible only with Nutils 8. Only the final commit relates to the solid participant so it can trivially be split off into a separate PR if that is preferred.

The fluid modifications are organized in many small commits with their distinct purpose hopefully clear from the commit message. Up to d89f08d the formulation itself is not modified, though results change slightly because of minor bug fixes (e.g. 4b7b925, 6e05ed0). Beyond that the formulation is progressively simplified to the point of requiring only the previous solution, rather than the past four. The change of d89f08d could optionally be modified to involve the previous `F` for higher accuracy, though at the expense of oscillations, which the current implementation also suffers from -- the proposed formulation is oscillation free. Commit 35b8b34 does away with the hacky `qw` definition by switching to a uniform integration scheme, which anyway seems like reasonable enough given the non-polynomial nature of the integrand. All in all, the modified script is of a more standard nature and should be easier to follow for most Nutils users.

The failing Lint docs test seems unrelated to the changes in this PR.

closes #217 