### PR TITLE
Add hook to check image names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,10 @@ repos:
   rev: 'v8.0.1'
   hooks:
   - id: clang-format
+- repo: local
+  hooks:
+    - id: check-image-naming
+      name: check image names
+      language: python
+      entry: tools/check-image-names.py
+      files: ".*/images/.*"

--- a/tools/check-image-names.py
+++ b/tools/check-image-names.py
@@ -1,0 +1,24 @@
+#!python3
+
+import sys
+import os
+
+problems = False
+for file in sys.argv[1:]:
+    parts = file.split(os.sep)
+    # Ignore non-interesting files
+    if len(parts) != 3 or parts[1] != "images":
+        continue
+
+    if parts[0] == "quickstart":
+        prefix = "quickstart-"
+    else:
+        prefix = f"tutorials-{parts[0]}-"
+
+    if not parts[2].startswith(prefix):
+        print(f"Incorrect: {file}")
+        print(f"Expected prefix: {prefix}")
+        print()
+        problems = True
+
+sys.exit(1 if problems else 0)


### PR DESCRIPTION
This PR adds a pre-commit hook that checks if the names of images in `A/images/` are correctly prefixed.

The required prefix is: `tutorial-<A>-` or `quickstart-` if `A` is `quickstart`.

This is required to prevent conflicts in the website assets folder.
