### PR TITLE
Use endTime = 5 like max-time in precice-config.xml

### DIFF
--- a/perpendicular-flap/fluid-openfoam/system/controlDict
+++ b/perpendicular-flap/fluid-openfoam/system/controlDict
@@ -15,7 +15,7 @@ startTime       0;
 
 stopAt          endTime;
 
-endTime         10;
+endTime         5;
 
 deltaT          0.01;
 


### PR DESCRIPTION
I'm not sure if it really matters, because preCICE does the steering, but having a different `endTime` here looks strange to me.