### PR TITLE
Optimize Upload times for systemtests

### DIFF
--- a/.github/workflows/run_testsuite_workflow.yml
+++ b/.github/workflows/run_testsuite_workflow.yml
@@ -63,7 +63,7 @@ jobs:
         cd ../../
     - name: Archive run files
       if: ${{  failure() || inputs.upload_artifacts == 'TRUE' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: runs
         path: |


### PR DESCRIPTION
Apparently we have been using a wrong version here: 
https://github.com/actions/upload-artifact/issues/199#issuecomment-1862996650

This should fix performance problems for now without complicating the workflow too much. 

I would consider it a fix for https://github.com/precice/tutorials/issues/425