### PR TITLE
Port elastic-tube-1d solvers to version 3

### DIFF
--- a/elastic-tube-1d/fluid-cpp/CMakeLists.txt
+++ b/elastic-tube-1d/fluid-cpp/CMakeLists.txt
@@ -15,7 +15,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STRE
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
 endif()
 
-find_package(precice REQUIRED CONFIG)
+find_package(precice 3 REQUIRED CONFIG)
 find_package(LAPACK REQUIRED)
 
 add_executable(FluidSolver

--- a/elastic-tube-1d/fluid-python/FluidSolver.py
+++ b/elastic-tube-1d/fluid-python/FluidSolver.py
@@ -106,7 +106,8 @@ print("Fluid: init precice...")
 # preCICE defines timestep size of solver via precice-config.xml
 interface.initialize()
 
-crossSectionLength = interface.read_data(meshName, crossSectionLengthName, vertexIDs, 0)
+crossSectionLength = interface.read_data(
+    meshName, crossSectionLengthName, vertexIDs, 0)
 
 crossSectionLength_old = np.copy(crossSectionLength)
 # initialize such that mass conservation is fulfilled
@@ -123,7 +124,8 @@ while interface.is_coupling_ongoing():
 
     precice_dt = interface.get_max_time_step_size()
 
-    crossSectionLength = interface.read_data(meshName, crossSectionLengthName, vertexIDs, precice_dt)
+    crossSectionLength = interface.read_data(
+        meshName, crossSectionLengthName, vertexIDs, precice_dt)
     velocity, pressure, success = perform_partitioned_implicit_euler_step(
         velocity_old, pressure_old, crossSectionLength_old, crossSectionLength, dx, precice_dt, velocity_in(
             t + precice_dt), custom_coupling=True)

--- a/elastic-tube-1d/fluid-python/FluidSolver.py
+++ b/elastic-tube-1d/fluid-python/FluidSolver.py
@@ -90,9 +90,7 @@ if plotting_mode == config.PlottingModes.VIDEO:
         writer = FFMpegWriter(fps=15, metadata=metadata)
         writer.setup(fig, "writer_test.mp4", 100)
 
-vertexIDs = np.zeros(N + 1)
 grid = np.zeros([N + 1, dimensions])
-
 grid[:, 0] = np.linspace(0, L, N + 1)  # x component
 grid[:, 1] = 0  # y component, leave blank
 
@@ -118,19 +116,19 @@ velocity_old = velocity_in(
 print(crossSectionLength_old)
 
 time_it = 0
-precice_dt = interface.get_max_time_step_size()
 while interface.is_coupling_ongoing():
     # When an implicit coupling scheme is used, checkpointing is required
     if interface.requires_writing_checkpoint():
         pass
 
+    precice_dt = interface.get_max_time_step_size()
+
+    crossSectionLength = interface.read_data(meshName, crossSectionLengthName, vertexIDs, precice_dt)
     velocity, pressure, success = perform_partitioned_implicit_euler_step(
         velocity_old, pressure_old, crossSectionLength_old, crossSectionLength, dx, precice_dt, velocity_in(
             t + precice_dt), custom_coupling=True)
     interface.write_data(meshName, pressureName, vertexIDs, pressure)
     interface.advance(precice_dt)
-    precice_dt = interface.get_max_time_step_size()
-    crossSectionLength = interface.read_data(meshName, crossSectionLengthName, vertexIDs, precice_dt)
 
     # i.e. not yet converged
     if interface.requires_reading_checkpoint():

--- a/elastic-tube-1d/fluid-python/FluidSolver.py
+++ b/elastic-tube-1d/fluid-python/FluidSolver.py
@@ -10,8 +10,6 @@ import matplotlib.pyplot as plt
 import matplotlib.animation as manimation
 from output import writeOutputToVTK
 import precice
-from precice import action_write_initial_data, action_write_iteration_checkpoint, \
-    action_read_iteration_checkpoint
 
 # physical properties of the tube
 r0 = 1 / np.sqrt(np.pi)  # radius of the tube
@@ -68,10 +66,14 @@ print("Starting Fluid Solver...")
 print("N: " + str(N))
 
 print("Configure preCICE...")
-interface = precice.Interface("Fluid", args.configurationFileName, 0, 1)
+interface = precice.Participant("Fluid", args.configurationFileName, 0, 1)
 print("preCICE configured...")
 
-dimensions = interface.get_dimensions()
+meshName = "Fluid-Nodes-Mesh"
+crossSectionLengthName = "CrossSectionLength"
+pressureName = "Pressure"
+
+dimensions = interface.get_mesh_dimensions(meshName)
 
 velocity = velocity_in(0) * np.ones(N + 1)
 velocity_old = velocity_in(0) * np.ones(N + 1)
@@ -88,33 +90,25 @@ if plotting_mode == config.PlottingModes.VIDEO:
         writer = FFMpegWriter(fps=15, metadata=metadata)
         writer.setup(fig, "writer_test.mp4", 100)
 
-meshID = interface.get_mesh_id("Fluid-Nodes-Mesh")
-crossSectionLengthID = interface.get_data_id("CrossSectionLength", meshID)
-pressureID = interface.get_data_id("Pressure", meshID)
-
 vertexIDs = np.zeros(N + 1)
 grid = np.zeros([N + 1, dimensions])
 
 grid[:, 0] = np.linspace(0, L, N + 1)  # x component
 grid[:, 1] = 0  # y component, leave blank
 
-vertexIDs = interface.set_mesh_vertices(meshID, grid)
+vertexIDs = interface.set_mesh_vertices(meshName, grid)
+
+if interface.requires_initial_data():
+    interface.write_data(meshName, pressureName, vertexIDs, pressure)
 
 t = 0
+
 
 print("Fluid: init precice...")
 # preCICE defines timestep size of solver via precice-config.xml
 precice_dt = interface.initialize()
 
-if interface.is_action_required(action_write_initial_data()):
-    interface.write_block_scalar_data(pressureID, vertexIDs, pressure)
-    interface.mark_action_fulfilled(action_write_initial_data())
-
-interface.initialize_data()
-
-if interface.is_read_data_available():
-    crossSectionLength = interface.read_block_scalar_data(
-        crossSectionLengthID, vertexIDs)
+crossSectionLength = interface.read_data(meshName, crossSectionLengthName, vertexIDs, 0)
 
 crossSectionLength_old = np.copy(crossSectionLength)
 # initialize such that mass conservation is fulfilled
@@ -124,22 +118,23 @@ velocity_old = velocity_in(
 print(crossSectionLength_old)
 
 time_it = 0
+precice_dt = interface.get_max_time_step_size()
 while interface.is_coupling_ongoing():
     # When an implicit coupling scheme is used, checkpointing is required
-    if interface.is_action_required(action_write_iteration_checkpoint()):
-        interface.mark_action_fulfilled(action_write_iteration_checkpoint())
+    if interface.requires_writing_checkpoint():
+        pass
 
     velocity, pressure, success = perform_partitioned_implicit_euler_step(
         velocity_old, pressure_old, crossSectionLength_old, crossSectionLength, dx, precice_dt, velocity_in(
             t + precice_dt), custom_coupling=True)
-    interface.write_block_scalar_data(pressureID, vertexIDs, pressure)
+    interface.write_data(meshName, pressureName, vertexIDs, pressure)
     interface.advance(precice_dt)
-    crossSectionLength = interface.read_block_scalar_data(
-        crossSectionLengthID, vertexIDs)
+    precice_dt = interface.get_max_time_step_size()
+    crossSectionLength = interface.read_data(meshName, crossSectionLengthName, vertexIDs, precice_dt)
 
     # i.e. not yet converged
-    if interface.is_action_required(action_read_iteration_checkpoint()):
-        interface.mark_action_fulfilled(action_read_iteration_checkpoint())
+    if interface.requires_reading_checkpoint():
+        pass
     else:  # converged, timestep complete
         t += precice_dt
         if plotting_mode is config.PlottingModes.VIDEO:
@@ -159,5 +154,3 @@ print("Exiting FluidSolver")
 
 if plotting_mode is config.PlottingModes.VIDEO and writeVideoToFile:
     writer.finish()
-
-interface.finalize()

--- a/elastic-tube-1d/fluid-python/FluidSolver.py
+++ b/elastic-tube-1d/fluid-python/FluidSolver.py
@@ -106,7 +106,7 @@ t = 0
 
 print("Fluid: init precice...")
 # preCICE defines timestep size of solver via precice-config.xml
-precice_dt = interface.initialize()
+interface.initialize()
 
 crossSectionLength = interface.read_data(meshName, crossSectionLengthName, vertexIDs, 0)
 

--- a/elastic-tube-1d/precice-config.xml
+++ b/elastic-tube-1d/precice-config.xml
@@ -46,7 +46,7 @@
   <coupling-scheme:serial-implicit>
     <participants first="Fluid" second="Solid" />
     <max-time value="1.0" />
-    <time-window-size value="0.01" valid-digits="8" />
+    <time-window-size value="0.01" />
     <max-iterations value="40" />
     <exchange data="Pressure" mesh="Fluid-Nodes-Mesh" from="Fluid" to="Solid" />
     <exchange

--- a/elastic-tube-1d/solid-cpp/CMakeLists.txt
+++ b/elastic-tube-1d/solid-cpp/CMakeLists.txt
@@ -15,7 +15,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STRE
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
 endif()
 
-find_package(precice REQUIRED CONFIG)
+find_package(precice 3 REQUIRED CONFIG)
 
 add_executable(SolidSolver
   src/SolidComputeSolution.cpp

--- a/elastic-tube-1d/solid-cpp/src/SolidComputeSolution.cpp
+++ b/elastic-tube-1d/solid-cpp/src/SolidComputeSolution.cpp
@@ -8,10 +8,12 @@ void SolidComputeSolution(int chunkLength, double const * const pressure, double
    */
   const double PI    = 3.14159265359;
   const double E = 10000;
-  const double c_mk2 = E / 2 * std::sqrt(PI);
+  const double r0 = 1.0/ std::sqrt(PI);
+  const double c_mk = std::sqrt(E / 2 / r0);
+  const double c_mk2 = c_mk * c_mk;
   const double pressure0 = 0.0;
+
   for (int i = 0; i < chunkLength; i++) {
-    //crossSectionLength[i] = 4.0 / ((2.0 - pressure[i]) * (2.0 - pressure[i]));
-    crossSectionLength[i] = std::pow((pressure0 - 2.0 * c_mk2) / (pressure[i] - 2.0 * c_mk2), 2);
+    crossSectionLength[i] =  std::pow((pressure0 - 2.0 * c_mk2), 2.0) / std::pow((pressure[i] - 2.0 * c_mk2), 2.0);
   }
 }

--- a/elastic-tube-1d/solid-cpp/src/SolidSolver.cpp
+++ b/elastic-tube-1d/solid-cpp/src/SolidSolver.cpp
@@ -16,8 +16,9 @@ int main(int argc, char **argv)
   }
 
   std::string configFileName(argv[1]);
-  int         domainSize  = 100; // N
-  int         chunkLength = domainSize + 1;
+  const int         domainSize  = 100; // N
+  const int         chunkLength = domainSize + 1;
+  const double      tubeLength = 10;
 
   std::cout << "N: " << domainSize << std::endl;
   std::cout << "inputs: " << argc << std::endl;
@@ -34,12 +35,11 @@ int main(int argc, char **argv)
 
   std::vector<double> pressure(chunkLength, 0.0);
   std::vector<double> crossSectionLength(chunkLength, 1.0);
-  std::vector<double> grid(dimensions * chunkLength);
 
-  for (int i = 0; i < chunkLength; i++) {
-    for (int j = 0; j < dimensions; j++) {
-      grid[i * dimensions + j] = i * (1 - j);
-    }
+  std::vector<double> grid(dimensions * chunkLength, 0.0);
+  const double dx = tubeLength/domainSize;
+  for (int i = 0; i < chunkLength; ++i) {
+    grid[i * dimensions] = dx*i;
   }
 
   std::vector<int> vertexIDs(chunkLength);

--- a/elastic-tube-1d/solid-python/SolidSolver.py
+++ b/elastic-tube-1d/solid-python/SolidSolver.py
@@ -57,7 +57,8 @@ grid[:, 1] = 0  # np.linspace(0, config.L, N+1)  # y component, leave blank
 vertexIDs = interface.set_mesh_vertices(meshName, grid)
 
 if interface.requires_initial_data():
-    interface.write_data(meshName, crossSectionLengthName, vertexIDs, crossSectionLength)
+    interface.write_data(meshName, crossSectionLengthName,
+                         vertexIDs, crossSectionLength)
 
 print("Solid: init precice...")
 
@@ -71,7 +72,7 @@ pressure0 = p0 * np.ones_like(pressure)
 
 
 def solve(pressure):
-    return crossSection0 * ( (pressure0 - 2.0 * c_mk ** 2) ** 2 / (pressure - 2.0 * c_mk ** 2) ** 2)
+    return crossSection0 * ((pressure0 - 2.0 * c_mk ** 2) ** 2 / (pressure - 2.0 * c_mk ** 2) ** 2)
 
 
 while interface.is_coupling_ongoing():
@@ -82,9 +83,11 @@ while interface.is_coupling_ongoing():
     precice_dt = interface.get_max_time_step_size()
 
     # Read data, solve timestep, and write data
-    pressure = interface.read_data(meshName, pressureName, vertexIDs, precice_dt)
+    pressure = interface.read_data(
+        meshName, pressureName, vertexIDs, precice_dt)
     crossSectionLength = solve(pressure)
-    interface.write_data(meshName, crossSectionLengthName, vertexIDs, crossSectionLength)
+    interface.write_data(meshName, crossSectionLengthName,
+                         vertexIDs, crossSectionLength)
 
     # Advance the coupling
     interface.advance(precice_dt)


### PR DESCRIPTION
This PR ports the elastic-tube-1d cpp solvers to version 3


This also rearranges the solvers to follow the pattern read data -> solve -> write data -> advance.

Also fixes the incorrect coordinates in solid-cpp #340 
