### PR TITLE
Solve compatibility issue by using pandas newer version and matplotlib for plotting

### DIFF
--- a/oscillator/plot-trajectory.py
+++ b/oscillator/plot-trajectory.py
@@ -19,13 +19,13 @@ filename = args.csvFile
 df = pd.read_csv(filename, delimiter=';')
 
 if args.plotType == PlotType.U_OVER_T.name:
-    plt.plot(df['time'], df['position'])
+    plt.plot(df['time'].to_numpy(), df['position'].to_numpy())
     plt.title(PlotType.U_OVER_T.value)
 elif args.plotType == PlotType.V_OVER_T.name:
-    plt.plot(df['time'], df['velocity'])
+    plt.plot(df['time'].to_numpy(), df['velocity'].to_numpy())
     plt.title(PlotType.V_OVER_T.value)
 elif args.plotType == PlotType.TRAJECTORY.name:
-    plt.plot(df['position'], df['velocity'])
+    plt.plot(df['position'].to_numpy(), df['velocity'].to_numpy())
     plt.scatter([df['position'][0]], [df['velocity'][0]], label=f"(u,v) at t={df['time'][0]}")
     plt.scatter([df['position'].iloc[-1]], [df['velocity'].iloc[-1]],
                 label=f"(u,v) at t={df['time'].iloc[-1]}", marker="*")


### PR DESCRIPTION
For the newer `pandas` version(2.2.0 for my instance), it requires the data to be converted to a numpy array before indexing for plotting with `matplotlib.pyplot.plot()`. Otherwise it gives error like:
```
ValueError: Multi-dimensional indexing (e.g. `obj[:, None]`) is no longer supported. Convert to a numpy array before indexing instead.
```
The `plot-trajectory.py` in the tutorial case `oscillator` is this case.
