### PR TITLE
Add bottombar to nutils cases

### DIFF
--- a/channel-transport/fluid-nutils/requirements.txt
+++ b/channel-transport/fluid-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+bottombar>=2.1
 pyprecice==3.0.0.0dev2

--- a/flow-over-heated-plate/solid-nutils/requirements.txt
+++ b/flow-over-heated-plate/solid-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+bottombar>=2.1
 pyprecice==3.0.0.0dev2

--- a/partitioned-heat-conduction-direct/nutils/requirements.txt
+++ b/partitioned-heat-conduction-direct/nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+bottombar>=2.1
 pyprecice==3.0.0.0dev2

--- a/partitioned-heat-conduction/nutils/requirements.txt
+++ b/partitioned-heat-conduction/nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+bottombar>=2.1
 pyprecice==3.0.0.0dev2

--- a/perpendicular-flap/solid-nutils/requirements.txt
+++ b/perpendicular-flap/solid-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==8
+bottombar>=2.1
 pyprecice==3.0.0.0dev2

--- a/two-scale-heat-conduction/macro-nutils/requirements.txt
+++ b/two-scale-heat-conduction/macro-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+bottombar>=2.1
 pyprecice==3.0.0.0dev2

--- a/two-scale-heat-conduction/micro-nutils/requirements.txt
+++ b/two-scale-heat-conduction/micro-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+bottombar>=2.1
 pyprecice==3.0.0.0dev2


### PR DESCRIPTION
This PR adds bottombar to nutils cases to prevent a signal interrupt in preCICE.
Only exception is the nutils 6 case.

Original solution from here https://github.com/precice/tutorials/pull/431#pullrequestreview-1812711006
