### PR TITLE
Use dedicated OpenFOAM solver clang format to make solver compile again

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     - id: autopep8
       args: [ --in-place, --exit-code, --aggressive, --ignore=E402, --max-line-length=120 ]
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v8.0.1'
+  rev: 'v14.0.6'
   hooks:
   - id: clang-format
 - repo: https://github.com/koalaman/shellcheck-precommit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
   rev: 'v14.0.6'
   hooks:
   - id: clang-format
+    exclude: '\.json$'
 - repo: https://github.com/koalaman/shellcheck-precommit
   rev: v0.10.0
   hooks:

--- a/elastic-tube-1d/fluid-cpp/src/FluidComputeSolution.cpp
+++ b/elastic-tube-1d/fluid-cpp/src/FluidComputeSolution.cpp
@@ -22,20 +22,20 @@ public:
   }
 
 private:
-  T * first;
+  T  *first;
   int stride;
 };
 
 extern "C" {
 void dgesv_(
-    int *   n,
-    int *   nrhs,
+    int    *n,
+    int    *nrhs,
     double *A,
-    int *   lda,
-    int *   ipiv,
+    int    *lda,
+    int    *ipiv,
     double *b,
-    int *   ldb,
-    int *   info);
+    int    *ldb,
+    int    *info);
 }
 
 /* Function for fluid_nl i.e. non-linear */
@@ -48,8 +48,8 @@ int fluidComputeSolutionSerial(
     int                 N,
     double              kappa,
     double              tau,
-    double *            velocity,
-    double *            pressure)
+    double             *velocity,
+    double             *pressure)
 {
   const double PI = 3.141592653589793;
 

--- a/elastic-tube-1d/fluid-cpp/src/FluidComputeSolution.h
+++ b/elastic-tube-1d/fluid-cpp/src/FluidComputeSolution.h
@@ -11,5 +11,5 @@ int fluidComputeSolutionSerial(
     int                 N,
     double              kappa,
     double              tau,
-    double *            velocity,
-    double *            pressure);
+    double             *velocity,
+    double             *pressure);

--- a/elastic-tube-1d/fluid-cpp/src/FluidSolver.cpp
+++ b/elastic-tube-1d/fluid-cpp/src/FluidSolver.cpp
@@ -20,14 +20,14 @@ int main(int argc, char **argv)
   }
 
   std::string  configFileName(argv[1]);
-  int          domainSize  = 100; //N
+  int          domainSize  = 100; // N
   int          chunkLength = domainSize + 1;
   const double kappa       = 100;
   const double L           = 10.0; // tube length
 
   const std::string solverName = "Fluid";
 
-  std::string outputFilePrefix = "./output/out_fluid"; //extra
+  std::string outputFilePrefix = "./output/out_fluid"; // extra
 
   precice::Participant interface(solverName, configFileName, 0, 1);
   std::cout << "preCICE configured..." << std::endl;

--- a/elastic-tube-1d/fluid-cpp/src/utilities.cpp
+++ b/elastic-tube-1d/fluid-cpp/src/utilities.cpp
@@ -8,22 +8,22 @@
 #include <string>
 #include <vector>
 
-/* 
-   Function for solving the linear system 
+/*
+   Function for solving the linear system
    LAPACK is used DGESV computes the solution to a real system of linear equations
    A * x = b,
    where A is an N-by-N matrix and x and b are N-by-NRHS matrices.
 */
 extern "C" {
 void dgesv_(
-    int *   n,
-    int *   nrhs,
+    int    *n,
+    int    *nrhs,
     double *A,
-    int *   lda,
-    int *   ipiv,
+    int    *lda,
+    int    *ipiv,
     double *b,
-    int *   ldb,
-    int *   info);
+    int    *ldb,
+    int    *info);
 }
 
 void initializeWriting(std::ofstream &filestream)

--- a/elastic-tube-1d/fluid-cpp/src/utilities.h
+++ b/elastic-tube-1d/fluid-cpp/src/utilities.h
@@ -5,9 +5,9 @@ void write_vtk(double      t,
                int         iteration,
                const char *filename_prefix,
                int         N_slices,
-               double *    grid,
-               double *    velocity,
-               double *    pressure,
-               double *    diameter);
+               double     *grid,
+               double     *velocity,
+               double     *pressure,
+               double     *diameter);
 
 #endif

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/FMI.h
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/FMI.h
@@ -115,7 +115,7 @@ struct FMIInstance_ {
 
   void *userData;
 
-  FMILogMessage *     logMessage;
+  FMILogMessage      *logMessage;
   FMILogFunctionCall *logFunctionCall;
 
   double time;

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/FMI2.h
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/FMI2.h
@@ -17,62 +17,62 @@ struct FMI2Functions_ {
     ****************************************************/
 
   /* required functions */
-  fmi2GetTypesPlatformTYPE *       fmi2GetTypesPlatform;
-  fmi2GetVersionTYPE *             fmi2GetVersion;
-  fmi2SetDebugLoggingTYPE *        fmi2SetDebugLogging;
-  fmi2InstantiateTYPE *            fmi2Instantiate;
-  fmi2FreeInstanceTYPE *           fmi2FreeInstance;
-  fmi2SetupExperimentTYPE *        fmi2SetupExperiment;
+  fmi2GetTypesPlatformTYPE        *fmi2GetTypesPlatform;
+  fmi2GetVersionTYPE              *fmi2GetVersion;
+  fmi2SetDebugLoggingTYPE         *fmi2SetDebugLogging;
+  fmi2InstantiateTYPE             *fmi2Instantiate;
+  fmi2FreeInstanceTYPE            *fmi2FreeInstance;
+  fmi2SetupExperimentTYPE         *fmi2SetupExperiment;
   fmi2EnterInitializationModeTYPE *fmi2EnterInitializationMode;
-  fmi2ExitInitializationModeTYPE * fmi2ExitInitializationMode;
-  fmi2TerminateTYPE *              fmi2Terminate;
-  fmi2ResetTYPE *                  fmi2Reset;
-  fmi2GetRealTYPE *                fmi2GetReal;
-  fmi2GetIntegerTYPE *             fmi2GetInteger;
-  fmi2GetBooleanTYPE *             fmi2GetBoolean;
-  fmi2GetStringTYPE *              fmi2GetString;
-  fmi2SetRealTYPE *                fmi2SetReal;
-  fmi2SetIntegerTYPE *             fmi2SetInteger;
-  fmi2SetBooleanTYPE *             fmi2SetBoolean;
-  fmi2SetStringTYPE *              fmi2SetString;
+  fmi2ExitInitializationModeTYPE  *fmi2ExitInitializationMode;
+  fmi2TerminateTYPE               *fmi2Terminate;
+  fmi2ResetTYPE                   *fmi2Reset;
+  fmi2GetRealTYPE                 *fmi2GetReal;
+  fmi2GetIntegerTYPE              *fmi2GetInteger;
+  fmi2GetBooleanTYPE              *fmi2GetBoolean;
+  fmi2GetStringTYPE               *fmi2GetString;
+  fmi2SetRealTYPE                 *fmi2SetReal;
+  fmi2SetIntegerTYPE              *fmi2SetInteger;
+  fmi2SetBooleanTYPE              *fmi2SetBoolean;
+  fmi2SetStringTYPE               *fmi2SetString;
 
   /* optional functions */
-  fmi2GetFMUstateTYPE *             fmi2GetFMUstate;
-  fmi2SetFMUstateTYPE *             fmi2SetFMUstate;
-  fmi2FreeFMUstateTYPE *            fmi2FreeFMUstate;
-  fmi2SerializedFMUstateSizeTYPE *  fmi2SerializedFMUstateSize;
-  fmi2SerializeFMUstateTYPE *       fmi2SerializeFMUstate;
-  fmi2DeSerializeFMUstateTYPE *     fmi2DeSerializeFMUstate;
+  fmi2GetFMUstateTYPE              *fmi2GetFMUstate;
+  fmi2SetFMUstateTYPE              *fmi2SetFMUstate;
+  fmi2FreeFMUstateTYPE             *fmi2FreeFMUstate;
+  fmi2SerializedFMUstateSizeTYPE   *fmi2SerializedFMUstateSize;
+  fmi2SerializeFMUstateTYPE        *fmi2SerializeFMUstate;
+  fmi2DeSerializeFMUstateTYPE      *fmi2DeSerializeFMUstate;
   fmi2GetDirectionalDerivativeTYPE *fmi2GetDirectionalDerivative;
 
   /***************************************************
     Functions for FMI 2.0 for Model Exchange
     ****************************************************/
 
-  fmi2EnterEventModeTYPE *               fmi2EnterEventMode;
-  fmi2NewDiscreteStatesTYPE *            fmi2NewDiscreteStates;
-  fmi2EnterContinuousTimeModeTYPE *      fmi2EnterContinuousTimeMode;
-  fmi2CompletedIntegratorStepTYPE *      fmi2CompletedIntegratorStep;
-  fmi2SetTimeTYPE *                      fmi2SetTime;
-  fmi2SetContinuousStatesTYPE *          fmi2SetContinuousStates;
-  fmi2GetDerivativesTYPE *               fmi2GetDerivatives;
-  fmi2GetEventIndicatorsTYPE *           fmi2GetEventIndicators;
-  fmi2GetContinuousStatesTYPE *          fmi2GetContinuousStates;
+  fmi2EnterEventModeTYPE                *fmi2EnterEventMode;
+  fmi2NewDiscreteStatesTYPE             *fmi2NewDiscreteStates;
+  fmi2EnterContinuousTimeModeTYPE       *fmi2EnterContinuousTimeMode;
+  fmi2CompletedIntegratorStepTYPE       *fmi2CompletedIntegratorStep;
+  fmi2SetTimeTYPE                       *fmi2SetTime;
+  fmi2SetContinuousStatesTYPE           *fmi2SetContinuousStates;
+  fmi2GetDerivativesTYPE                *fmi2GetDerivatives;
+  fmi2GetEventIndicatorsTYPE            *fmi2GetEventIndicators;
+  fmi2GetContinuousStatesTYPE           *fmi2GetContinuousStates;
   fmi2GetNominalsOfContinuousStatesTYPE *fmi2GetNominalsOfContinuousStates;
 
   /***************************************************
     Functions for FMI 2.0 for Co-Simulation
     ****************************************************/
 
-  fmi2SetRealInputDerivativesTYPE * fmi2SetRealInputDerivatives;
+  fmi2SetRealInputDerivativesTYPE  *fmi2SetRealInputDerivatives;
   fmi2GetRealOutputDerivativesTYPE *fmi2GetRealOutputDerivatives;
-  fmi2DoStepTYPE *                  fmi2DoStep;
-  fmi2CancelStepTYPE *              fmi2CancelStep;
-  fmi2GetStatusTYPE *               fmi2GetStatus;
-  fmi2GetRealStatusTYPE *           fmi2GetRealStatus;
-  fmi2GetIntegerStatusTYPE *        fmi2GetIntegerStatus;
-  fmi2GetBooleanStatusTYPE *        fmi2GetBooleanStatus;
-  fmi2GetStringStatusTYPE *         fmi2GetStringStatus;
+  fmi2DoStepTYPE                   *fmi2DoStep;
+  fmi2CancelStepTYPE               *fmi2CancelStep;
+  fmi2GetStatusTYPE                *fmi2GetStatus;
+  fmi2GetRealStatusTYPE            *fmi2GetRealStatus;
+  fmi2GetIntegerStatusTYPE         *fmi2GetIntegerStatus;
+  fmi2GetBooleanStatusTYPE         *fmi2GetBooleanStatus;
+  fmi2GetStringStatusTYPE          *fmi2GetStringStatus;
 };
 
 /***************************************************
@@ -145,7 +145,7 @@ FMI_STATIC FMIStatus FMI2SerializeFMUstate(FMIInstance *instance, fmi2FMUstate F
 FMI_STATIC FMIStatus FMI2DeSerializeFMUstate(FMIInstance *instance, const fmi2Byte serializedState[], size_t size, fmi2FMUstate *FMUstate);
 
 /* Getting partial derivatives */
-FMI_STATIC FMIStatus FMI2GetDirectionalDerivative(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI2GetDirectionalDerivative(FMIInstance             *instance,
                                                   const fmi2ValueReference vUnknown_ref[], size_t nUnknown,
                                                   const fmi2ValueReference vKnown_ref[], size_t nKnown,
                                                   const fmi2Real dvKnown[],
@@ -186,12 +186,12 @@ Types for Functions for FMI2 for Co-Simulation
 ****************************************************/
 
 /* Simulating the slave */
-FMI_STATIC FMIStatus FMI2SetRealInputDerivatives(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI2SetRealInputDerivatives(FMIInstance             *instance,
                                                  const fmi2ValueReference vr[], size_t nvr,
                                                  const fmi2Integer order[],
                                                  const fmi2Real    value[]);
 
-FMI_STATIC FMIStatus FMI2GetRealOutputDerivatives(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI2GetRealOutputDerivatives(FMIInstance             *instance,
                                                   const fmi2ValueReference vr[], size_t nvr,
                                                   const fmi2Integer order[],
                                                   fmi2Real          value[]);

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/FMI3.h
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/FMI3.h
@@ -23,83 +23,83 @@ struct FMI3Functions_ {
     ****************************************************/
 
   /* Inquire version numbers and set debug logging */
-  fmi3GetVersionTYPE *     fmi3GetVersion;
+  fmi3GetVersionTYPE      *fmi3GetVersion;
   fmi3SetDebugLoggingTYPE *fmi3SetDebugLogging;
 
   /* Creation and destruction of FMU instances */
-  fmi3InstantiateModelExchangeTYPE *     fmi3InstantiateModelExchange;
-  fmi3InstantiateCoSimulationTYPE *      fmi3InstantiateCoSimulation;
+  fmi3InstantiateModelExchangeTYPE      *fmi3InstantiateModelExchange;
+  fmi3InstantiateCoSimulationTYPE       *fmi3InstantiateCoSimulation;
   fmi3InstantiateScheduledExecutionTYPE *fmi3InstantiateScheduledExecution;
-  fmi3FreeInstanceTYPE *                 fmi3FreeInstance;
+  fmi3FreeInstanceTYPE                  *fmi3FreeInstance;
 
   /* Enter and exit initialization mode, terminate and reset */
   fmi3EnterInitializationModeTYPE *fmi3EnterInitializationMode;
-  fmi3ExitInitializationModeTYPE * fmi3ExitInitializationMode;
-  fmi3EnterEventModeTYPE *         fmi3EnterEventMode;
-  fmi3TerminateTYPE *              fmi3Terminate;
-  fmi3ResetTYPE *                  fmi3Reset;
+  fmi3ExitInitializationModeTYPE  *fmi3ExitInitializationMode;
+  fmi3EnterEventModeTYPE          *fmi3EnterEventMode;
+  fmi3TerminateTYPE               *fmi3Terminate;
+  fmi3ResetTYPE                   *fmi3Reset;
 
   /* Getting and setting variable values */
   fmi3GetFloat32TYPE *fmi3GetFloat32;
   fmi3GetFloat64TYPE *fmi3GetFloat64;
-  fmi3GetInt8TYPE *   fmi3GetInt8;
-  fmi3GetUInt8TYPE *  fmi3GetUInt8;
-  fmi3GetInt16TYPE *  fmi3GetInt16;
-  fmi3GetUInt16TYPE * fmi3GetUInt16;
-  fmi3GetInt32TYPE *  fmi3GetInt32;
-  fmi3GetUInt32TYPE * fmi3GetUInt32;
-  fmi3GetInt64TYPE *  fmi3GetInt64;
-  fmi3GetUInt64TYPE * fmi3GetUInt64;
+  fmi3GetInt8TYPE    *fmi3GetInt8;
+  fmi3GetUInt8TYPE   *fmi3GetUInt8;
+  fmi3GetInt16TYPE   *fmi3GetInt16;
+  fmi3GetUInt16TYPE  *fmi3GetUInt16;
+  fmi3GetInt32TYPE   *fmi3GetInt32;
+  fmi3GetUInt32TYPE  *fmi3GetUInt32;
+  fmi3GetInt64TYPE   *fmi3GetInt64;
+  fmi3GetUInt64TYPE  *fmi3GetUInt64;
   fmi3GetBooleanTYPE *fmi3GetBoolean;
-  fmi3GetStringTYPE * fmi3GetString;
-  fmi3GetBinaryTYPE * fmi3GetBinary;
-  fmi3GetClockTYPE *  fmi3GetClock;
+  fmi3GetStringTYPE  *fmi3GetString;
+  fmi3GetBinaryTYPE  *fmi3GetBinary;
+  fmi3GetClockTYPE   *fmi3GetClock;
   fmi3SetFloat32TYPE *fmi3SetFloat32;
   fmi3SetFloat64TYPE *fmi3SetFloat64;
-  fmi3SetInt8TYPE *   fmi3SetInt8;
-  fmi3SetUInt8TYPE *  fmi3SetUInt8;
-  fmi3SetInt16TYPE *  fmi3SetInt16;
-  fmi3SetUInt16TYPE * fmi3SetUInt16;
-  fmi3SetInt32TYPE *  fmi3SetInt32;
-  fmi3SetUInt32TYPE * fmi3SetUInt32;
-  fmi3SetInt64TYPE *  fmi3SetInt64;
-  fmi3SetUInt64TYPE * fmi3SetUInt64;
+  fmi3SetInt8TYPE    *fmi3SetInt8;
+  fmi3SetUInt8TYPE   *fmi3SetUInt8;
+  fmi3SetInt16TYPE   *fmi3SetInt16;
+  fmi3SetUInt16TYPE  *fmi3SetUInt16;
+  fmi3SetInt32TYPE   *fmi3SetInt32;
+  fmi3SetUInt32TYPE  *fmi3SetUInt32;
+  fmi3SetInt64TYPE   *fmi3SetInt64;
+  fmi3SetUInt64TYPE  *fmi3SetUInt64;
   fmi3SetBooleanTYPE *fmi3SetBoolean;
-  fmi3SetStringTYPE * fmi3SetString;
-  fmi3SetBinaryTYPE * fmi3SetBinary;
-  fmi3SetClockTYPE *  fmi3SetClock;
+  fmi3SetStringTYPE  *fmi3SetString;
+  fmi3SetBinaryTYPE  *fmi3SetBinary;
+  fmi3SetClockTYPE   *fmi3SetClock;
 
   /* Getting Variable Dependency Information */
   fmi3GetNumberOfVariableDependenciesTYPE *fmi3GetNumberOfVariableDependencies;
-  fmi3GetVariableDependenciesTYPE *        fmi3GetVariableDependencies;
+  fmi3GetVariableDependenciesTYPE         *fmi3GetVariableDependencies;
 
   /* Getting and setting the internal FMU state */
-  fmi3GetFMUStateTYPE *           fmi3GetFMUState;
-  fmi3SetFMUStateTYPE *           fmi3SetFMUState;
-  fmi3FreeFMUStateTYPE *          fmi3FreeFMUState;
+  fmi3GetFMUStateTYPE            *fmi3GetFMUState;
+  fmi3SetFMUStateTYPE            *fmi3SetFMUState;
+  fmi3FreeFMUStateTYPE           *fmi3FreeFMUState;
   fmi3SerializedFMUStateSizeTYPE *fmi3SerializedFMUStateSize;
-  fmi3SerializeFMUStateTYPE *     fmi3SerializeFMUState;
-  fmi3DeserializeFMUStateTYPE *   fmi3DeserializeFMUState;
+  fmi3SerializeFMUStateTYPE      *fmi3SerializeFMUState;
+  fmi3DeserializeFMUStateTYPE    *fmi3DeserializeFMUState;
 
   /* Getting partial derivatives */
   fmi3GetDirectionalDerivativeTYPE *fmi3GetDirectionalDerivative;
-  fmi3GetAdjointDerivativeTYPE *    fmi3GetAdjointDerivative;
+  fmi3GetAdjointDerivativeTYPE     *fmi3GetAdjointDerivative;
 
   /* Entering and exiting the Configuration or Reconfiguration Mode */
   fmi3EnterConfigurationModeTYPE *fmi3EnterConfigurationMode;
-  fmi3ExitConfigurationModeTYPE * fmi3ExitConfigurationMode;
+  fmi3ExitConfigurationModeTYPE  *fmi3ExitConfigurationMode;
 
   /* Clock related functions */
-  fmi3GetIntervalDecimalTYPE *    fmi3GetIntervalDecimal;
-  fmi3GetIntervalFractionTYPE *   fmi3GetIntervalFraction;
-  fmi3GetShiftDecimalTYPE *       fmi3GetShiftDecimal;
-  fmi3GetShiftFractionTYPE *      fmi3GetShiftFraction;
-  fmi3SetIntervalDecimalTYPE *    fmi3SetIntervalDecimal;
-  fmi3SetIntervalFractionTYPE *   fmi3SetIntervalFraction;
-  fmi3SetShiftDecimalTYPE *       fmi3SetShiftDecimal;
-  fmi3SetShiftFractionTYPE *      fmi3SetShiftFraction;
+  fmi3GetIntervalDecimalTYPE     *fmi3GetIntervalDecimal;
+  fmi3GetIntervalFractionTYPE    *fmi3GetIntervalFraction;
+  fmi3GetShiftDecimalTYPE        *fmi3GetShiftDecimal;
+  fmi3GetShiftFractionTYPE       *fmi3GetShiftFraction;
+  fmi3SetIntervalDecimalTYPE     *fmi3SetIntervalDecimal;
+  fmi3SetIntervalFractionTYPE    *fmi3SetIntervalFraction;
+  fmi3SetShiftDecimalTYPE        *fmi3SetShiftDecimal;
+  fmi3SetShiftFractionTYPE       *fmi3SetShiftFraction;
   fmi3EvaluateDiscreteStatesTYPE *fmi3EvaluateDiscreteStates;
-  fmi3UpdateDiscreteStatesTYPE *  fmi3UpdateDiscreteStates;
+  fmi3UpdateDiscreteStatesTYPE   *fmi3UpdateDiscreteStates;
 
   /***************************************************
     Functions for Model Exchange
@@ -109,24 +109,24 @@ struct FMI3Functions_ {
   fmi3CompletedIntegratorStepTYPE *fmi3CompletedIntegratorStep;
 
   /* Providing independent variables and re-initialization of caching */
-  fmi3SetTimeTYPE *            fmi3SetTime;
+  fmi3SetTimeTYPE             *fmi3SetTime;
   fmi3SetContinuousStatesTYPE *fmi3SetContinuousStates;
 
   /* Evaluation of the model equations */
   fmi3GetContinuousStateDerivativesTYPE *fmi3GetContinuousStateDerivatives;
-  fmi3GetEventIndicatorsTYPE *           fmi3GetEventIndicators;
-  fmi3GetContinuousStatesTYPE *          fmi3GetContinuousStates;
+  fmi3GetEventIndicatorsTYPE            *fmi3GetEventIndicators;
+  fmi3GetContinuousStatesTYPE           *fmi3GetContinuousStates;
   fmi3GetNominalsOfContinuousStatesTYPE *fmi3GetNominalsOfContinuousStates;
-  fmi3GetNumberOfEventIndicatorsTYPE *   fmi3GetNumberOfEventIndicators;
-  fmi3GetNumberOfContinuousStatesTYPE *  fmi3GetNumberOfContinuousStates;
+  fmi3GetNumberOfEventIndicatorsTYPE    *fmi3GetNumberOfEventIndicators;
+  fmi3GetNumberOfContinuousStatesTYPE   *fmi3GetNumberOfContinuousStates;
 
   /***************************************************
     Functions for FMI 3.0 for Co-Simulation
     ****************************************************/
 
-  fmi3EnterStepModeTYPE *       fmi3EnterStepMode;
+  fmi3EnterStepModeTYPE        *fmi3EnterStepMode;
   fmi3GetOutputDerivativesTYPE *fmi3GetOutputDerivatives;
-  fmi3DoStepTYPE *              fmi3DoStep;
+  fmi3DoStepTYPE               *fmi3DoStep;
 
   /***************************************************
     Functions for Scheduled Execution
@@ -142,7 +142,7 @@ Common Functions
 /* Inquire version numbers and setting logging status */
 FMI_STATIC const char *FMI3GetVersion(FMIInstance *instance);
 
-FMI_STATIC FMIStatus FMI3SetDebugLogging(FMIInstance *    instance,
+FMI_STATIC FMIStatus FMI3SetDebugLogging(FMIInstance     *instance,
                                          fmi3Boolean      loggingOn,
                                          size_t           nCategories,
                                          const fmi3String categories[]);
@@ -156,7 +156,7 @@ FMI_STATIC FMIStatus FMI3InstantiateModelExchange(
     fmi3Boolean  loggingOn);
 
 FMI_STATIC FMIStatus FMI3InstantiateCoSimulation(
-    FMIInstance *                  instance,
+    FMIInstance                   *instance,
     fmi3String                     instantiationToken,
     fmi3String                     resourcePath,
     fmi3Boolean                    visible,
@@ -168,7 +168,7 @@ FMI_STATIC FMIStatus FMI3InstantiateCoSimulation(
     fmi3IntermediateUpdateCallback intermediateUpdate);
 
 FMI_STATIC FMIStatus FMI3InstantiateScheduledExecution(
-    FMIInstance *                instance,
+    FMIInstance                 *instance,
     fmi3String                   instantiationToken,
     fmi3String                   resourcePath,
     fmi3Boolean                  visible,
@@ -198,180 +198,180 @@ FMI_STATIC FMIStatus FMI3Terminate(FMIInstance *instance);
 FMI_STATIC FMIStatus FMI3Reset(FMIInstance *instance);
 
 /* Getting and setting variable values */
-FMI_STATIC FMIStatus FMI3GetFloat32(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetFloat32(FMIInstance             *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t                   nValueReferences,
                                     fmi3Float32              values[],
                                     size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetFloat64(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetFloat64(FMIInstance             *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t                   nValueReferences,
                                     fmi3Float64              values[],
                                     size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetInt8(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetInt8(FMIInstance             *instance,
                                  const fmi3ValueReference valueReferences[],
                                  size_t                   nValueReferences,
                                  fmi3Int8                 values[],
                                  size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetUInt8(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetUInt8(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   fmi3UInt8                values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetInt16(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetInt16(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   fmi3Int16                values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetUInt16(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetUInt16(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    fmi3UInt16               values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetInt32(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetInt32(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   fmi3Int32                values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetUInt32(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetUInt32(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    fmi3UInt32               values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetInt64(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetInt64(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   fmi3Int64                values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetUInt64(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetUInt64(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    fmi3UInt64               values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetBoolean(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetBoolean(FMIInstance             *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t                   nValueReferences,
                                     fmi3Boolean              values[],
                                     size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetString(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetString(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    fmi3String               values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetBinary(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetBinary(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    size_t                   sizes[],
                                    fmi3Binary               values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetClock(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetClock(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   fmi3Clock                values[]);
 
-FMI_STATIC FMIStatus FMI3SetFloat32(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetFloat32(FMIInstance             *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t                   nValueReferences,
                                     const fmi3Float32        values[],
                                     size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetFloat64(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetFloat64(FMIInstance             *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t                   nValueReferences,
                                     const fmi3Float64        values[],
                                     size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetInt8(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetInt8(FMIInstance             *instance,
                                  const fmi3ValueReference valueReferences[],
                                  size_t                   nValueReferences,
                                  const fmi3Int8           values[],
                                  size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetUInt8(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetUInt8(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   const fmi3UInt8          values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetInt16(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetInt16(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   const fmi3Int16          values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetUInt16(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetUInt16(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    const fmi3UInt16         values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetInt32(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetInt32(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   const fmi3Int32          values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetUInt32(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetUInt32(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    const fmi3UInt32         values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetInt64(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetInt64(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   const fmi3Int64          values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetUInt64(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetUInt64(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    const fmi3UInt64         values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetBoolean(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetBoolean(FMIInstance             *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t                   nValueReferences,
                                     const fmi3Boolean        values[],
                                     size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetString(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetString(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    const fmi3String         values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetBinary(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetBinary(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    const size_t             sizes[],
                                    const fmi3Binary         values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetClock(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetClock(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   const fmi3Clock          values[]);
 
 /* Getting Variable Dependency Information */
-FMI_STATIC FMIStatus FMI3GetNumberOfVariableDependencies(FMIInstance *      instance,
+FMI_STATIC FMIStatus FMI3GetNumberOfVariableDependencies(FMIInstance       *instance,
                                                          fmi3ValueReference valueReference,
-                                                         size_t *           nDependencies);
+                                                         size_t            *nDependencies);
 
-FMI_STATIC FMIStatus FMI3GetVariableDependencies(FMIInstance *      instance,
+FMI_STATIC FMIStatus FMI3GetVariableDependencies(FMIInstance       *instance,
                                                  fmi3ValueReference dependent,
                                                  size_t             elementIndicesOfDependent[],
                                                  fmi3ValueReference independents[],
@@ -388,20 +388,20 @@ FMI_STATIC FMIStatus FMI3FreeFMUState(FMIInstance *instance, fmi3FMUState *FMUSt
 
 FMI_STATIC FMIStatus FMI3SerializedFMUStateSize(FMIInstance *instance,
                                                 fmi3FMUState FMUState,
-                                                size_t *     size);
+                                                size_t      *size);
 
 FMI_STATIC FMIStatus FMI3SerializeFMUState(FMIInstance *instance,
                                            fmi3FMUState FMUState,
                                            fmi3Byte     serializedState[],
                                            size_t       size);
 
-FMI_STATIC FMIStatus FMI3DeserializeFMUState(FMIInstance *  instance,
+FMI_STATIC FMIStatus FMI3DeserializeFMUState(FMIInstance   *instance,
                                              const fmi3Byte serializedState[],
                                              size_t         size,
-                                             fmi3FMUState * FMUState);
+                                             fmi3FMUState  *FMUState);
 
 /* Getting partial derivatives */
-FMI_STATIC FMIStatus FMI3GetDirectionalDerivative(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetDirectionalDerivative(FMIInstance             *instance,
                                                   const fmi3ValueReference unknowns[],
                                                   size_t                   nUnknowns,
                                                   const fmi3ValueReference knowns[],
@@ -411,7 +411,7 @@ FMI_STATIC FMIStatus FMI3GetDirectionalDerivative(FMIInstance *            insta
                                                   fmi3Float64              sensitivity[],
                                                   size_t                   nSensitivity);
 
-FMI_STATIC FMIStatus FMI3GetAdjointDerivative(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetAdjointDerivative(FMIInstance             *instance,
                                               const fmi3ValueReference unknowns[],
                                               size_t                   nUnknowns,
                                               const fmi3ValueReference knowns[],
@@ -426,47 +426,47 @@ FMI_STATIC FMIStatus FMI3EnterConfigurationMode(FMIInstance *instance);
 
 FMI_STATIC FMIStatus FMI3ExitConfigurationMode(FMIInstance *instance);
 
-FMI_STATIC FMIStatus FMI3GetIntervalDecimal(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetIntervalDecimal(FMIInstance             *instance,
                                             const fmi3ValueReference valueReferences[],
                                             size_t                   nValueReferences,
                                             fmi3Float64              intervals[],
                                             fmi3IntervalQualifier    qualifiers[]);
 
-FMI_STATIC FMIStatus FMI3GetIntervalFraction(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetIntervalFraction(FMIInstance             *instance,
                                              const fmi3ValueReference valueReferences[],
                                              size_t                   nValueReferences,
                                              fmi3UInt64               intervalCounters[],
                                              fmi3UInt64               resolutions[],
                                              fmi3IntervalQualifier    qualifiers[]);
 
-FMI_STATIC FMIStatus FMI3GetShiftDecimal(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetShiftDecimal(FMIInstance             *instance,
                                          const fmi3ValueReference valueReferences[],
                                          size_t                   nValueReferences,
                                          fmi3Float64              shifts[]);
 
-FMI_STATIC FMIStatus FMI3GetShiftFraction(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetShiftFraction(FMIInstance             *instance,
                                           const fmi3ValueReference valueReferences[],
                                           size_t                   nValueReferences,
                                           fmi3UInt64               shiftCounters[],
                                           fmi3UInt64               resolutions[]);
 
-FMI_STATIC FMIStatus FMI3SetIntervalDecimal(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetIntervalDecimal(FMIInstance             *instance,
                                             const fmi3ValueReference valueReferences[],
                                             size_t                   nValueReferences,
                                             const fmi3Float64        intervals[]);
 
-FMI_STATIC FMIStatus FMI3SetIntervalFraction(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetIntervalFraction(FMIInstance             *instance,
                                              const fmi3ValueReference valueReferences[],
                                              size_t                   nValueReferences,
                                              const fmi3UInt64         intervalCounters[],
                                              const fmi3UInt64         resolutions[]);
 
-FMI_STATIC FMIStatus FMI3SetShiftDecimal(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetShiftDecimal(FMIInstance             *instance,
                                          const fmi3ValueReference valueReferences[],
                                          size_t                   nValueReferences,
                                          const fmi3Float64        shifts[]);
 
-FMI_STATIC FMIStatus FMI3SetShiftFraction(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetShiftFraction(FMIInstance             *instance,
                                           const fmi3ValueReference valueReferences[],
                                           size_t                   nValueReferences,
                                           const fmi3UInt64         shiftCounters[],
@@ -496,7 +496,7 @@ FMI_STATIC FMIStatus FMI3CompletedIntegratorStep(FMIInstance *instance,
 /* Providing independent variables and re-initialization of caching */
 FMI_STATIC FMIStatus FMI3SetTime(FMIInstance *instance, fmi3Float64 time);
 
-FMI_STATIC FMIStatus FMI3SetContinuousStates(FMIInstance *     instance,
+FMI_STATIC FMIStatus FMI3SetContinuousStates(FMIInstance      *instance,
                                              const fmi3Float64 continuousStates[],
                                              size_t            nContinuousStates);
 
@@ -518,10 +518,10 @@ FMI_STATIC FMIStatus FMI3GetNominalsOfContinuousStates(FMIInstance *instance,
                                                        size_t       nContinuousStates);
 
 FMI_STATIC FMIStatus FMI3GetNumberOfEventIndicators(FMIInstance *instance,
-                                                    size_t *     nEventIndicators);
+                                                    size_t      *nEventIndicators);
 
 FMI_STATIC FMIStatus FMI3GetNumberOfContinuousStates(FMIInstance *instance,
-                                                     size_t *     nContinuousStates);
+                                                     size_t      *nContinuousStates);
 
 /***************************************************
 Functions for Co-Simulation
@@ -531,7 +531,7 @@ Functions for Co-Simulation
 
 FMI_STATIC FMIStatus FMI3EnterStepMode(FMIInstance *instance);
 
-FMI_STATIC FMIStatus FMI3GetOutputDerivatives(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetOutputDerivatives(FMIInstance             *instance,
                                               const fmi3ValueReference valueReferences[],
                                               size_t                   nValueReferences,
                                               const fmi3Int32          orders[],
@@ -551,7 +551,7 @@ FMI_STATIC FMIStatus FMI3DoStep(FMIInstance *instance,
 Functions for Scheduled Execution
 ****************************************************/
 
-FMI_STATIC FMIStatus FMI3ActivateModelPartition(FMIInstance *      instance,
+FMI_STATIC FMIStatus FMI3ActivateModelPartition(FMIInstance       *instance,
                                                 fmi3ValueReference clockReference,
                                                 fmi3Float64        activationTime);
 

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmi2FunctionTypes.h
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmi2FunctionTypes.h
@@ -220,8 +220,8 @@ typedef fmi2Status fmi2NewDiscreteStatesTYPE(fmi2Component c, fmi2EventInfo *fmi
 typedef fmi2Status fmi2EnterContinuousTimeModeTYPE(fmi2Component c);
 typedef fmi2Status fmi2CompletedIntegratorStepTYPE(fmi2Component c,
                                                    fmi2Boolean   noSetFMUStatePriorToCurrentPoint,
-                                                   fmi2Boolean * enterEventMode,
-                                                   fmi2Boolean * terminateSimulation);
+                                                   fmi2Boolean  *enterEventMode,
+                                                   fmi2Boolean  *terminateSimulation);
 
 /* Providing independent variables and re-initialization of caching */
 typedef fmi2Status fmi2SetTimeTYPE(fmi2Component c, fmi2Real time);

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmi2Functions.h
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmi2Functions.h
@@ -240,38 +240,38 @@ Common Functions
 
 /* Inquire version numbers of header files */
 FMI2_Export fmi2GetTypesPlatformTYPE fmi2GetTypesPlatform;
-FMI2_Export fmi2GetVersionTYPE fmi2GetVersion;
-FMI2_Export fmi2SetDebugLoggingTYPE fmi2SetDebugLogging;
+FMI2_Export fmi2GetVersionTYPE       fmi2GetVersion;
+FMI2_Export fmi2SetDebugLoggingTYPE  fmi2SetDebugLogging;
 
 /* Creation and destruction of FMU instances */
-FMI2_Export fmi2InstantiateTYPE fmi2Instantiate;
+FMI2_Export fmi2InstantiateTYPE  fmi2Instantiate;
 FMI2_Export fmi2FreeInstanceTYPE fmi2FreeInstance;
 
 /* Enter and exit initialization mode, terminate and reset */
-FMI2_Export fmi2SetupExperimentTYPE fmi2SetupExperiment;
+FMI2_Export fmi2SetupExperimentTYPE         fmi2SetupExperiment;
 FMI2_Export fmi2EnterInitializationModeTYPE fmi2EnterInitializationMode;
-FMI2_Export fmi2ExitInitializationModeTYPE fmi2ExitInitializationMode;
-FMI2_Export fmi2TerminateTYPE fmi2Terminate;
-FMI2_Export fmi2ResetTYPE fmi2Reset;
+FMI2_Export fmi2ExitInitializationModeTYPE  fmi2ExitInitializationMode;
+FMI2_Export fmi2TerminateTYPE               fmi2Terminate;
+FMI2_Export fmi2ResetTYPE                   fmi2Reset;
 
 /* Getting and setting variables values */
-FMI2_Export fmi2GetRealTYPE fmi2GetReal;
+FMI2_Export fmi2GetRealTYPE    fmi2GetReal;
 FMI2_Export fmi2GetIntegerTYPE fmi2GetInteger;
 FMI2_Export fmi2GetBooleanTYPE fmi2GetBoolean;
-FMI2_Export fmi2GetStringTYPE fmi2GetString;
+FMI2_Export fmi2GetStringTYPE  fmi2GetString;
 
-FMI2_Export fmi2SetRealTYPE fmi2SetReal;
+FMI2_Export fmi2SetRealTYPE    fmi2SetReal;
 FMI2_Export fmi2SetIntegerTYPE fmi2SetInteger;
 FMI2_Export fmi2SetBooleanTYPE fmi2SetBoolean;
-FMI2_Export fmi2SetStringTYPE fmi2SetString;
+FMI2_Export fmi2SetStringTYPE  fmi2SetString;
 
 /* Getting and setting the internal FMU state */
-FMI2_Export fmi2GetFMUstateTYPE fmi2GetFMUstate;
-FMI2_Export fmi2SetFMUstateTYPE fmi2SetFMUstate;
-FMI2_Export fmi2FreeFMUstateTYPE fmi2FreeFMUstate;
+FMI2_Export fmi2GetFMUstateTYPE            fmi2GetFMUstate;
+FMI2_Export fmi2SetFMUstateTYPE            fmi2SetFMUstate;
+FMI2_Export fmi2FreeFMUstateTYPE           fmi2FreeFMUstate;
 FMI2_Export fmi2SerializedFMUstateSizeTYPE fmi2SerializedFMUstateSize;
-FMI2_Export fmi2SerializeFMUstateTYPE fmi2SerializeFMUstate;
-FMI2_Export fmi2DeSerializeFMUstateTYPE fmi2DeSerializeFMUstate;
+FMI2_Export fmi2SerializeFMUstateTYPE      fmi2SerializeFMUstate;
+FMI2_Export fmi2DeSerializeFMUstateTYPE    fmi2DeSerializeFMUstate;
 
 /* Getting partial derivatives */
 FMI2_Export fmi2GetDirectionalDerivativeTYPE fmi2GetDirectionalDerivative;
@@ -281,19 +281,19 @@ Functions for FMI2 for Model Exchange
 ****************************************************/
 
 /* Enter and exit the different modes */
-FMI2_Export fmi2EnterEventModeTYPE fmi2EnterEventMode;
-FMI2_Export fmi2NewDiscreteStatesTYPE fmi2NewDiscreteStates;
+FMI2_Export fmi2EnterEventModeTYPE          fmi2EnterEventMode;
+FMI2_Export fmi2NewDiscreteStatesTYPE       fmi2NewDiscreteStates;
 FMI2_Export fmi2EnterContinuousTimeModeTYPE fmi2EnterContinuousTimeMode;
 FMI2_Export fmi2CompletedIntegratorStepTYPE fmi2CompletedIntegratorStep;
 
 /* Providing independent variables and re-initialization of caching */
-FMI2_Export fmi2SetTimeTYPE fmi2SetTime;
+FMI2_Export fmi2SetTimeTYPE             fmi2SetTime;
 FMI2_Export fmi2SetContinuousStatesTYPE fmi2SetContinuousStates;
 
 /* Evaluation of the model equations */
-FMI2_Export fmi2GetDerivativesTYPE fmi2GetDerivatives;
-FMI2_Export fmi2GetEventIndicatorsTYPE fmi2GetEventIndicators;
-FMI2_Export fmi2GetContinuousStatesTYPE fmi2GetContinuousStates;
+FMI2_Export fmi2GetDerivativesTYPE                fmi2GetDerivatives;
+FMI2_Export fmi2GetEventIndicatorsTYPE            fmi2GetEventIndicators;
+FMI2_Export fmi2GetContinuousStatesTYPE           fmi2GetContinuousStates;
 FMI2_Export fmi2GetNominalsOfContinuousStatesTYPE fmi2GetNominalsOfContinuousStates;
 
 /***************************************************
@@ -301,18 +301,18 @@ Functions for FMI2 for Co-Simulation
 ****************************************************/
 
 /* Simulating the slave */
-FMI2_Export fmi2SetRealInputDerivativesTYPE fmi2SetRealInputDerivatives;
+FMI2_Export fmi2SetRealInputDerivativesTYPE  fmi2SetRealInputDerivatives;
 FMI2_Export fmi2GetRealOutputDerivativesTYPE fmi2GetRealOutputDerivatives;
 
-FMI2_Export fmi2DoStepTYPE fmi2DoStep;
+FMI2_Export fmi2DoStepTYPE     fmi2DoStep;
 FMI2_Export fmi2CancelStepTYPE fmi2CancelStep;
 
 /* Inquire slave status */
-FMI2_Export fmi2GetStatusTYPE fmi2GetStatus;
-FMI2_Export fmi2GetRealStatusTYPE fmi2GetRealStatus;
+FMI2_Export fmi2GetStatusTYPE        fmi2GetStatus;
+FMI2_Export fmi2GetRealStatusTYPE    fmi2GetRealStatus;
 FMI2_Export fmi2GetIntegerStatusTYPE fmi2GetIntegerStatus;
 FMI2_Export fmi2GetBooleanStatusTYPE fmi2GetBooleanStatus;
-FMI2_Export fmi2GetStringStatusTYPE fmi2GetStringStatus;
+FMI2_Export fmi2GetStringStatusTYPE  fmi2GetStringStatus;
 
 #ifdef __cplusplus
 } /* end of extern "C" { */

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmi2TypesPlatform.h
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmi2TypesPlatform.h
@@ -89,9 +89,9 @@
                              ('\0' terminated, UTF8 encoded)
    fmi2Byte                : smallest addressable unit of the machine, typically one byte.
 */
-typedef void *          fmi2Component;            /* Pointer to FMU instance       */
-typedef void *          fmi2ComponentEnvironment; /* Pointer to FMU environment    */
-typedef void *          fmi2FMUstate;             /* Pointer to internal FMU state */
+typedef void           *fmi2Component;            /* Pointer to FMU instance       */
+typedef void           *fmi2ComponentEnvironment; /* Pointer to FMU environment    */
+typedef void           *fmi2FMUstate;             /* Pointer to internal FMU state */
 typedef unsigned int    fmi2ValueReference;
 typedef double          fmi2Real;
 typedef int             fmi2Integer;

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmi3FunctionTypes.h
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmi3FunctionTypes.h
@@ -97,8 +97,8 @@ typedef void (*fmi3IntermediateUpdateCallback)(
     fmi3Boolean             intermediateVariableGetAllowed,
     fmi3Boolean             intermediateStepFinished,
     fmi3Boolean             canReturnEarly,
-    fmi3Boolean *           earlyReturnRequested,
-    fmi3Float64 *           earlyReturnTime);
+    fmi3Boolean            *earlyReturnRequested,
+    fmi3Float64            *earlyReturnTime);
 /* end::CallbackIntermediateUpdate[] */
 
 /* tag::CallbackPreemptionLock[] */
@@ -372,7 +372,7 @@ typedef fmi3Status fmi3SetClockTYPE(fmi3Instance             instance,
 /* tag::GetNumberOfVariableDependencies[] */
 typedef fmi3Status fmi3GetNumberOfVariableDependenciesTYPE(fmi3Instance       instance,
                                                            fmi3ValueReference valueReference,
-                                                           size_t *           nDependencies);
+                                                           size_t            *nDependencies);
 /* end::GetNumberOfVariableDependencies[] */
 
 /* tag::GetVariableDependencies[] */
@@ -401,7 +401,7 @@ typedef fmi3Status fmi3FreeFMUStateTYPE(fmi3Instance instance, fmi3FMUState *FMU
 /* tag::SerializedFMUStateSize[] */
 typedef fmi3Status fmi3SerializedFMUStateSizeTYPE(fmi3Instance instance,
                                                   fmi3FMUState FMUState,
-                                                  size_t *     size);
+                                                  size_t      *size);
 /* end::SerializedFMUStateSize[] */
 
 /* tag::SerializeFMUState[] */
@@ -415,7 +415,7 @@ typedef fmi3Status fmi3SerializeFMUStateTYPE(fmi3Instance instance,
 typedef fmi3Status fmi3DeserializeFMUStateTYPE(fmi3Instance   instance,
                                                const fmi3Byte serializedState[],
                                                size_t         size,
-                                               fmi3FMUState * FMUState);
+                                               fmi3FMUState  *FMUState);
 /* end::DeserializeFMUState[] */
 
 /* Getting partial derivatives */
@@ -582,12 +582,12 @@ typedef fmi3Status fmi3GetNominalsOfContinuousStatesTYPE(fmi3Instance instance,
 
 /* tag::GetNumberOfEventIndicators[] */
 typedef fmi3Status fmi3GetNumberOfEventIndicatorsTYPE(fmi3Instance instance,
-                                                      size_t *     nEventIndicators);
+                                                      size_t      *nEventIndicators);
 /* end::GetNumberOfEventIndicators[] */
 
 /* tag::GetNumberOfContinuousStates[] */
 typedef fmi3Status fmi3GetNumberOfContinuousStatesTYPE(fmi3Instance instance,
-                                                       size_t *     nContinuousStates);
+                                                       size_t      *nContinuousStates);
 /* end::GetNumberOfContinuousStates[] */
 
 /***************************************************

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmi3Functions.h
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmi3Functions.h
@@ -222,83 +222,83 @@ Common Functions
 ****************************************************/
 
 /* Inquire version numbers and set debug logging */
-FMI3_Export fmi3GetVersionTYPE fmi3GetVersion;
+FMI3_Export fmi3GetVersionTYPE      fmi3GetVersion;
 FMI3_Export fmi3SetDebugLoggingTYPE fmi3SetDebugLogging;
 
 /* Creation and destruction of FMU instances */
-FMI3_Export fmi3InstantiateModelExchangeTYPE fmi3InstantiateModelExchange;
-FMI3_Export fmi3InstantiateCoSimulationTYPE fmi3InstantiateCoSimulation;
+FMI3_Export fmi3InstantiateModelExchangeTYPE      fmi3InstantiateModelExchange;
+FMI3_Export fmi3InstantiateCoSimulationTYPE       fmi3InstantiateCoSimulation;
 FMI3_Export fmi3InstantiateScheduledExecutionTYPE fmi3InstantiateScheduledExecution;
-FMI3_Export fmi3FreeInstanceTYPE fmi3FreeInstance;
+FMI3_Export fmi3FreeInstanceTYPE                  fmi3FreeInstance;
 
 /* Enter and exit initialization mode, terminate and reset */
 FMI3_Export fmi3EnterInitializationModeTYPE fmi3EnterInitializationMode;
-FMI3_Export fmi3ExitInitializationModeTYPE fmi3ExitInitializationMode;
-FMI3_Export fmi3EnterEventModeTYPE fmi3EnterEventMode;
-FMI3_Export fmi3TerminateTYPE fmi3Terminate;
-FMI3_Export fmi3ResetTYPE fmi3Reset;
+FMI3_Export fmi3ExitInitializationModeTYPE  fmi3ExitInitializationMode;
+FMI3_Export fmi3EnterEventModeTYPE          fmi3EnterEventMode;
+FMI3_Export fmi3TerminateTYPE               fmi3Terminate;
+FMI3_Export fmi3ResetTYPE                   fmi3Reset;
 
 /* Getting and setting variables values */
 FMI3_Export fmi3GetFloat32TYPE fmi3GetFloat32;
 FMI3_Export fmi3GetFloat64TYPE fmi3GetFloat64;
-FMI3_Export fmi3GetInt8TYPE fmi3GetInt8;
-FMI3_Export fmi3GetUInt8TYPE fmi3GetUInt8;
-FMI3_Export fmi3GetInt16TYPE fmi3GetInt16;
-FMI3_Export fmi3GetUInt16TYPE fmi3GetUInt16;
-FMI3_Export fmi3GetInt32TYPE fmi3GetInt32;
-FMI3_Export fmi3GetUInt32TYPE fmi3GetUInt32;
-FMI3_Export fmi3GetInt64TYPE fmi3GetInt64;
-FMI3_Export fmi3GetUInt64TYPE fmi3GetUInt64;
+FMI3_Export fmi3GetInt8TYPE    fmi3GetInt8;
+FMI3_Export fmi3GetUInt8TYPE   fmi3GetUInt8;
+FMI3_Export fmi3GetInt16TYPE   fmi3GetInt16;
+FMI3_Export fmi3GetUInt16TYPE  fmi3GetUInt16;
+FMI3_Export fmi3GetInt32TYPE   fmi3GetInt32;
+FMI3_Export fmi3GetUInt32TYPE  fmi3GetUInt32;
+FMI3_Export fmi3GetInt64TYPE   fmi3GetInt64;
+FMI3_Export fmi3GetUInt64TYPE  fmi3GetUInt64;
 FMI3_Export fmi3GetBooleanTYPE fmi3GetBoolean;
-FMI3_Export fmi3GetStringTYPE fmi3GetString;
-FMI3_Export fmi3GetBinaryTYPE fmi3GetBinary;
-FMI3_Export fmi3GetClockTYPE fmi3GetClock;
+FMI3_Export fmi3GetStringTYPE  fmi3GetString;
+FMI3_Export fmi3GetBinaryTYPE  fmi3GetBinary;
+FMI3_Export fmi3GetClockTYPE   fmi3GetClock;
 FMI3_Export fmi3SetFloat32TYPE fmi3SetFloat32;
 FMI3_Export fmi3SetFloat64TYPE fmi3SetFloat64;
-FMI3_Export fmi3SetInt8TYPE fmi3SetInt8;
-FMI3_Export fmi3SetUInt8TYPE fmi3SetUInt8;
-FMI3_Export fmi3SetInt16TYPE fmi3SetInt16;
-FMI3_Export fmi3SetUInt16TYPE fmi3SetUInt16;
-FMI3_Export fmi3SetInt32TYPE fmi3SetInt32;
-FMI3_Export fmi3SetUInt32TYPE fmi3SetUInt32;
-FMI3_Export fmi3SetInt64TYPE fmi3SetInt64;
-FMI3_Export fmi3SetUInt64TYPE fmi3SetUInt64;
+FMI3_Export fmi3SetInt8TYPE    fmi3SetInt8;
+FMI3_Export fmi3SetUInt8TYPE   fmi3SetUInt8;
+FMI3_Export fmi3SetInt16TYPE   fmi3SetInt16;
+FMI3_Export fmi3SetUInt16TYPE  fmi3SetUInt16;
+FMI3_Export fmi3SetInt32TYPE   fmi3SetInt32;
+FMI3_Export fmi3SetUInt32TYPE  fmi3SetUInt32;
+FMI3_Export fmi3SetInt64TYPE   fmi3SetInt64;
+FMI3_Export fmi3SetUInt64TYPE  fmi3SetUInt64;
 FMI3_Export fmi3SetBooleanTYPE fmi3SetBoolean;
-FMI3_Export fmi3SetStringTYPE fmi3SetString;
-FMI3_Export fmi3SetBinaryTYPE fmi3SetBinary;
-FMI3_Export fmi3SetClockTYPE fmi3SetClock;
+FMI3_Export fmi3SetStringTYPE  fmi3SetString;
+FMI3_Export fmi3SetBinaryTYPE  fmi3SetBinary;
+FMI3_Export fmi3SetClockTYPE   fmi3SetClock;
 
 /* Getting Variable Dependency Information */
 FMI3_Export fmi3GetNumberOfVariableDependenciesTYPE fmi3GetNumberOfVariableDependencies;
-FMI3_Export fmi3GetVariableDependenciesTYPE fmi3GetVariableDependencies;
+FMI3_Export fmi3GetVariableDependenciesTYPE         fmi3GetVariableDependencies;
 
 /* Getting and setting the internal FMU state */
-FMI3_Export fmi3GetFMUStateTYPE fmi3GetFMUState;
-FMI3_Export fmi3SetFMUStateTYPE fmi3SetFMUState;
-FMI3_Export fmi3FreeFMUStateTYPE fmi3FreeFMUState;
+FMI3_Export fmi3GetFMUStateTYPE            fmi3GetFMUState;
+FMI3_Export fmi3SetFMUStateTYPE            fmi3SetFMUState;
+FMI3_Export fmi3FreeFMUStateTYPE           fmi3FreeFMUState;
 FMI3_Export fmi3SerializedFMUStateSizeTYPE fmi3SerializedFMUStateSize;
-FMI3_Export fmi3SerializeFMUStateTYPE fmi3SerializeFMUState;
-FMI3_Export fmi3DeserializeFMUStateTYPE fmi3DeserializeFMUState;
+FMI3_Export fmi3SerializeFMUStateTYPE      fmi3SerializeFMUState;
+FMI3_Export fmi3DeserializeFMUStateTYPE    fmi3DeserializeFMUState;
 
 /* Getting partial derivatives */
 FMI3_Export fmi3GetDirectionalDerivativeTYPE fmi3GetDirectionalDerivative;
-FMI3_Export fmi3GetAdjointDerivativeTYPE fmi3GetAdjointDerivative;
+FMI3_Export fmi3GetAdjointDerivativeTYPE     fmi3GetAdjointDerivative;
 
 /* Entering and exiting the Configuration or Reconfiguration Mode */
 FMI3_Export fmi3EnterConfigurationModeTYPE fmi3EnterConfigurationMode;
-FMI3_Export fmi3ExitConfigurationModeTYPE fmi3ExitConfigurationMode;
+FMI3_Export fmi3ExitConfigurationModeTYPE  fmi3ExitConfigurationMode;
 
 /* Clock related functions */
-FMI3_Export fmi3GetIntervalDecimalTYPE fmi3GetIntervalDecimal;
-FMI3_Export fmi3GetIntervalFractionTYPE fmi3GetIntervalFraction;
-FMI3_Export fmi3GetShiftDecimalTYPE fmi3GetShiftDecimal;
-FMI3_Export fmi3GetShiftFractionTYPE fmi3GetShiftFraction;
-FMI3_Export fmi3SetIntervalDecimalTYPE fmi3SetIntervalDecimal;
-FMI3_Export fmi3SetIntervalFractionTYPE fmi3SetIntervalFraction;
-FMI3_Export fmi3SetShiftDecimalTYPE fmi3SetShiftDecimal;
-FMI3_Export fmi3SetShiftFractionTYPE fmi3SetShiftFraction;
+FMI3_Export fmi3GetIntervalDecimalTYPE     fmi3GetIntervalDecimal;
+FMI3_Export fmi3GetIntervalFractionTYPE    fmi3GetIntervalFraction;
+FMI3_Export fmi3GetShiftDecimalTYPE        fmi3GetShiftDecimal;
+FMI3_Export fmi3GetShiftFractionTYPE       fmi3GetShiftFraction;
+FMI3_Export fmi3SetIntervalDecimalTYPE     fmi3SetIntervalDecimal;
+FMI3_Export fmi3SetIntervalFractionTYPE    fmi3SetIntervalFraction;
+FMI3_Export fmi3SetShiftDecimalTYPE        fmi3SetShiftDecimal;
+FMI3_Export fmi3SetShiftFractionTYPE       fmi3SetShiftFraction;
 FMI3_Export fmi3EvaluateDiscreteStatesTYPE fmi3EvaluateDiscreteStates;
-FMI3_Export fmi3UpdateDiscreteStatesTYPE fmi3UpdateDiscreteStates;
+FMI3_Export fmi3UpdateDiscreteStatesTYPE   fmi3UpdateDiscreteStates;
 
 /***************************************************
 Functions for Model Exchange
@@ -315,20 +315,20 @@ FMI3_Export fmi3SetContinuousStatesTYPE fmi3SetContinuousStates;
 
 /* Evaluation of the model equations */
 FMI3_Export fmi3GetContinuousStateDerivativesTYPE fmi3GetContinuousStateDerivatives;
-FMI3_Export fmi3GetEventIndicatorsTYPE fmi3GetEventIndicators;
-FMI3_Export fmi3GetContinuousStatesTYPE fmi3GetContinuousStates;
+FMI3_Export fmi3GetEventIndicatorsTYPE            fmi3GetEventIndicators;
+FMI3_Export fmi3GetContinuousStatesTYPE           fmi3GetContinuousStates;
 FMI3_Export fmi3GetNominalsOfContinuousStatesTYPE fmi3GetNominalsOfContinuousStates;
-FMI3_Export fmi3GetNumberOfEventIndicatorsTYPE fmi3GetNumberOfEventIndicators;
-FMI3_Export fmi3GetNumberOfContinuousStatesTYPE fmi3GetNumberOfContinuousStates;
+FMI3_Export fmi3GetNumberOfEventIndicatorsTYPE    fmi3GetNumberOfEventIndicators;
+FMI3_Export fmi3GetNumberOfContinuousStatesTYPE   fmi3GetNumberOfContinuousStates;
 
 /***************************************************
 Functions for Co-Simulation
 ****************************************************/
 
 /* Simulating the FMU */
-FMI3_Export fmi3EnterStepModeTYPE fmi3EnterStepMode;
+FMI3_Export fmi3EnterStepModeTYPE        fmi3EnterStepMode;
 FMI3_Export fmi3GetOutputDerivativesTYPE fmi3GetOutputDerivatives;
-FMI3_Export fmi3DoStepTYPE fmi3DoStep;
+FMI3_Export fmi3DoStepTYPE               fmi3DoStep;
 
 /***************************************************
 Functions for Scheduled Execution

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmi3PlatformTypes.h
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmi3PlatformTypes.h
@@ -74,11 +74,11 @@ typedef bool            fmi3Boolean; /* Data type to be used with fmi3True and f
 typedef char            fmi3Char;    /* Data type for one character */
 typedef const fmi3Char *fmi3String;  /* Data type for character strings
                                          ('\0' terminated, UTF-8 encoded) */
-typedef uint8_t         fmi3Byte;    /* Smallest addressable unit of the machine
+typedef uint8_t fmi3Byte;            /* Smallest addressable unit of the machine
                                          (typically one byte) */
 typedef const fmi3Byte *fmi3Binary;  /* Data type for binary data
                                          (out-of-band length terminated) */
-typedef bool            fmi3Clock;   /* Data type to be used with fmi3ClockActive and
+typedef bool fmi3Clock;              /* Data type to be used with fmi3ClockActive and
                                          fmi3ClockInactive */
 
 /* Values for fmi3Boolean */

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmiModelFunctions.h
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmiModelFunctions.h
@@ -175,7 +175,7 @@ DllExport fmiComponent fmiInstantiateModel(fmiString            instanceName,
                                            fmiCallbackFunctions functions,
                                            fmiBoolean           loggingOn);
 DllExport void         fmiFreeModelInstance(fmiComponent c);
-DllExport fmiStatus fmiSetDebugLogging(fmiComponent c, fmiBoolean loggingOn);
+DllExport fmiStatus    fmiSetDebugLogging(fmiComponent c, fmiBoolean loggingOn);
 
 /* Providing independent variables and re-initialization of caching */
 DllExport fmiStatus fmiSetTime(fmiComponent c, fmiReal time);

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmiModelTypes.h
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmiModelTypes.h
@@ -74,12 +74,12 @@
    fmiString        : 32 bit pointer
 
 */
-typedef void *       fmiComponent;
+typedef void        *fmiComponent;
 typedef unsigned int fmiValueReference;
 typedef double       fmiReal;
 typedef int          fmiInteger;
 typedef char         fmiBoolean;
-typedef const char * fmiString;
+typedef const char  *fmiString;
 
 /* Values for fmiBoolean  */
 #define fmiTrue 1

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmiPlatformTypes.h
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/fmiPlatformTypes.h
@@ -56,12 +56,12 @@
    fmiString        : 32 bit pointer
 
 */
-typedef void *       fmiComponent;
+typedef void        *fmiComponent;
 typedef unsigned int fmiValueReference;
 typedef double       fmiReal;
 typedef int          fmiInteger;
 typedef char         fmiBoolean;
-typedef const char * fmiString;
+typedef const char  *fmiString;
 
 /* Values for fmiBoolean  */
 #define fmiTrue 1

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/model.h
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/include/model.h
@@ -90,13 +90,13 @@ typedef void (*loggerType)(void *componentEnvironment, int status, const char *c
 typedef void (*lockPreemptionType)();
 typedef void (*unlockPreemptionType)();
 
-typedef void (*intermediateUpdateType)(void *  instanceEnvironment,
+typedef void (*intermediateUpdateType)(void   *instanceEnvironment,
                                        double  intermediateUpdateTime,
                                        bool    intermediateVariableSetRequested,
                                        bool    intermediateVariableGetAllowed,
                                        bool    intermediateStepFinished,
                                        bool    canReturnEarly,
-                                       bool *  earlyReturnRequested,
+                                       bool   *earlyReturnRequested,
                                        double *earlyReturnTime);
 
 typedef void (*clockUpdateType)(void *instanceEnvironment);
@@ -106,9 +106,9 @@ typedef struct {
   double        startTime;
   double        time;
   double        solverStepSize;
-  const char *  instanceName;
+  const char   *instanceName;
   InterfaceType type;
-  const char *  resourceLocation;
+  const char   *resourceLocation;
 
   Status status;
 
@@ -123,7 +123,7 @@ typedef struct {
   bool logEvents;
   bool logErrors;
 
-  void *     componentEnvironment;
+  void      *componentEnvironment;
   ModelState state;
 
   // event info
@@ -156,10 +156,10 @@ typedef struct {
 ModelInstance *createModelInstance(
     loggerType             logger,
     intermediateUpdateType intermediateUpdate,
-    void *                 componentEnvironment,
-    const char *           instanceName,
-    const char *           instantiationToken,
-    const char *           resourceLocation,
+    void                  *componentEnvironment,
+    const char            *instanceName,
+    const char            *instantiationToken,
+    const char            *resourceLocation,
     bool                   loggingOn,
     InterfaceType          interfaceType);
 
@@ -214,7 +214,7 @@ Status getOutputDerivative(ModelInstance *comp, ValueReference valueReference, i
 Status getPartialDerivative(ModelInstance *comp, ValueReference unknown, ValueReference known, double *partialDerivative);
 void   getEventIndicators(ModelInstance *comp, double z[], size_t nz);
 void   eventUpdate(ModelInstance *comp);
-//void updateEventTime(ModelInstance *comp);
+// void updateEventTime(ModelInstance *comp);
 
 bool   invalidNumber(ModelInstance *comp, const char *f, const char *arg, size_t actual, size_t expected);
 bool   invalidState(ModelInstance *comp, const char *f, int statesExpected);

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/src/FMI.c
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/src/FMI.c
@@ -139,7 +139,7 @@ const char *FMIValuesToString(FMIInstance *instance, size_t vValues, const size_
 
     for (size_t i = 0; i < vValues; i++) {
 
-      char * s = &instance->buf2[pos];
+      char  *s = &instance->buf2[pos];
       size_t n = instance->bufsize2 - pos;
 
       switch (variableType) {

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/src/FMI2.c
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/src/FMI2.c
@@ -371,7 +371,7 @@ FMIStatus FMI2DeSerializeFMUstate(FMIInstance *instance, const fmi2Byte serializ
 }
 
 /* Getting partial derivatives */
-FMIStatus FMI2GetDirectionalDerivative(FMIInstance *            instance,
+FMIStatus FMI2GetDirectionalDerivative(FMIInstance             *instance,
                                        const fmi2ValueReference vUnknown_ref[], size_t nUnknown,
                                        const fmi2ValueReference vKnown_ref[], size_t nKnown,
                                        const fmi2Real dvKnown[],
@@ -484,7 +484,7 @@ Co-Simulation
 ****************************************************/
 
 /* Simulating the slave */
-FMIStatus FMI2SetRealInputDerivatives(FMIInstance *            instance,
+FMIStatus FMI2SetRealInputDerivatives(FMIInstance             *instance,
                                       const fmi2ValueReference vr[], size_t nvr,
                                       const fmi2Integer order[],
                                       const fmi2Real    value[])
@@ -492,7 +492,7 @@ FMIStatus FMI2SetRealInputDerivatives(FMIInstance *            instance,
   CALL_ARGS(SetRealInputDerivatives, "vr=0x%p, nvr=%zu, order=0x%p, value=0x%p", vr, nvr, order, value);
 }
 
-FMIStatus FMI2GetRealOutputDerivatives(FMIInstance *            instance,
+FMIStatus FMI2GetRealOutputDerivatives(FMIInstance             *instance,
                                        const fmi2ValueReference vr[], size_t nvr,
                                        const fmi2Integer order[],
                                        fmi2Real          value[])

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/src/FMI3.c
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/src/FMI3.c
@@ -100,7 +100,7 @@ const char *FMI3GetVersion(FMIInstance *instance)
   return instance->fmi3Functions->fmi3GetVersion();
 }
 
-FMIStatus FMI3SetDebugLogging(FMIInstance *    instance,
+FMIStatus FMI3SetDebugLogging(FMIInstance     *instance,
                               fmi3Boolean      loggingOn,
                               size_t           nCategories,
                               const fmi3String categories[])
@@ -293,7 +293,7 @@ FMIStatus FMI3InstantiateModelExchange(
 }
 
 FMIStatus FMI3InstantiateCoSimulation(
-    FMIInstance *                  instance,
+    FMIInstance                   *instance,
     fmi3String                     instantiationToken,
     fmi3String                     resourcePath,
     fmi3Boolean                    visible,
@@ -367,7 +367,7 @@ FMIStatus FMI3InstantiateCoSimulation(
 }
 
 FMIStatus FMI3InstantiateScheduledExecution(
-    FMIInstance *                instance,
+    FMIInstance                 *instance,
     fmi3String                   instantiationToken,
     fmi3String                   resourcePath,
     fmi3Boolean                  visible,
@@ -497,7 +497,7 @@ FMIStatus FMI3Reset(FMIInstance *instance)
 }
 
 /* Getting and setting variable values */
-FMIStatus FMI3GetFloat32(FMIInstance *            instance,
+FMIStatus FMI3GetFloat32(FMIInstance             *instance,
                          const fmi3ValueReference valueReferences[],
                          size_t                   nValueReferences,
                          fmi3Float32              values[],
@@ -506,7 +506,7 @@ FMIStatus FMI3GetFloat32(FMIInstance *            instance,
   CALL_ARRAY(Get, Float32);
 }
 
-FMIStatus FMI3GetFloat64(FMIInstance *            instance,
+FMIStatus FMI3GetFloat64(FMIInstance             *instance,
                          const fmi3ValueReference valueReferences[],
                          size_t                   nValueReferences,
                          fmi3Float64              values[],
@@ -515,7 +515,7 @@ FMIStatus FMI3GetFloat64(FMIInstance *            instance,
   CALL_ARRAY(Get, Float64);
 }
 
-FMIStatus FMI3GetInt8(FMIInstance *            instance,
+FMIStatus FMI3GetInt8(FMIInstance             *instance,
                       const fmi3ValueReference valueReferences[],
                       size_t                   nValueReferences,
                       fmi3Int8                 values[],
@@ -524,7 +524,7 @@ FMIStatus FMI3GetInt8(FMIInstance *            instance,
   CALL_ARRAY(Get, Int8);
 }
 
-FMIStatus FMI3GetUInt8(FMIInstance *            instance,
+FMIStatus FMI3GetUInt8(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        fmi3UInt8                values[],
@@ -533,7 +533,7 @@ FMIStatus FMI3GetUInt8(FMIInstance *            instance,
   CALL_ARRAY(Get, UInt8);
 }
 
-FMIStatus FMI3GetInt16(FMIInstance *            instance,
+FMIStatus FMI3GetInt16(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        fmi3Int16                values[],
@@ -542,7 +542,7 @@ FMIStatus FMI3GetInt16(FMIInstance *            instance,
   CALL_ARRAY(Get, Int16);
 }
 
-FMIStatus FMI3GetUInt16(FMIInstance *            instance,
+FMIStatus FMI3GetUInt16(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         fmi3UInt16               values[],
@@ -551,7 +551,7 @@ FMIStatus FMI3GetUInt16(FMIInstance *            instance,
   CALL_ARRAY(Get, UInt16);
 }
 
-FMIStatus FMI3GetInt32(FMIInstance *            instance,
+FMIStatus FMI3GetInt32(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        fmi3Int32                values[],
@@ -560,7 +560,7 @@ FMIStatus FMI3GetInt32(FMIInstance *            instance,
   CALL_ARRAY(Get, Int32);
 }
 
-FMIStatus FMI3GetUInt32(FMIInstance *            instance,
+FMIStatus FMI3GetUInt32(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         fmi3UInt32               values[],
@@ -569,7 +569,7 @@ FMIStatus FMI3GetUInt32(FMIInstance *            instance,
   CALL_ARRAY(Get, UInt32);
 }
 
-FMIStatus FMI3GetInt64(FMIInstance *            instance,
+FMIStatus FMI3GetInt64(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        fmi3Int64                values[],
@@ -578,7 +578,7 @@ FMIStatus FMI3GetInt64(FMIInstance *            instance,
   CALL_ARRAY(Get, Int64);
 }
 
-FMIStatus FMI3GetUInt64(FMIInstance *            instance,
+FMIStatus FMI3GetUInt64(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         fmi3UInt64               values[],
@@ -587,7 +587,7 @@ FMIStatus FMI3GetUInt64(FMIInstance *            instance,
   CALL_ARRAY(Get, UInt64);
 }
 
-FMIStatus FMI3GetBoolean(FMIInstance *            instance,
+FMIStatus FMI3GetBoolean(FMIInstance             *instance,
                          const fmi3ValueReference valueReferences[],
                          size_t                   nValueReferences,
                          fmi3Boolean              values[],
@@ -596,7 +596,7 @@ FMIStatus FMI3GetBoolean(FMIInstance *            instance,
   CALL_ARRAY(Get, Boolean);
 }
 
-FMIStatus FMI3GetString(FMIInstance *            instance,
+FMIStatus FMI3GetString(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         fmi3String               values[],
@@ -605,7 +605,7 @@ FMIStatus FMI3GetString(FMIInstance *            instance,
   CALL_ARRAY(Get, String);
 }
 
-FMIStatus FMI3GetBinary(FMIInstance *            instance,
+FMIStatus FMI3GetBinary(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         size_t                   sizes[],
@@ -624,7 +624,7 @@ FMIStatus FMI3GetBinary(FMIInstance *            instance,
   return status;
 }
 
-FMIStatus FMI3GetClock(FMIInstance *            instance,
+FMIStatus FMI3GetClock(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        fmi3Clock                values[])
@@ -641,7 +641,7 @@ FMIStatus FMI3GetClock(FMIInstance *            instance,
   return status;
 }
 
-FMIStatus FMI3SetFloat32(FMIInstance *            instance,
+FMIStatus FMI3SetFloat32(FMIInstance             *instance,
                          const fmi3ValueReference valueReferences[],
                          size_t                   nValueReferences,
                          const fmi3Float32        values[],
@@ -650,7 +650,7 @@ FMIStatus FMI3SetFloat32(FMIInstance *            instance,
   CALL_ARRAY(Set, Float32);
 }
 
-FMIStatus FMI3SetFloat64(FMIInstance *            instance,
+FMIStatus FMI3SetFloat64(FMIInstance             *instance,
                          const fmi3ValueReference valueReferences[],
                          size_t                   nValueReferences,
                          const fmi3Float64        values[],
@@ -659,7 +659,7 @@ FMIStatus FMI3SetFloat64(FMIInstance *            instance,
   CALL_ARRAY(Set, Float64);
 }
 
-FMIStatus FMI3SetInt8(FMIInstance *            instance,
+FMIStatus FMI3SetInt8(FMIInstance             *instance,
                       const fmi3ValueReference valueReferences[],
                       size_t                   nValueReferences,
                       const fmi3Int8           values[],
@@ -668,7 +668,7 @@ FMIStatus FMI3SetInt8(FMIInstance *            instance,
   CALL_ARRAY(Set, Int8);
 }
 
-FMIStatus FMI3SetUInt8(FMIInstance *            instance,
+FMIStatus FMI3SetUInt8(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        const fmi3UInt8          values[],
@@ -677,7 +677,7 @@ FMIStatus FMI3SetUInt8(FMIInstance *            instance,
   CALL_ARRAY(Set, UInt8);
 }
 
-FMIStatus FMI3SetInt16(FMIInstance *            instance,
+FMIStatus FMI3SetInt16(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        const fmi3Int16          values[],
@@ -686,7 +686,7 @@ FMIStatus FMI3SetInt16(FMIInstance *            instance,
   CALL_ARRAY(Set, Int16);
 }
 
-FMIStatus FMI3SetUInt16(FMIInstance *            instance,
+FMIStatus FMI3SetUInt16(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         const fmi3UInt16         values[],
@@ -695,7 +695,7 @@ FMIStatus FMI3SetUInt16(FMIInstance *            instance,
   CALL_ARRAY(Set, UInt16);
 }
 
-FMIStatus FMI3SetInt32(FMIInstance *            instance,
+FMIStatus FMI3SetInt32(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        const fmi3Int32          values[],
@@ -704,7 +704,7 @@ FMIStatus FMI3SetInt32(FMIInstance *            instance,
   CALL_ARRAY(Set, Int32);
 }
 
-FMIStatus FMI3SetUInt32(FMIInstance *            instance,
+FMIStatus FMI3SetUInt32(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         const fmi3UInt32         values[],
@@ -713,7 +713,7 @@ FMIStatus FMI3SetUInt32(FMIInstance *            instance,
   CALL_ARRAY(Set, UInt32);
 }
 
-FMIStatus FMI3SetInt64(FMIInstance *            instance,
+FMIStatus FMI3SetInt64(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        const fmi3Int64          values[],
@@ -722,7 +722,7 @@ FMIStatus FMI3SetInt64(FMIInstance *            instance,
   CALL_ARRAY(Set, Int64);
 }
 
-FMIStatus FMI3SetUInt64(FMIInstance *            instance,
+FMIStatus FMI3SetUInt64(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         const fmi3UInt64         values[],
@@ -731,7 +731,7 @@ FMIStatus FMI3SetUInt64(FMIInstance *            instance,
   CALL_ARRAY(Set, UInt64);
 }
 
-FMIStatus FMI3SetBoolean(FMIInstance *            instance,
+FMIStatus FMI3SetBoolean(FMIInstance             *instance,
                          const fmi3ValueReference valueReferences[],
                          size_t                   nValueReferences,
                          const fmi3Boolean        values[],
@@ -740,7 +740,7 @@ FMIStatus FMI3SetBoolean(FMIInstance *            instance,
   CALL_ARRAY(Set, Boolean);
 }
 
-FMIStatus FMI3SetString(FMIInstance *            instance,
+FMIStatus FMI3SetString(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         const fmi3String         values[],
@@ -749,7 +749,7 @@ FMIStatus FMI3SetString(FMIInstance *            instance,
   CALL_ARRAY(Set, String);
 }
 
-FMIStatus FMI3SetBinary(FMIInstance *            instance,
+FMIStatus FMI3SetBinary(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         const size_t             sizes[],
@@ -768,7 +768,7 @@ FMIStatus FMI3SetBinary(FMIInstance *            instance,
   return status;
 }
 
-FMIStatus FMI3SetClock(FMIInstance *            instance,
+FMIStatus FMI3SetClock(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        const fmi3Clock          values[])
@@ -786,14 +786,14 @@ FMIStatus FMI3SetClock(FMIInstance *            instance,
 }
 
 /* Getting Variable Dependency Information */
-FMIStatus FMI3GetNumberOfVariableDependencies(FMIInstance *      instance,
+FMIStatus FMI3GetNumberOfVariableDependencies(FMIInstance       *instance,
                                               fmi3ValueReference valueReference,
-                                              size_t *           nDependencies)
+                                              size_t            *nDependencies)
 {
   CALL_ARGS(GetNumberOfVariableDependencies, "valueReference=%u, nDependencies=0x%p", valueReference, nDependencies);
 }
 
-FMIStatus FMI3GetVariableDependencies(FMIInstance *      instance,
+FMIStatus FMI3GetVariableDependencies(FMIInstance       *instance,
                                       fmi3ValueReference dependent,
                                       size_t             elementIndicesOfDependent[],
                                       fmi3ValueReference independents[],
@@ -823,7 +823,7 @@ FMIStatus FMI3FreeFMUState(FMIInstance *instance, fmi3FMUState *FMUState)
 
 FMIStatus FMI3SerializedFMUStateSize(FMIInstance *instance,
                                      fmi3FMUState FMUState,
-                                     size_t *     size)
+                                     size_t      *size)
 {
   FMIStatus status = (FMIStatus) instance->fmi3Functions->fmi3SerializedFMUStateSize(instance->component, FMUState, size);
   if (instance->logFunctionCall) {
@@ -840,16 +840,16 @@ FMIStatus FMI3SerializeFMUState(FMIInstance *instance,
   CALL_ARGS(SerializeFMUState, "FMUstate=0x%p, serializedState=0x%p, size=%zu", FMUState, serializedState, size);
 }
 
-FMIStatus FMI3DeserializeFMUState(FMIInstance *  instance,
+FMIStatus FMI3DeserializeFMUState(FMIInstance   *instance,
                                   const fmi3Byte serializedState[],
                                   size_t         size,
-                                  fmi3FMUState * FMUState)
+                                  fmi3FMUState  *FMUState)
 {
   CALL_ARGS(DeserializeFMUState, "serializedState=0x%p, size=%zu, FMUState=0x%p", serializedState, size, FMUState);
 }
 
 /* Getting partial derivatives */
-FMIStatus FMI3GetDirectionalDerivative(FMIInstance *            instance,
+FMIStatus FMI3GetDirectionalDerivative(FMIInstance             *instance,
                                        const fmi3ValueReference unknowns[],
                                        size_t                   nUnknowns,
                                        const fmi3ValueReference knowns[],
@@ -864,7 +864,7 @@ FMIStatus FMI3GetDirectionalDerivative(FMIInstance *            instance,
             unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity);
 }
 
-FMIStatus FMI3GetAdjointDerivative(FMIInstance *            instance,
+FMIStatus FMI3GetAdjointDerivative(FMIInstance             *instance,
                                    const fmi3ValueReference unknowns[],
                                    size_t                   nUnknowns,
                                    const fmi3ValueReference knowns[],
@@ -892,7 +892,7 @@ FMIStatus FMI3ExitConfigurationMode(FMIInstance *instance)
 
 /* Clock related functions */
 
-FMI_STATIC FMIStatus FMI3GetIntervalDecimal(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetIntervalDecimal(FMIInstance             *instance,
                                             const fmi3ValueReference valueReferences[],
                                             size_t                   nValueReferences,
                                             fmi3Float64              intervals[],
@@ -903,7 +903,7 @@ FMI_STATIC FMIStatus FMI3GetIntervalDecimal(FMIInstance *            instance,
             valueReferences, nValueReferences, intervals, qualifiers);
 }
 
-FMIStatus FMI3GetIntervalFraction(FMIInstance *            instance,
+FMIStatus FMI3GetIntervalFraction(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   fmi3UInt64               intervalCounters[],
@@ -915,7 +915,7 @@ FMIStatus FMI3GetIntervalFraction(FMIInstance *            instance,
             valueReferences, nValueReferences, intervalCounters, resolutions, qualifiers);
 }
 
-FMIStatus FMI3GetShiftDecimal(FMIInstance *            instance,
+FMIStatus FMI3GetShiftDecimal(FMIInstance             *instance,
                               const fmi3ValueReference valueReferences[],
                               size_t                   nValueReferences,
                               fmi3Float64              shifts[])
@@ -925,7 +925,7 @@ FMIStatus FMI3GetShiftDecimal(FMIInstance *            instance,
             valueReferences, nValueReferences, shifts);
 }
 
-FMIStatus FMI3GetShiftFraction(FMIInstance *            instance,
+FMIStatus FMI3GetShiftFraction(FMIInstance             *instance,
                                const fmi3ValueReference valueReferences[],
                                size_t                   nValueReferences,
                                fmi3UInt64               shiftCounters[],
@@ -936,7 +936,7 @@ FMIStatus FMI3GetShiftFraction(FMIInstance *            instance,
             valueReferences, nValueReferences, shiftCounters, resolutions);
 }
 
-FMIStatus FMI3SetIntervalDecimal(FMIInstance *            instance,
+FMIStatus FMI3SetIntervalDecimal(FMIInstance             *instance,
                                  const fmi3ValueReference valueReferences[],
                                  size_t                   nValueReferences,
                                  const fmi3Float64        intervals[])
@@ -946,7 +946,7 @@ FMIStatus FMI3SetIntervalDecimal(FMIInstance *            instance,
             valueReferences, nValueReferences, intervals);
 }
 
-FMIStatus FMI3SetIntervalFraction(FMIInstance *            instance,
+FMIStatus FMI3SetIntervalFraction(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   const fmi3UInt64         intervalCounters[],
@@ -957,7 +957,7 @@ FMIStatus FMI3SetIntervalFraction(FMIInstance *            instance,
             valueReferences, nValueReferences, intervalCounters, resolutions);
 }
 
-FMIStatus FMI3SetShiftDecimal(FMIInstance *            instance,
+FMIStatus FMI3SetShiftDecimal(FMIInstance             *instance,
                               const fmi3ValueReference valueReferences[],
                               size_t                   nValueReferences,
                               const fmi3Float64        shifts[])
@@ -967,7 +967,7 @@ FMIStatus FMI3SetShiftDecimal(FMIInstance *            instance,
             valueReferences, nValueReferences, shifts);
 }
 
-FMIStatus FMI3SetShiftFraction(FMIInstance *            instance,
+FMIStatus FMI3SetShiftFraction(FMIInstance             *instance,
                                const fmi3ValueReference valueReferences[],
                                size_t                   nValueReferences,
                                const fmi3UInt64         shiftCounters[],
@@ -1037,7 +1037,7 @@ FMIStatus FMI3SetTime(FMIInstance *instance, fmi3Float64 time)
   CALL_ARGS(SetTime, "time=%.16g", time);
 }
 
-FMIStatus FMI3SetContinuousStates(FMIInstance *     instance,
+FMIStatus FMI3SetContinuousStates(FMIInstance      *instance,
                                   const fmi3Float64 continuousStates[],
                                   size_t            nContinuousStates)
 {
@@ -1114,13 +1114,13 @@ FMIStatus FMI3GetNominalsOfContinuousStates(FMIInstance *instance,
 }
 
 FMIStatus FMI3GetNumberOfEventIndicators(FMIInstance *instance,
-                                         size_t *     nEventIndicators)
+                                         size_t      *nEventIndicators)
 {
   CALL_ARGS(GetNumberOfEventIndicators, "nEventIndicators=0x%p", nEventIndicators);
 }
 
 FMIStatus FMI3GetNumberOfContinuousStates(FMIInstance *instance,
-                                          size_t *     nContinuousStates)
+                                          size_t      *nContinuousStates)
 {
   CALL_ARGS(GetNumberOfContinuousStates, "nContinuousStates=0x%p", nContinuousStates);
 }
@@ -1136,7 +1136,7 @@ FMIStatus FMI3EnterStepMode(FMIInstance *instance)
   CALL(EnterStepMode);
 }
 
-FMIStatus FMI3GetOutputDerivatives(FMIInstance *            instance,
+FMIStatus FMI3GetOutputDerivatives(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    const fmi3Int32          orders[],
@@ -1171,7 +1171,7 @@ FMIStatus FMI3DoStep(FMIInstance *instance,
   return status;
 }
 
-FMIStatus FMI3ActivateModelPartition(FMIInstance *      instance,
+FMIStatus FMI3ActivateModelPartition(FMIInstance       *instance,
                                      fmi3ValueReference clockReference,
                                      fmi3Float64        activationTime)
 {

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/src/cosimulation.c
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/src/cosimulation.c
@@ -18,10 +18,10 @@
 ModelInstance *createModelInstance(
     loggerType             cbLogger,
     intermediateUpdateType intermediateUpdate,
-    void *                 componentEnvironment,
-    const char *           instanceName,
-    const char *           instantiationToken,
-    const char *           resourceLocation,
+    void                  *componentEnvironment,
+    const char            *instanceName,
+    const char            *instantiationToken,
+    const char            *resourceLocation,
     bool                   loggingOn,
     InterfaceType          interfaceType)
 {
@@ -203,7 +203,7 @@ static void logMessage(ModelInstance *comp, int status, const char *category, co
 
   va_list args1;
   size_t  len = 0;
-  char *  buf = "";
+  char   *buf = "";
 
   va_copy(args1, args);
   len = vsnprintf(buf, len, message, args1);

--- a/flow-around-controlled-moving-cylinder/controller-fmi/fmu/src/fmi3Functions.c
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/fmu/src/fmi3Functions.c
@@ -860,7 +860,7 @@ fmi3Status fmi3SetClock(fmi3Instance             instance,
 
 fmi3Status fmi3GetNumberOfVariableDependencies(fmi3Instance       instance,
                                                fmi3ValueReference valueReference,
-                                               size_t *           nDependencies)
+                                               size_t            *nDependencies)
 {
   UNUSED(valueReference);
   UNUSED(nDependencies);
@@ -925,7 +925,7 @@ fmi3Status fmi3FreeFMUState(fmi3Instance instance, fmi3FMUState *FMUState)
 
 fmi3Status fmi3SerializedFMUStateSize(fmi3Instance instance,
                                       fmi3FMUState FMUState,
-                                      size_t *     size)
+                                      size_t      *size)
 {
 
   UNUSED(instance);
@@ -962,7 +962,7 @@ fmi3Status fmi3SerializeFMUState(fmi3Instance instance,
 fmi3Status fmi3DeserializeFMUState(fmi3Instance   instance,
                                    const fmi3Byte serializedState[],
                                    size_t         size,
-                                   fmi3FMUState * FMUState)
+                                   fmi3FMUState  *FMUState)
 {
 
   ASSERT_STATE(DeserializeFMUState);
@@ -1391,7 +1391,7 @@ fmi3Status fmi3GetNominalsOfContinuousStates(fmi3Instance instance,
 }
 
 fmi3Status fmi3GetNumberOfEventIndicators(fmi3Instance instance,
-                                          size_t *     nEventIndicators)
+                                          size_t      *nEventIndicators)
 {
 
   ASSERT_STATE(GetNumberOfEventIndicators);
@@ -1404,7 +1404,7 @@ fmi3Status fmi3GetNumberOfEventIndicators(fmi3Instance instance,
 }
 
 fmi3Status fmi3GetNumberOfContinuousStates(fmi3Instance instance,
-                                           size_t *     nContinuousStates)
+                                           size_t      *nContinuousStates)
 {
 
   ASSERT_STATE(GetNumberOfContinuousStates);

--- a/oscillator/solver-fmi/fmu/include/FMI.h
+++ b/oscillator/solver-fmi/fmu/include/FMI.h
@@ -115,7 +115,7 @@ struct FMIInstance_ {
 
   void *userData;
 
-  FMILogMessage *     logMessage;
+  FMILogMessage      *logMessage;
   FMILogFunctionCall *logFunctionCall;
 
   double time;

--- a/oscillator/solver-fmi/fmu/include/FMI2.h
+++ b/oscillator/solver-fmi/fmu/include/FMI2.h
@@ -17,62 +17,62 @@ struct FMI2Functions_ {
     ****************************************************/
 
   /* required functions */
-  fmi2GetTypesPlatformTYPE *       fmi2GetTypesPlatform;
-  fmi2GetVersionTYPE *             fmi2GetVersion;
-  fmi2SetDebugLoggingTYPE *        fmi2SetDebugLogging;
-  fmi2InstantiateTYPE *            fmi2Instantiate;
-  fmi2FreeInstanceTYPE *           fmi2FreeInstance;
-  fmi2SetupExperimentTYPE *        fmi2SetupExperiment;
+  fmi2GetTypesPlatformTYPE        *fmi2GetTypesPlatform;
+  fmi2GetVersionTYPE              *fmi2GetVersion;
+  fmi2SetDebugLoggingTYPE         *fmi2SetDebugLogging;
+  fmi2InstantiateTYPE             *fmi2Instantiate;
+  fmi2FreeInstanceTYPE            *fmi2FreeInstance;
+  fmi2SetupExperimentTYPE         *fmi2SetupExperiment;
   fmi2EnterInitializationModeTYPE *fmi2EnterInitializationMode;
-  fmi2ExitInitializationModeTYPE * fmi2ExitInitializationMode;
-  fmi2TerminateTYPE *              fmi2Terminate;
-  fmi2ResetTYPE *                  fmi2Reset;
-  fmi2GetRealTYPE *                fmi2GetReal;
-  fmi2GetIntegerTYPE *             fmi2GetInteger;
-  fmi2GetBooleanTYPE *             fmi2GetBoolean;
-  fmi2GetStringTYPE *              fmi2GetString;
-  fmi2SetRealTYPE *                fmi2SetReal;
-  fmi2SetIntegerTYPE *             fmi2SetInteger;
-  fmi2SetBooleanTYPE *             fmi2SetBoolean;
-  fmi2SetStringTYPE *              fmi2SetString;
+  fmi2ExitInitializationModeTYPE  *fmi2ExitInitializationMode;
+  fmi2TerminateTYPE               *fmi2Terminate;
+  fmi2ResetTYPE                   *fmi2Reset;
+  fmi2GetRealTYPE                 *fmi2GetReal;
+  fmi2GetIntegerTYPE              *fmi2GetInteger;
+  fmi2GetBooleanTYPE              *fmi2GetBoolean;
+  fmi2GetStringTYPE               *fmi2GetString;
+  fmi2SetRealTYPE                 *fmi2SetReal;
+  fmi2SetIntegerTYPE              *fmi2SetInteger;
+  fmi2SetBooleanTYPE              *fmi2SetBoolean;
+  fmi2SetStringTYPE               *fmi2SetString;
 
   /* optional functions */
-  fmi2GetFMUstateTYPE *             fmi2GetFMUstate;
-  fmi2SetFMUstateTYPE *             fmi2SetFMUstate;
-  fmi2FreeFMUstateTYPE *            fmi2FreeFMUstate;
-  fmi2SerializedFMUstateSizeTYPE *  fmi2SerializedFMUstateSize;
-  fmi2SerializeFMUstateTYPE *       fmi2SerializeFMUstate;
-  fmi2DeSerializeFMUstateTYPE *     fmi2DeSerializeFMUstate;
+  fmi2GetFMUstateTYPE              *fmi2GetFMUstate;
+  fmi2SetFMUstateTYPE              *fmi2SetFMUstate;
+  fmi2FreeFMUstateTYPE             *fmi2FreeFMUstate;
+  fmi2SerializedFMUstateSizeTYPE   *fmi2SerializedFMUstateSize;
+  fmi2SerializeFMUstateTYPE        *fmi2SerializeFMUstate;
+  fmi2DeSerializeFMUstateTYPE      *fmi2DeSerializeFMUstate;
   fmi2GetDirectionalDerivativeTYPE *fmi2GetDirectionalDerivative;
 
   /***************************************************
     Functions for FMI 2.0 for Model Exchange
     ****************************************************/
 
-  fmi2EnterEventModeTYPE *               fmi2EnterEventMode;
-  fmi2NewDiscreteStatesTYPE *            fmi2NewDiscreteStates;
-  fmi2EnterContinuousTimeModeTYPE *      fmi2EnterContinuousTimeMode;
-  fmi2CompletedIntegratorStepTYPE *      fmi2CompletedIntegratorStep;
-  fmi2SetTimeTYPE *                      fmi2SetTime;
-  fmi2SetContinuousStatesTYPE *          fmi2SetContinuousStates;
-  fmi2GetDerivativesTYPE *               fmi2GetDerivatives;
-  fmi2GetEventIndicatorsTYPE *           fmi2GetEventIndicators;
-  fmi2GetContinuousStatesTYPE *          fmi2GetContinuousStates;
+  fmi2EnterEventModeTYPE                *fmi2EnterEventMode;
+  fmi2NewDiscreteStatesTYPE             *fmi2NewDiscreteStates;
+  fmi2EnterContinuousTimeModeTYPE       *fmi2EnterContinuousTimeMode;
+  fmi2CompletedIntegratorStepTYPE       *fmi2CompletedIntegratorStep;
+  fmi2SetTimeTYPE                       *fmi2SetTime;
+  fmi2SetContinuousStatesTYPE           *fmi2SetContinuousStates;
+  fmi2GetDerivativesTYPE                *fmi2GetDerivatives;
+  fmi2GetEventIndicatorsTYPE            *fmi2GetEventIndicators;
+  fmi2GetContinuousStatesTYPE           *fmi2GetContinuousStates;
   fmi2GetNominalsOfContinuousStatesTYPE *fmi2GetNominalsOfContinuousStates;
 
   /***************************************************
     Functions for FMI 2.0 for Co-Simulation
     ****************************************************/
 
-  fmi2SetRealInputDerivativesTYPE * fmi2SetRealInputDerivatives;
+  fmi2SetRealInputDerivativesTYPE  *fmi2SetRealInputDerivatives;
   fmi2GetRealOutputDerivativesTYPE *fmi2GetRealOutputDerivatives;
-  fmi2DoStepTYPE *                  fmi2DoStep;
-  fmi2CancelStepTYPE *              fmi2CancelStep;
-  fmi2GetStatusTYPE *               fmi2GetStatus;
-  fmi2GetRealStatusTYPE *           fmi2GetRealStatus;
-  fmi2GetIntegerStatusTYPE *        fmi2GetIntegerStatus;
-  fmi2GetBooleanStatusTYPE *        fmi2GetBooleanStatus;
-  fmi2GetStringStatusTYPE *         fmi2GetStringStatus;
+  fmi2DoStepTYPE                   *fmi2DoStep;
+  fmi2CancelStepTYPE               *fmi2CancelStep;
+  fmi2GetStatusTYPE                *fmi2GetStatus;
+  fmi2GetRealStatusTYPE            *fmi2GetRealStatus;
+  fmi2GetIntegerStatusTYPE         *fmi2GetIntegerStatus;
+  fmi2GetBooleanStatusTYPE         *fmi2GetBooleanStatus;
+  fmi2GetStringStatusTYPE          *fmi2GetStringStatus;
 };
 
 /***************************************************
@@ -145,7 +145,7 @@ FMI_STATIC FMIStatus FMI2SerializeFMUstate(FMIInstance *instance, fmi2FMUstate F
 FMI_STATIC FMIStatus FMI2DeSerializeFMUstate(FMIInstance *instance, const fmi2Byte serializedState[], size_t size, fmi2FMUstate *FMUstate);
 
 /* Getting partial derivatives */
-FMI_STATIC FMIStatus FMI2GetDirectionalDerivative(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI2GetDirectionalDerivative(FMIInstance             *instance,
                                                   const fmi2ValueReference vUnknown_ref[], size_t nUnknown,
                                                   const fmi2ValueReference vKnown_ref[], size_t nKnown,
                                                   const fmi2Real dvKnown[],
@@ -186,12 +186,12 @@ Types for Functions for FMI2 for Co-Simulation
 ****************************************************/
 
 /* Simulating the slave */
-FMI_STATIC FMIStatus FMI2SetRealInputDerivatives(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI2SetRealInputDerivatives(FMIInstance             *instance,
                                                  const fmi2ValueReference vr[], size_t nvr,
                                                  const fmi2Integer order[],
                                                  const fmi2Real    value[]);
 
-FMI_STATIC FMIStatus FMI2GetRealOutputDerivatives(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI2GetRealOutputDerivatives(FMIInstance             *instance,
                                                   const fmi2ValueReference vr[], size_t nvr,
                                                   const fmi2Integer order[],
                                                   fmi2Real          value[]);

--- a/oscillator/solver-fmi/fmu/include/FMI3.h
+++ b/oscillator/solver-fmi/fmu/include/FMI3.h
@@ -23,83 +23,83 @@ struct FMI3Functions_ {
     ****************************************************/
 
   /* Inquire version numbers and set debug logging */
-  fmi3GetVersionTYPE *     fmi3GetVersion;
+  fmi3GetVersionTYPE      *fmi3GetVersion;
   fmi3SetDebugLoggingTYPE *fmi3SetDebugLogging;
 
   /* Creation and destruction of FMU instances */
-  fmi3InstantiateModelExchangeTYPE *     fmi3InstantiateModelExchange;
-  fmi3InstantiateCoSimulationTYPE *      fmi3InstantiateCoSimulation;
+  fmi3InstantiateModelExchangeTYPE      *fmi3InstantiateModelExchange;
+  fmi3InstantiateCoSimulationTYPE       *fmi3InstantiateCoSimulation;
   fmi3InstantiateScheduledExecutionTYPE *fmi3InstantiateScheduledExecution;
-  fmi3FreeInstanceTYPE *                 fmi3FreeInstance;
+  fmi3FreeInstanceTYPE                  *fmi3FreeInstance;
 
   /* Enter and exit initialization mode, terminate and reset */
   fmi3EnterInitializationModeTYPE *fmi3EnterInitializationMode;
-  fmi3ExitInitializationModeTYPE * fmi3ExitInitializationMode;
-  fmi3EnterEventModeTYPE *         fmi3EnterEventMode;
-  fmi3TerminateTYPE *              fmi3Terminate;
-  fmi3ResetTYPE *                  fmi3Reset;
+  fmi3ExitInitializationModeTYPE  *fmi3ExitInitializationMode;
+  fmi3EnterEventModeTYPE          *fmi3EnterEventMode;
+  fmi3TerminateTYPE               *fmi3Terminate;
+  fmi3ResetTYPE                   *fmi3Reset;
 
   /* Getting and setting variable values */
   fmi3GetFloat32TYPE *fmi3GetFloat32;
   fmi3GetFloat64TYPE *fmi3GetFloat64;
-  fmi3GetInt8TYPE *   fmi3GetInt8;
-  fmi3GetUInt8TYPE *  fmi3GetUInt8;
-  fmi3GetInt16TYPE *  fmi3GetInt16;
-  fmi3GetUInt16TYPE * fmi3GetUInt16;
-  fmi3GetInt32TYPE *  fmi3GetInt32;
-  fmi3GetUInt32TYPE * fmi3GetUInt32;
-  fmi3GetInt64TYPE *  fmi3GetInt64;
-  fmi3GetUInt64TYPE * fmi3GetUInt64;
+  fmi3GetInt8TYPE    *fmi3GetInt8;
+  fmi3GetUInt8TYPE   *fmi3GetUInt8;
+  fmi3GetInt16TYPE   *fmi3GetInt16;
+  fmi3GetUInt16TYPE  *fmi3GetUInt16;
+  fmi3GetInt32TYPE   *fmi3GetInt32;
+  fmi3GetUInt32TYPE  *fmi3GetUInt32;
+  fmi3GetInt64TYPE   *fmi3GetInt64;
+  fmi3GetUInt64TYPE  *fmi3GetUInt64;
   fmi3GetBooleanTYPE *fmi3GetBoolean;
-  fmi3GetStringTYPE * fmi3GetString;
-  fmi3GetBinaryTYPE * fmi3GetBinary;
-  fmi3GetClockTYPE *  fmi3GetClock;
+  fmi3GetStringTYPE  *fmi3GetString;
+  fmi3GetBinaryTYPE  *fmi3GetBinary;
+  fmi3GetClockTYPE   *fmi3GetClock;
   fmi3SetFloat32TYPE *fmi3SetFloat32;
   fmi3SetFloat64TYPE *fmi3SetFloat64;
-  fmi3SetInt8TYPE *   fmi3SetInt8;
-  fmi3SetUInt8TYPE *  fmi3SetUInt8;
-  fmi3SetInt16TYPE *  fmi3SetInt16;
-  fmi3SetUInt16TYPE * fmi3SetUInt16;
-  fmi3SetInt32TYPE *  fmi3SetInt32;
-  fmi3SetUInt32TYPE * fmi3SetUInt32;
-  fmi3SetInt64TYPE *  fmi3SetInt64;
-  fmi3SetUInt64TYPE * fmi3SetUInt64;
+  fmi3SetInt8TYPE    *fmi3SetInt8;
+  fmi3SetUInt8TYPE   *fmi3SetUInt8;
+  fmi3SetInt16TYPE   *fmi3SetInt16;
+  fmi3SetUInt16TYPE  *fmi3SetUInt16;
+  fmi3SetInt32TYPE   *fmi3SetInt32;
+  fmi3SetUInt32TYPE  *fmi3SetUInt32;
+  fmi3SetInt64TYPE   *fmi3SetInt64;
+  fmi3SetUInt64TYPE  *fmi3SetUInt64;
   fmi3SetBooleanTYPE *fmi3SetBoolean;
-  fmi3SetStringTYPE * fmi3SetString;
-  fmi3SetBinaryTYPE * fmi3SetBinary;
-  fmi3SetClockTYPE *  fmi3SetClock;
+  fmi3SetStringTYPE  *fmi3SetString;
+  fmi3SetBinaryTYPE  *fmi3SetBinary;
+  fmi3SetClockTYPE   *fmi3SetClock;
 
   /* Getting Variable Dependency Information */
   fmi3GetNumberOfVariableDependenciesTYPE *fmi3GetNumberOfVariableDependencies;
-  fmi3GetVariableDependenciesTYPE *        fmi3GetVariableDependencies;
+  fmi3GetVariableDependenciesTYPE         *fmi3GetVariableDependencies;
 
   /* Getting and setting the internal FMU state */
-  fmi3GetFMUStateTYPE *           fmi3GetFMUState;
-  fmi3SetFMUStateTYPE *           fmi3SetFMUState;
-  fmi3FreeFMUStateTYPE *          fmi3FreeFMUState;
+  fmi3GetFMUStateTYPE            *fmi3GetFMUState;
+  fmi3SetFMUStateTYPE            *fmi3SetFMUState;
+  fmi3FreeFMUStateTYPE           *fmi3FreeFMUState;
   fmi3SerializedFMUStateSizeTYPE *fmi3SerializedFMUStateSize;
-  fmi3SerializeFMUStateTYPE *     fmi3SerializeFMUState;
-  fmi3DeserializeFMUStateTYPE *   fmi3DeserializeFMUState;
+  fmi3SerializeFMUStateTYPE      *fmi3SerializeFMUState;
+  fmi3DeserializeFMUStateTYPE    *fmi3DeserializeFMUState;
 
   /* Getting partial derivatives */
   fmi3GetDirectionalDerivativeTYPE *fmi3GetDirectionalDerivative;
-  fmi3GetAdjointDerivativeTYPE *    fmi3GetAdjointDerivative;
+  fmi3GetAdjointDerivativeTYPE     *fmi3GetAdjointDerivative;
 
   /* Entering and exiting the Configuration or Reconfiguration Mode */
   fmi3EnterConfigurationModeTYPE *fmi3EnterConfigurationMode;
-  fmi3ExitConfigurationModeTYPE * fmi3ExitConfigurationMode;
+  fmi3ExitConfigurationModeTYPE  *fmi3ExitConfigurationMode;
 
   /* Clock related functions */
-  fmi3GetIntervalDecimalTYPE *    fmi3GetIntervalDecimal;
-  fmi3GetIntervalFractionTYPE *   fmi3GetIntervalFraction;
-  fmi3GetShiftDecimalTYPE *       fmi3GetShiftDecimal;
-  fmi3GetShiftFractionTYPE *      fmi3GetShiftFraction;
-  fmi3SetIntervalDecimalTYPE *    fmi3SetIntervalDecimal;
-  fmi3SetIntervalFractionTYPE *   fmi3SetIntervalFraction;
-  fmi3SetShiftDecimalTYPE *       fmi3SetShiftDecimal;
-  fmi3SetShiftFractionTYPE *      fmi3SetShiftFraction;
+  fmi3GetIntervalDecimalTYPE     *fmi3GetIntervalDecimal;
+  fmi3GetIntervalFractionTYPE    *fmi3GetIntervalFraction;
+  fmi3GetShiftDecimalTYPE        *fmi3GetShiftDecimal;
+  fmi3GetShiftFractionTYPE       *fmi3GetShiftFraction;
+  fmi3SetIntervalDecimalTYPE     *fmi3SetIntervalDecimal;
+  fmi3SetIntervalFractionTYPE    *fmi3SetIntervalFraction;
+  fmi3SetShiftDecimalTYPE        *fmi3SetShiftDecimal;
+  fmi3SetShiftFractionTYPE       *fmi3SetShiftFraction;
   fmi3EvaluateDiscreteStatesTYPE *fmi3EvaluateDiscreteStates;
-  fmi3UpdateDiscreteStatesTYPE *  fmi3UpdateDiscreteStates;
+  fmi3UpdateDiscreteStatesTYPE   *fmi3UpdateDiscreteStates;
 
   /***************************************************
     Functions for Model Exchange
@@ -109,24 +109,24 @@ struct FMI3Functions_ {
   fmi3CompletedIntegratorStepTYPE *fmi3CompletedIntegratorStep;
 
   /* Providing independent variables and re-initialization of caching */
-  fmi3SetTimeTYPE *            fmi3SetTime;
+  fmi3SetTimeTYPE             *fmi3SetTime;
   fmi3SetContinuousStatesTYPE *fmi3SetContinuousStates;
 
   /* Evaluation of the model equations */
   fmi3GetContinuousStateDerivativesTYPE *fmi3GetContinuousStateDerivatives;
-  fmi3GetEventIndicatorsTYPE *           fmi3GetEventIndicators;
-  fmi3GetContinuousStatesTYPE *          fmi3GetContinuousStates;
+  fmi3GetEventIndicatorsTYPE            *fmi3GetEventIndicators;
+  fmi3GetContinuousStatesTYPE           *fmi3GetContinuousStates;
   fmi3GetNominalsOfContinuousStatesTYPE *fmi3GetNominalsOfContinuousStates;
-  fmi3GetNumberOfEventIndicatorsTYPE *   fmi3GetNumberOfEventIndicators;
-  fmi3GetNumberOfContinuousStatesTYPE *  fmi3GetNumberOfContinuousStates;
+  fmi3GetNumberOfEventIndicatorsTYPE    *fmi3GetNumberOfEventIndicators;
+  fmi3GetNumberOfContinuousStatesTYPE   *fmi3GetNumberOfContinuousStates;
 
   /***************************************************
     Functions for FMI 3.0 for Co-Simulation
     ****************************************************/
 
-  fmi3EnterStepModeTYPE *       fmi3EnterStepMode;
+  fmi3EnterStepModeTYPE        *fmi3EnterStepMode;
   fmi3GetOutputDerivativesTYPE *fmi3GetOutputDerivatives;
-  fmi3DoStepTYPE *              fmi3DoStep;
+  fmi3DoStepTYPE               *fmi3DoStep;
 
   /***************************************************
     Functions for Scheduled Execution
@@ -142,7 +142,7 @@ Common Functions
 /* Inquire version numbers and setting logging status */
 FMI_STATIC const char *FMI3GetVersion(FMIInstance *instance);
 
-FMI_STATIC FMIStatus FMI3SetDebugLogging(FMIInstance *    instance,
+FMI_STATIC FMIStatus FMI3SetDebugLogging(FMIInstance     *instance,
                                          fmi3Boolean      loggingOn,
                                          size_t           nCategories,
                                          const fmi3String categories[]);
@@ -156,7 +156,7 @@ FMI_STATIC FMIStatus FMI3InstantiateModelExchange(
     fmi3Boolean  loggingOn);
 
 FMI_STATIC FMIStatus FMI3InstantiateCoSimulation(
-    FMIInstance *                  instance,
+    FMIInstance                   *instance,
     fmi3String                     instantiationToken,
     fmi3String                     resourcePath,
     fmi3Boolean                    visible,
@@ -168,7 +168,7 @@ FMI_STATIC FMIStatus FMI3InstantiateCoSimulation(
     fmi3IntermediateUpdateCallback intermediateUpdate);
 
 FMI_STATIC FMIStatus FMI3InstantiateScheduledExecution(
-    FMIInstance *                instance,
+    FMIInstance                 *instance,
     fmi3String                   instantiationToken,
     fmi3String                   resourcePath,
     fmi3Boolean                  visible,
@@ -198,180 +198,180 @@ FMI_STATIC FMIStatus FMI3Terminate(FMIInstance *instance);
 FMI_STATIC FMIStatus FMI3Reset(FMIInstance *instance);
 
 /* Getting and setting variable values */
-FMI_STATIC FMIStatus FMI3GetFloat32(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetFloat32(FMIInstance             *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t                   nValueReferences,
                                     fmi3Float32              values[],
                                     size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetFloat64(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetFloat64(FMIInstance             *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t                   nValueReferences,
                                     fmi3Float64              values[],
                                     size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetInt8(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetInt8(FMIInstance             *instance,
                                  const fmi3ValueReference valueReferences[],
                                  size_t                   nValueReferences,
                                  fmi3Int8                 values[],
                                  size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetUInt8(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetUInt8(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   fmi3UInt8                values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetInt16(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetInt16(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   fmi3Int16                values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetUInt16(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetUInt16(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    fmi3UInt16               values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetInt32(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetInt32(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   fmi3Int32                values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetUInt32(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetUInt32(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    fmi3UInt32               values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetInt64(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetInt64(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   fmi3Int64                values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetUInt64(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetUInt64(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    fmi3UInt64               values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetBoolean(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetBoolean(FMIInstance             *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t                   nValueReferences,
                                     fmi3Boolean              values[],
                                     size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetString(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetString(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    fmi3String               values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetBinary(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetBinary(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    size_t                   sizes[],
                                    fmi3Binary               values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3GetClock(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetClock(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   fmi3Clock                values[]);
 
-FMI_STATIC FMIStatus FMI3SetFloat32(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetFloat32(FMIInstance             *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t                   nValueReferences,
                                     const fmi3Float32        values[],
                                     size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetFloat64(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetFloat64(FMIInstance             *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t                   nValueReferences,
                                     const fmi3Float64        values[],
                                     size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetInt8(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetInt8(FMIInstance             *instance,
                                  const fmi3ValueReference valueReferences[],
                                  size_t                   nValueReferences,
                                  const fmi3Int8           values[],
                                  size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetUInt8(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetUInt8(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   const fmi3UInt8          values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetInt16(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetInt16(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   const fmi3Int16          values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetUInt16(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetUInt16(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    const fmi3UInt16         values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetInt32(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetInt32(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   const fmi3Int32          values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetUInt32(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetUInt32(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    const fmi3UInt32         values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetInt64(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetInt64(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   const fmi3Int64          values[],
                                   size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetUInt64(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetUInt64(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    const fmi3UInt64         values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetBoolean(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetBoolean(FMIInstance             *instance,
                                     const fmi3ValueReference valueReferences[],
                                     size_t                   nValueReferences,
                                     const fmi3Boolean        values[],
                                     size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetString(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetString(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    const fmi3String         values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetBinary(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetBinary(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    const size_t             sizes[],
                                    const fmi3Binary         values[],
                                    size_t                   nValues);
 
-FMI_STATIC FMIStatus FMI3SetClock(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetClock(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   const fmi3Clock          values[]);
 
 /* Getting Variable Dependency Information */
-FMI_STATIC FMIStatus FMI3GetNumberOfVariableDependencies(FMIInstance *      instance,
+FMI_STATIC FMIStatus FMI3GetNumberOfVariableDependencies(FMIInstance       *instance,
                                                          fmi3ValueReference valueReference,
-                                                         size_t *           nDependencies);
+                                                         size_t            *nDependencies);
 
-FMI_STATIC FMIStatus FMI3GetVariableDependencies(FMIInstance *      instance,
+FMI_STATIC FMIStatus FMI3GetVariableDependencies(FMIInstance       *instance,
                                                  fmi3ValueReference dependent,
                                                  size_t             elementIndicesOfDependent[],
                                                  fmi3ValueReference independents[],
@@ -388,20 +388,20 @@ FMI_STATIC FMIStatus FMI3FreeFMUState(FMIInstance *instance, fmi3FMUState *FMUSt
 
 FMI_STATIC FMIStatus FMI3SerializedFMUStateSize(FMIInstance *instance,
                                                 fmi3FMUState FMUState,
-                                                size_t *     size);
+                                                size_t      *size);
 
 FMI_STATIC FMIStatus FMI3SerializeFMUState(FMIInstance *instance,
                                            fmi3FMUState FMUState,
                                            fmi3Byte     serializedState[],
                                            size_t       size);
 
-FMI_STATIC FMIStatus FMI3DeserializeFMUState(FMIInstance *  instance,
+FMI_STATIC FMIStatus FMI3DeserializeFMUState(FMIInstance   *instance,
                                              const fmi3Byte serializedState[],
                                              size_t         size,
-                                             fmi3FMUState * FMUState);
+                                             fmi3FMUState  *FMUState);
 
 /* Getting partial derivatives */
-FMI_STATIC FMIStatus FMI3GetDirectionalDerivative(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetDirectionalDerivative(FMIInstance             *instance,
                                                   const fmi3ValueReference unknowns[],
                                                   size_t                   nUnknowns,
                                                   const fmi3ValueReference knowns[],
@@ -411,7 +411,7 @@ FMI_STATIC FMIStatus FMI3GetDirectionalDerivative(FMIInstance *            insta
                                                   fmi3Float64              sensitivity[],
                                                   size_t                   nSensitivity);
 
-FMI_STATIC FMIStatus FMI3GetAdjointDerivative(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetAdjointDerivative(FMIInstance             *instance,
                                               const fmi3ValueReference unknowns[],
                                               size_t                   nUnknowns,
                                               const fmi3ValueReference knowns[],
@@ -426,47 +426,47 @@ FMI_STATIC FMIStatus FMI3EnterConfigurationMode(FMIInstance *instance);
 
 FMI_STATIC FMIStatus FMI3ExitConfigurationMode(FMIInstance *instance);
 
-FMI_STATIC FMIStatus FMI3GetIntervalDecimal(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetIntervalDecimal(FMIInstance             *instance,
                                             const fmi3ValueReference valueReferences[],
                                             size_t                   nValueReferences,
                                             fmi3Float64              intervals[],
                                             fmi3IntervalQualifier    qualifiers[]);
 
-FMI_STATIC FMIStatus FMI3GetIntervalFraction(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetIntervalFraction(FMIInstance             *instance,
                                              const fmi3ValueReference valueReferences[],
                                              size_t                   nValueReferences,
                                              fmi3UInt64               intervalCounters[],
                                              fmi3UInt64               resolutions[],
                                              fmi3IntervalQualifier    qualifiers[]);
 
-FMI_STATIC FMIStatus FMI3GetShiftDecimal(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetShiftDecimal(FMIInstance             *instance,
                                          const fmi3ValueReference valueReferences[],
                                          size_t                   nValueReferences,
                                          fmi3Float64              shifts[]);
 
-FMI_STATIC FMIStatus FMI3GetShiftFraction(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetShiftFraction(FMIInstance             *instance,
                                           const fmi3ValueReference valueReferences[],
                                           size_t                   nValueReferences,
                                           fmi3UInt64               shiftCounters[],
                                           fmi3UInt64               resolutions[]);
 
-FMI_STATIC FMIStatus FMI3SetIntervalDecimal(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetIntervalDecimal(FMIInstance             *instance,
                                             const fmi3ValueReference valueReferences[],
                                             size_t                   nValueReferences,
                                             const fmi3Float64        intervals[]);
 
-FMI_STATIC FMIStatus FMI3SetIntervalFraction(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetIntervalFraction(FMIInstance             *instance,
                                              const fmi3ValueReference valueReferences[],
                                              size_t                   nValueReferences,
                                              const fmi3UInt64         intervalCounters[],
                                              const fmi3UInt64         resolutions[]);
 
-FMI_STATIC FMIStatus FMI3SetShiftDecimal(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetShiftDecimal(FMIInstance             *instance,
                                          const fmi3ValueReference valueReferences[],
                                          size_t                   nValueReferences,
                                          const fmi3Float64        shifts[]);
 
-FMI_STATIC FMIStatus FMI3SetShiftFraction(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3SetShiftFraction(FMIInstance             *instance,
                                           const fmi3ValueReference valueReferences[],
                                           size_t                   nValueReferences,
                                           const fmi3UInt64         shiftCounters[],
@@ -496,7 +496,7 @@ FMI_STATIC FMIStatus FMI3CompletedIntegratorStep(FMIInstance *instance,
 /* Providing independent variables and re-initialization of caching */
 FMI_STATIC FMIStatus FMI3SetTime(FMIInstance *instance, fmi3Float64 time);
 
-FMI_STATIC FMIStatus FMI3SetContinuousStates(FMIInstance *     instance,
+FMI_STATIC FMIStatus FMI3SetContinuousStates(FMIInstance      *instance,
                                              const fmi3Float64 continuousStates[],
                                              size_t            nContinuousStates);
 
@@ -518,10 +518,10 @@ FMI_STATIC FMIStatus FMI3GetNominalsOfContinuousStates(FMIInstance *instance,
                                                        size_t       nContinuousStates);
 
 FMI_STATIC FMIStatus FMI3GetNumberOfEventIndicators(FMIInstance *instance,
-                                                    size_t *     nEventIndicators);
+                                                    size_t      *nEventIndicators);
 
 FMI_STATIC FMIStatus FMI3GetNumberOfContinuousStates(FMIInstance *instance,
-                                                     size_t *     nContinuousStates);
+                                                     size_t      *nContinuousStates);
 
 /***************************************************
 Functions for Co-Simulation
@@ -531,7 +531,7 @@ Functions for Co-Simulation
 
 FMI_STATIC FMIStatus FMI3EnterStepMode(FMIInstance *instance);
 
-FMI_STATIC FMIStatus FMI3GetOutputDerivatives(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetOutputDerivatives(FMIInstance             *instance,
                                               const fmi3ValueReference valueReferences[],
                                               size_t                   nValueReferences,
                                               const fmi3Int32          orders[],
@@ -551,7 +551,7 @@ FMI_STATIC FMIStatus FMI3DoStep(FMIInstance *instance,
 Functions for Scheduled Execution
 ****************************************************/
 
-FMI_STATIC FMIStatus FMI3ActivateModelPartition(FMIInstance *      instance,
+FMI_STATIC FMIStatus FMI3ActivateModelPartition(FMIInstance       *instance,
                                                 fmi3ValueReference clockReference,
                                                 fmi3Float64        activationTime);
 

--- a/oscillator/solver-fmi/fmu/include/fmi2FunctionTypes.h
+++ b/oscillator/solver-fmi/fmu/include/fmi2FunctionTypes.h
@@ -220,8 +220,8 @@ typedef fmi2Status fmi2NewDiscreteStatesTYPE(fmi2Component c, fmi2EventInfo *fmi
 typedef fmi2Status fmi2EnterContinuousTimeModeTYPE(fmi2Component c);
 typedef fmi2Status fmi2CompletedIntegratorStepTYPE(fmi2Component c,
                                                    fmi2Boolean   noSetFMUStatePriorToCurrentPoint,
-                                                   fmi2Boolean * enterEventMode,
-                                                   fmi2Boolean * terminateSimulation);
+                                                   fmi2Boolean  *enterEventMode,
+                                                   fmi2Boolean  *terminateSimulation);
 
 /* Providing independent variables and re-initialization of caching */
 typedef fmi2Status fmi2SetTimeTYPE(fmi2Component c, fmi2Real time);

--- a/oscillator/solver-fmi/fmu/include/fmi2Functions.h
+++ b/oscillator/solver-fmi/fmu/include/fmi2Functions.h
@@ -240,38 +240,38 @@ Common Functions
 
 /* Inquire version numbers of header files */
 FMI2_Export fmi2GetTypesPlatformTYPE fmi2GetTypesPlatform;
-FMI2_Export fmi2GetVersionTYPE fmi2GetVersion;
-FMI2_Export fmi2SetDebugLoggingTYPE fmi2SetDebugLogging;
+FMI2_Export fmi2GetVersionTYPE       fmi2GetVersion;
+FMI2_Export fmi2SetDebugLoggingTYPE  fmi2SetDebugLogging;
 
 /* Creation and destruction of FMU instances */
-FMI2_Export fmi2InstantiateTYPE fmi2Instantiate;
+FMI2_Export fmi2InstantiateTYPE  fmi2Instantiate;
 FMI2_Export fmi2FreeInstanceTYPE fmi2FreeInstance;
 
 /* Enter and exit initialization mode, terminate and reset */
-FMI2_Export fmi2SetupExperimentTYPE fmi2SetupExperiment;
+FMI2_Export fmi2SetupExperimentTYPE         fmi2SetupExperiment;
 FMI2_Export fmi2EnterInitializationModeTYPE fmi2EnterInitializationMode;
-FMI2_Export fmi2ExitInitializationModeTYPE fmi2ExitInitializationMode;
-FMI2_Export fmi2TerminateTYPE fmi2Terminate;
-FMI2_Export fmi2ResetTYPE fmi2Reset;
+FMI2_Export fmi2ExitInitializationModeTYPE  fmi2ExitInitializationMode;
+FMI2_Export fmi2TerminateTYPE               fmi2Terminate;
+FMI2_Export fmi2ResetTYPE                   fmi2Reset;
 
 /* Getting and setting variables values */
-FMI2_Export fmi2GetRealTYPE fmi2GetReal;
+FMI2_Export fmi2GetRealTYPE    fmi2GetReal;
 FMI2_Export fmi2GetIntegerTYPE fmi2GetInteger;
 FMI2_Export fmi2GetBooleanTYPE fmi2GetBoolean;
-FMI2_Export fmi2GetStringTYPE fmi2GetString;
+FMI2_Export fmi2GetStringTYPE  fmi2GetString;
 
-FMI2_Export fmi2SetRealTYPE fmi2SetReal;
+FMI2_Export fmi2SetRealTYPE    fmi2SetReal;
 FMI2_Export fmi2SetIntegerTYPE fmi2SetInteger;
 FMI2_Export fmi2SetBooleanTYPE fmi2SetBoolean;
-FMI2_Export fmi2SetStringTYPE fmi2SetString;
+FMI2_Export fmi2SetStringTYPE  fmi2SetString;
 
 /* Getting and setting the internal FMU state */
-FMI2_Export fmi2GetFMUstateTYPE fmi2GetFMUstate;
-FMI2_Export fmi2SetFMUstateTYPE fmi2SetFMUstate;
-FMI2_Export fmi2FreeFMUstateTYPE fmi2FreeFMUstate;
+FMI2_Export fmi2GetFMUstateTYPE            fmi2GetFMUstate;
+FMI2_Export fmi2SetFMUstateTYPE            fmi2SetFMUstate;
+FMI2_Export fmi2FreeFMUstateTYPE           fmi2FreeFMUstate;
 FMI2_Export fmi2SerializedFMUstateSizeTYPE fmi2SerializedFMUstateSize;
-FMI2_Export fmi2SerializeFMUstateTYPE fmi2SerializeFMUstate;
-FMI2_Export fmi2DeSerializeFMUstateTYPE fmi2DeSerializeFMUstate;
+FMI2_Export fmi2SerializeFMUstateTYPE      fmi2SerializeFMUstate;
+FMI2_Export fmi2DeSerializeFMUstateTYPE    fmi2DeSerializeFMUstate;
 
 /* Getting partial derivatives */
 FMI2_Export fmi2GetDirectionalDerivativeTYPE fmi2GetDirectionalDerivative;
@@ -281,19 +281,19 @@ Functions for FMI2 for Model Exchange
 ****************************************************/
 
 /* Enter and exit the different modes */
-FMI2_Export fmi2EnterEventModeTYPE fmi2EnterEventMode;
-FMI2_Export fmi2NewDiscreteStatesTYPE fmi2NewDiscreteStates;
+FMI2_Export fmi2EnterEventModeTYPE          fmi2EnterEventMode;
+FMI2_Export fmi2NewDiscreteStatesTYPE       fmi2NewDiscreteStates;
 FMI2_Export fmi2EnterContinuousTimeModeTYPE fmi2EnterContinuousTimeMode;
 FMI2_Export fmi2CompletedIntegratorStepTYPE fmi2CompletedIntegratorStep;
 
 /* Providing independent variables and re-initialization of caching */
-FMI2_Export fmi2SetTimeTYPE fmi2SetTime;
+FMI2_Export fmi2SetTimeTYPE             fmi2SetTime;
 FMI2_Export fmi2SetContinuousStatesTYPE fmi2SetContinuousStates;
 
 /* Evaluation of the model equations */
-FMI2_Export fmi2GetDerivativesTYPE fmi2GetDerivatives;
-FMI2_Export fmi2GetEventIndicatorsTYPE fmi2GetEventIndicators;
-FMI2_Export fmi2GetContinuousStatesTYPE fmi2GetContinuousStates;
+FMI2_Export fmi2GetDerivativesTYPE                fmi2GetDerivatives;
+FMI2_Export fmi2GetEventIndicatorsTYPE            fmi2GetEventIndicators;
+FMI2_Export fmi2GetContinuousStatesTYPE           fmi2GetContinuousStates;
 FMI2_Export fmi2GetNominalsOfContinuousStatesTYPE fmi2GetNominalsOfContinuousStates;
 
 /***************************************************
@@ -301,18 +301,18 @@ Functions for FMI2 for Co-Simulation
 ****************************************************/
 
 /* Simulating the slave */
-FMI2_Export fmi2SetRealInputDerivativesTYPE fmi2SetRealInputDerivatives;
+FMI2_Export fmi2SetRealInputDerivativesTYPE  fmi2SetRealInputDerivatives;
 FMI2_Export fmi2GetRealOutputDerivativesTYPE fmi2GetRealOutputDerivatives;
 
-FMI2_Export fmi2DoStepTYPE fmi2DoStep;
+FMI2_Export fmi2DoStepTYPE     fmi2DoStep;
 FMI2_Export fmi2CancelStepTYPE fmi2CancelStep;
 
 /* Inquire slave status */
-FMI2_Export fmi2GetStatusTYPE fmi2GetStatus;
-FMI2_Export fmi2GetRealStatusTYPE fmi2GetRealStatus;
+FMI2_Export fmi2GetStatusTYPE        fmi2GetStatus;
+FMI2_Export fmi2GetRealStatusTYPE    fmi2GetRealStatus;
 FMI2_Export fmi2GetIntegerStatusTYPE fmi2GetIntegerStatus;
 FMI2_Export fmi2GetBooleanStatusTYPE fmi2GetBooleanStatus;
-FMI2_Export fmi2GetStringStatusTYPE fmi2GetStringStatus;
+FMI2_Export fmi2GetStringStatusTYPE  fmi2GetStringStatus;
 
 #ifdef __cplusplus
 } /* end of extern "C" { */

--- a/oscillator/solver-fmi/fmu/include/fmi2TypesPlatform.h
+++ b/oscillator/solver-fmi/fmu/include/fmi2TypesPlatform.h
@@ -89,9 +89,9 @@
                              ('\0' terminated, UTF8 encoded)
    fmi2Byte                : smallest addressable unit of the machine, typically one byte.
 */
-typedef void *          fmi2Component;            /* Pointer to FMU instance       */
-typedef void *          fmi2ComponentEnvironment; /* Pointer to FMU environment    */
-typedef void *          fmi2FMUstate;             /* Pointer to internal FMU state */
+typedef void           *fmi2Component;            /* Pointer to FMU instance       */
+typedef void           *fmi2ComponentEnvironment; /* Pointer to FMU environment    */
+typedef void           *fmi2FMUstate;             /* Pointer to internal FMU state */
 typedef unsigned int    fmi2ValueReference;
 typedef double          fmi2Real;
 typedef int             fmi2Integer;

--- a/oscillator/solver-fmi/fmu/include/fmi3FunctionTypes.h
+++ b/oscillator/solver-fmi/fmu/include/fmi3FunctionTypes.h
@@ -97,8 +97,8 @@ typedef void (*fmi3IntermediateUpdateCallback)(
     fmi3Boolean             intermediateVariableGetAllowed,
     fmi3Boolean             intermediateStepFinished,
     fmi3Boolean             canReturnEarly,
-    fmi3Boolean *           earlyReturnRequested,
-    fmi3Float64 *           earlyReturnTime);
+    fmi3Boolean            *earlyReturnRequested,
+    fmi3Float64            *earlyReturnTime);
 /* end::CallbackIntermediateUpdate[] */
 
 /* tag::CallbackPreemptionLock[] */
@@ -372,7 +372,7 @@ typedef fmi3Status fmi3SetClockTYPE(fmi3Instance             instance,
 /* tag::GetNumberOfVariableDependencies[] */
 typedef fmi3Status fmi3GetNumberOfVariableDependenciesTYPE(fmi3Instance       instance,
                                                            fmi3ValueReference valueReference,
-                                                           size_t *           nDependencies);
+                                                           size_t            *nDependencies);
 /* end::GetNumberOfVariableDependencies[] */
 
 /* tag::GetVariableDependencies[] */
@@ -401,7 +401,7 @@ typedef fmi3Status fmi3FreeFMUStateTYPE(fmi3Instance instance, fmi3FMUState *FMU
 /* tag::SerializedFMUStateSize[] */
 typedef fmi3Status fmi3SerializedFMUStateSizeTYPE(fmi3Instance instance,
                                                   fmi3FMUState FMUState,
-                                                  size_t *     size);
+                                                  size_t      *size);
 /* end::SerializedFMUStateSize[] */
 
 /* tag::SerializeFMUState[] */
@@ -415,7 +415,7 @@ typedef fmi3Status fmi3SerializeFMUStateTYPE(fmi3Instance instance,
 typedef fmi3Status fmi3DeserializeFMUStateTYPE(fmi3Instance   instance,
                                                const fmi3Byte serializedState[],
                                                size_t         size,
-                                               fmi3FMUState * FMUState);
+                                               fmi3FMUState  *FMUState);
 /* end::DeserializeFMUState[] */
 
 /* Getting partial derivatives */
@@ -582,12 +582,12 @@ typedef fmi3Status fmi3GetNominalsOfContinuousStatesTYPE(fmi3Instance instance,
 
 /* tag::GetNumberOfEventIndicators[] */
 typedef fmi3Status fmi3GetNumberOfEventIndicatorsTYPE(fmi3Instance instance,
-                                                      size_t *     nEventIndicators);
+                                                      size_t      *nEventIndicators);
 /* end::GetNumberOfEventIndicators[] */
 
 /* tag::GetNumberOfContinuousStates[] */
 typedef fmi3Status fmi3GetNumberOfContinuousStatesTYPE(fmi3Instance instance,
-                                                       size_t *     nContinuousStates);
+                                                       size_t      *nContinuousStates);
 /* end::GetNumberOfContinuousStates[] */
 
 /***************************************************

--- a/oscillator/solver-fmi/fmu/include/fmi3Functions.h
+++ b/oscillator/solver-fmi/fmu/include/fmi3Functions.h
@@ -222,83 +222,83 @@ Common Functions
 ****************************************************/
 
 /* Inquire version numbers and set debug logging */
-FMI3_Export fmi3GetVersionTYPE fmi3GetVersion;
+FMI3_Export fmi3GetVersionTYPE      fmi3GetVersion;
 FMI3_Export fmi3SetDebugLoggingTYPE fmi3SetDebugLogging;
 
 /* Creation and destruction of FMU instances */
-FMI3_Export fmi3InstantiateModelExchangeTYPE fmi3InstantiateModelExchange;
-FMI3_Export fmi3InstantiateCoSimulationTYPE fmi3InstantiateCoSimulation;
+FMI3_Export fmi3InstantiateModelExchangeTYPE      fmi3InstantiateModelExchange;
+FMI3_Export fmi3InstantiateCoSimulationTYPE       fmi3InstantiateCoSimulation;
 FMI3_Export fmi3InstantiateScheduledExecutionTYPE fmi3InstantiateScheduledExecution;
-FMI3_Export fmi3FreeInstanceTYPE fmi3FreeInstance;
+FMI3_Export fmi3FreeInstanceTYPE                  fmi3FreeInstance;
 
 /* Enter and exit initialization mode, terminate and reset */
 FMI3_Export fmi3EnterInitializationModeTYPE fmi3EnterInitializationMode;
-FMI3_Export fmi3ExitInitializationModeTYPE fmi3ExitInitializationMode;
-FMI3_Export fmi3EnterEventModeTYPE fmi3EnterEventMode;
-FMI3_Export fmi3TerminateTYPE fmi3Terminate;
-FMI3_Export fmi3ResetTYPE fmi3Reset;
+FMI3_Export fmi3ExitInitializationModeTYPE  fmi3ExitInitializationMode;
+FMI3_Export fmi3EnterEventModeTYPE          fmi3EnterEventMode;
+FMI3_Export fmi3TerminateTYPE               fmi3Terminate;
+FMI3_Export fmi3ResetTYPE                   fmi3Reset;
 
 /* Getting and setting variables values */
 FMI3_Export fmi3GetFloat32TYPE fmi3GetFloat32;
 FMI3_Export fmi3GetFloat64TYPE fmi3GetFloat64;
-FMI3_Export fmi3GetInt8TYPE fmi3GetInt8;
-FMI3_Export fmi3GetUInt8TYPE fmi3GetUInt8;
-FMI3_Export fmi3GetInt16TYPE fmi3GetInt16;
-FMI3_Export fmi3GetUInt16TYPE fmi3GetUInt16;
-FMI3_Export fmi3GetInt32TYPE fmi3GetInt32;
-FMI3_Export fmi3GetUInt32TYPE fmi3GetUInt32;
-FMI3_Export fmi3GetInt64TYPE fmi3GetInt64;
-FMI3_Export fmi3GetUInt64TYPE fmi3GetUInt64;
+FMI3_Export fmi3GetInt8TYPE    fmi3GetInt8;
+FMI3_Export fmi3GetUInt8TYPE   fmi3GetUInt8;
+FMI3_Export fmi3GetInt16TYPE   fmi3GetInt16;
+FMI3_Export fmi3GetUInt16TYPE  fmi3GetUInt16;
+FMI3_Export fmi3GetInt32TYPE   fmi3GetInt32;
+FMI3_Export fmi3GetUInt32TYPE  fmi3GetUInt32;
+FMI3_Export fmi3GetInt64TYPE   fmi3GetInt64;
+FMI3_Export fmi3GetUInt64TYPE  fmi3GetUInt64;
 FMI3_Export fmi3GetBooleanTYPE fmi3GetBoolean;
-FMI3_Export fmi3GetStringTYPE fmi3GetString;
-FMI3_Export fmi3GetBinaryTYPE fmi3GetBinary;
-FMI3_Export fmi3GetClockTYPE fmi3GetClock;
+FMI3_Export fmi3GetStringTYPE  fmi3GetString;
+FMI3_Export fmi3GetBinaryTYPE  fmi3GetBinary;
+FMI3_Export fmi3GetClockTYPE   fmi3GetClock;
 FMI3_Export fmi3SetFloat32TYPE fmi3SetFloat32;
 FMI3_Export fmi3SetFloat64TYPE fmi3SetFloat64;
-FMI3_Export fmi3SetInt8TYPE fmi3SetInt8;
-FMI3_Export fmi3SetUInt8TYPE fmi3SetUInt8;
-FMI3_Export fmi3SetInt16TYPE fmi3SetInt16;
-FMI3_Export fmi3SetUInt16TYPE fmi3SetUInt16;
-FMI3_Export fmi3SetInt32TYPE fmi3SetInt32;
-FMI3_Export fmi3SetUInt32TYPE fmi3SetUInt32;
-FMI3_Export fmi3SetInt64TYPE fmi3SetInt64;
-FMI3_Export fmi3SetUInt64TYPE fmi3SetUInt64;
+FMI3_Export fmi3SetInt8TYPE    fmi3SetInt8;
+FMI3_Export fmi3SetUInt8TYPE   fmi3SetUInt8;
+FMI3_Export fmi3SetInt16TYPE   fmi3SetInt16;
+FMI3_Export fmi3SetUInt16TYPE  fmi3SetUInt16;
+FMI3_Export fmi3SetInt32TYPE   fmi3SetInt32;
+FMI3_Export fmi3SetUInt32TYPE  fmi3SetUInt32;
+FMI3_Export fmi3SetInt64TYPE   fmi3SetInt64;
+FMI3_Export fmi3SetUInt64TYPE  fmi3SetUInt64;
 FMI3_Export fmi3SetBooleanTYPE fmi3SetBoolean;
-FMI3_Export fmi3SetStringTYPE fmi3SetString;
-FMI3_Export fmi3SetBinaryTYPE fmi3SetBinary;
-FMI3_Export fmi3SetClockTYPE fmi3SetClock;
+FMI3_Export fmi3SetStringTYPE  fmi3SetString;
+FMI3_Export fmi3SetBinaryTYPE  fmi3SetBinary;
+FMI3_Export fmi3SetClockTYPE   fmi3SetClock;
 
 /* Getting Variable Dependency Information */
 FMI3_Export fmi3GetNumberOfVariableDependenciesTYPE fmi3GetNumberOfVariableDependencies;
-FMI3_Export fmi3GetVariableDependenciesTYPE fmi3GetVariableDependencies;
+FMI3_Export fmi3GetVariableDependenciesTYPE         fmi3GetVariableDependencies;
 
 /* Getting and setting the internal FMU state */
-FMI3_Export fmi3GetFMUStateTYPE fmi3GetFMUState;
-FMI3_Export fmi3SetFMUStateTYPE fmi3SetFMUState;
-FMI3_Export fmi3FreeFMUStateTYPE fmi3FreeFMUState;
+FMI3_Export fmi3GetFMUStateTYPE            fmi3GetFMUState;
+FMI3_Export fmi3SetFMUStateTYPE            fmi3SetFMUState;
+FMI3_Export fmi3FreeFMUStateTYPE           fmi3FreeFMUState;
 FMI3_Export fmi3SerializedFMUStateSizeTYPE fmi3SerializedFMUStateSize;
-FMI3_Export fmi3SerializeFMUStateTYPE fmi3SerializeFMUState;
-FMI3_Export fmi3DeserializeFMUStateTYPE fmi3DeserializeFMUState;
+FMI3_Export fmi3SerializeFMUStateTYPE      fmi3SerializeFMUState;
+FMI3_Export fmi3DeserializeFMUStateTYPE    fmi3DeserializeFMUState;
 
 /* Getting partial derivatives */
 FMI3_Export fmi3GetDirectionalDerivativeTYPE fmi3GetDirectionalDerivative;
-FMI3_Export fmi3GetAdjointDerivativeTYPE fmi3GetAdjointDerivative;
+FMI3_Export fmi3GetAdjointDerivativeTYPE     fmi3GetAdjointDerivative;
 
 /* Entering and exiting the Configuration or Reconfiguration Mode */
 FMI3_Export fmi3EnterConfigurationModeTYPE fmi3EnterConfigurationMode;
-FMI3_Export fmi3ExitConfigurationModeTYPE fmi3ExitConfigurationMode;
+FMI3_Export fmi3ExitConfigurationModeTYPE  fmi3ExitConfigurationMode;
 
 /* Clock related functions */
-FMI3_Export fmi3GetIntervalDecimalTYPE fmi3GetIntervalDecimal;
-FMI3_Export fmi3GetIntervalFractionTYPE fmi3GetIntervalFraction;
-FMI3_Export fmi3GetShiftDecimalTYPE fmi3GetShiftDecimal;
-FMI3_Export fmi3GetShiftFractionTYPE fmi3GetShiftFraction;
-FMI3_Export fmi3SetIntervalDecimalTYPE fmi3SetIntervalDecimal;
-FMI3_Export fmi3SetIntervalFractionTYPE fmi3SetIntervalFraction;
-FMI3_Export fmi3SetShiftDecimalTYPE fmi3SetShiftDecimal;
-FMI3_Export fmi3SetShiftFractionTYPE fmi3SetShiftFraction;
+FMI3_Export fmi3GetIntervalDecimalTYPE     fmi3GetIntervalDecimal;
+FMI3_Export fmi3GetIntervalFractionTYPE    fmi3GetIntervalFraction;
+FMI3_Export fmi3GetShiftDecimalTYPE        fmi3GetShiftDecimal;
+FMI3_Export fmi3GetShiftFractionTYPE       fmi3GetShiftFraction;
+FMI3_Export fmi3SetIntervalDecimalTYPE     fmi3SetIntervalDecimal;
+FMI3_Export fmi3SetIntervalFractionTYPE    fmi3SetIntervalFraction;
+FMI3_Export fmi3SetShiftDecimalTYPE        fmi3SetShiftDecimal;
+FMI3_Export fmi3SetShiftFractionTYPE       fmi3SetShiftFraction;
 FMI3_Export fmi3EvaluateDiscreteStatesTYPE fmi3EvaluateDiscreteStates;
-FMI3_Export fmi3UpdateDiscreteStatesTYPE fmi3UpdateDiscreteStates;
+FMI3_Export fmi3UpdateDiscreteStatesTYPE   fmi3UpdateDiscreteStates;
 
 /***************************************************
 Functions for Model Exchange
@@ -315,20 +315,20 @@ FMI3_Export fmi3SetContinuousStatesTYPE fmi3SetContinuousStates;
 
 /* Evaluation of the model equations */
 FMI3_Export fmi3GetContinuousStateDerivativesTYPE fmi3GetContinuousStateDerivatives;
-FMI3_Export fmi3GetEventIndicatorsTYPE fmi3GetEventIndicators;
-FMI3_Export fmi3GetContinuousStatesTYPE fmi3GetContinuousStates;
+FMI3_Export fmi3GetEventIndicatorsTYPE            fmi3GetEventIndicators;
+FMI3_Export fmi3GetContinuousStatesTYPE           fmi3GetContinuousStates;
 FMI3_Export fmi3GetNominalsOfContinuousStatesTYPE fmi3GetNominalsOfContinuousStates;
-FMI3_Export fmi3GetNumberOfEventIndicatorsTYPE fmi3GetNumberOfEventIndicators;
-FMI3_Export fmi3GetNumberOfContinuousStatesTYPE fmi3GetNumberOfContinuousStates;
+FMI3_Export fmi3GetNumberOfEventIndicatorsTYPE    fmi3GetNumberOfEventIndicators;
+FMI3_Export fmi3GetNumberOfContinuousStatesTYPE   fmi3GetNumberOfContinuousStates;
 
 /***************************************************
 Functions for Co-Simulation
 ****************************************************/
 
 /* Simulating the FMU */
-FMI3_Export fmi3EnterStepModeTYPE fmi3EnterStepMode;
+FMI3_Export fmi3EnterStepModeTYPE        fmi3EnterStepMode;
 FMI3_Export fmi3GetOutputDerivativesTYPE fmi3GetOutputDerivatives;
-FMI3_Export fmi3DoStepTYPE fmi3DoStep;
+FMI3_Export fmi3DoStepTYPE               fmi3DoStep;
 
 /***************************************************
 Functions for Scheduled Execution

--- a/oscillator/solver-fmi/fmu/include/fmi3PlatformTypes.h
+++ b/oscillator/solver-fmi/fmu/include/fmi3PlatformTypes.h
@@ -74,11 +74,11 @@ typedef bool            fmi3Boolean; /* Data type to be used with fmi3True and f
 typedef char            fmi3Char;    /* Data type for one character */
 typedef const fmi3Char *fmi3String;  /* Data type for character strings
                                          ('\0' terminated, UTF-8 encoded) */
-typedef uint8_t         fmi3Byte;    /* Smallest addressable unit of the machine
+typedef uint8_t fmi3Byte;            /* Smallest addressable unit of the machine
                                          (typically one byte) */
 typedef const fmi3Byte *fmi3Binary;  /* Data type for binary data
                                          (out-of-band length terminated) */
-typedef bool            fmi3Clock;   /* Data type to be used with fmi3ClockActive and
+typedef bool fmi3Clock;              /* Data type to be used with fmi3ClockActive and
                                          fmi3ClockInactive */
 
 /* Values for fmi3Boolean */

--- a/oscillator/solver-fmi/fmu/include/fmiModelFunctions.h
+++ b/oscillator/solver-fmi/fmu/include/fmiModelFunctions.h
@@ -175,7 +175,7 @@ DllExport fmiComponent fmiInstantiateModel(fmiString            instanceName,
                                            fmiCallbackFunctions functions,
                                            fmiBoolean           loggingOn);
 DllExport void         fmiFreeModelInstance(fmiComponent c);
-DllExport fmiStatus fmiSetDebugLogging(fmiComponent c, fmiBoolean loggingOn);
+DllExport fmiStatus    fmiSetDebugLogging(fmiComponent c, fmiBoolean loggingOn);
 
 /* Providing independent variables and re-initialization of caching */
 DllExport fmiStatus fmiSetTime(fmiComponent c, fmiReal time);

--- a/oscillator/solver-fmi/fmu/include/fmiModelTypes.h
+++ b/oscillator/solver-fmi/fmu/include/fmiModelTypes.h
@@ -74,12 +74,12 @@
    fmiString        : 32 bit pointer
 
 */
-typedef void *       fmiComponent;
+typedef void        *fmiComponent;
 typedef unsigned int fmiValueReference;
 typedef double       fmiReal;
 typedef int          fmiInteger;
 typedef char         fmiBoolean;
-typedef const char * fmiString;
+typedef const char  *fmiString;
 
 /* Values for fmiBoolean  */
 #define fmiTrue 1

--- a/oscillator/solver-fmi/fmu/include/fmiPlatformTypes.h
+++ b/oscillator/solver-fmi/fmu/include/fmiPlatformTypes.h
@@ -56,12 +56,12 @@
    fmiString        : 32 bit pointer
 
 */
-typedef void *       fmiComponent;
+typedef void        *fmiComponent;
 typedef unsigned int fmiValueReference;
 typedef double       fmiReal;
 typedef int          fmiInteger;
 typedef char         fmiBoolean;
-typedef const char * fmiString;
+typedef const char  *fmiString;
 
 /* Values for fmiBoolean  */
 #define fmiTrue 1

--- a/oscillator/solver-fmi/fmu/include/model.h
+++ b/oscillator/solver-fmi/fmu/include/model.h
@@ -90,13 +90,13 @@ typedef void (*loggerType)(void *componentEnvironment, int status, const char *c
 typedef void (*lockPreemptionType)();
 typedef void (*unlockPreemptionType)();
 
-typedef void (*intermediateUpdateType)(void *  instanceEnvironment,
+typedef void (*intermediateUpdateType)(void   *instanceEnvironment,
                                        double  intermediateUpdateTime,
                                        bool    intermediateVariableSetRequested,
                                        bool    intermediateVariableGetAllowed,
                                        bool    intermediateStepFinished,
                                        bool    canReturnEarly,
-                                       bool *  earlyReturnRequested,
+                                       bool   *earlyReturnRequested,
                                        double *earlyReturnTime);
 
 typedef void (*clockUpdateType)(void *instanceEnvironment);
@@ -106,9 +106,9 @@ typedef struct {
   double        startTime;
   double        time;
   double        solverStepSize;
-  const char *  instanceName;
+  const char   *instanceName;
   InterfaceType type;
-  const char *  resourceLocation;
+  const char   *resourceLocation;
 
   Status status;
 
@@ -123,7 +123,7 @@ typedef struct {
   bool logEvents;
   bool logErrors;
 
-  void *     componentEnvironment;
+  void      *componentEnvironment;
   ModelState state;
 
   // event info
@@ -156,10 +156,10 @@ typedef struct {
 ModelInstance *createModelInstance(
     loggerType             logger,
     intermediateUpdateType intermediateUpdate,
-    void *                 componentEnvironment,
-    const char *           instanceName,
-    const char *           instantiationToken,
-    const char *           resourceLocation,
+    void                  *componentEnvironment,
+    const char            *instanceName,
+    const char            *instantiationToken,
+    const char            *resourceLocation,
     bool                   loggingOn,
     InterfaceType          interfaceType);
 
@@ -214,7 +214,7 @@ Status getOutputDerivative(ModelInstance *comp, ValueReference valueReference, i
 Status getPartialDerivative(ModelInstance *comp, ValueReference unknown, ValueReference known, double *partialDerivative);
 void   getEventIndicators(ModelInstance *comp, double z[], size_t nz);
 void   eventUpdate(ModelInstance *comp);
-//void updateEventTime(ModelInstance *comp);
+// void updateEventTime(ModelInstance *comp);
 
 bool   invalidNumber(ModelInstance *comp, const char *f, const char *arg, size_t actual, size_t expected);
 bool   invalidState(ModelInstance *comp, const char *f, int statesExpected);

--- a/oscillator/solver-fmi/fmu/src/FMI.c
+++ b/oscillator/solver-fmi/fmu/src/FMI.c
@@ -139,7 +139,7 @@ const char *FMIValuesToString(FMIInstance *instance, size_t vValues, const size_
 
     for (size_t i = 0; i < vValues; i++) {
 
-      char * s = &instance->buf2[pos];
+      char  *s = &instance->buf2[pos];
       size_t n = instance->bufsize2 - pos;
 
       switch (variableType) {

--- a/oscillator/solver-fmi/fmu/src/FMI2.c
+++ b/oscillator/solver-fmi/fmu/src/FMI2.c
@@ -371,7 +371,7 @@ FMIStatus FMI2DeSerializeFMUstate(FMIInstance *instance, const fmi2Byte serializ
 }
 
 /* Getting partial derivatives */
-FMIStatus FMI2GetDirectionalDerivative(FMIInstance *            instance,
+FMIStatus FMI2GetDirectionalDerivative(FMIInstance             *instance,
                                        const fmi2ValueReference vUnknown_ref[], size_t nUnknown,
                                        const fmi2ValueReference vKnown_ref[], size_t nKnown,
                                        const fmi2Real dvKnown[],
@@ -484,7 +484,7 @@ Co-Simulation
 ****************************************************/
 
 /* Simulating the slave */
-FMIStatus FMI2SetRealInputDerivatives(FMIInstance *            instance,
+FMIStatus FMI2SetRealInputDerivatives(FMIInstance             *instance,
                                       const fmi2ValueReference vr[], size_t nvr,
                                       const fmi2Integer order[],
                                       const fmi2Real    value[])
@@ -492,7 +492,7 @@ FMIStatus FMI2SetRealInputDerivatives(FMIInstance *            instance,
   CALL_ARGS(SetRealInputDerivatives, "vr=0x%p, nvr=%zu, order=0x%p, value=0x%p", vr, nvr, order, value);
 }
 
-FMIStatus FMI2GetRealOutputDerivatives(FMIInstance *            instance,
+FMIStatus FMI2GetRealOutputDerivatives(FMIInstance             *instance,
                                        const fmi2ValueReference vr[], size_t nvr,
                                        const fmi2Integer order[],
                                        fmi2Real          value[])

--- a/oscillator/solver-fmi/fmu/src/FMI3.c
+++ b/oscillator/solver-fmi/fmu/src/FMI3.c
@@ -100,7 +100,7 @@ const char *FMI3GetVersion(FMIInstance *instance)
   return instance->fmi3Functions->fmi3GetVersion();
 }
 
-FMIStatus FMI3SetDebugLogging(FMIInstance *    instance,
+FMIStatus FMI3SetDebugLogging(FMIInstance     *instance,
                               fmi3Boolean      loggingOn,
                               size_t           nCategories,
                               const fmi3String categories[])
@@ -293,7 +293,7 @@ FMIStatus FMI3InstantiateModelExchange(
 }
 
 FMIStatus FMI3InstantiateCoSimulation(
-    FMIInstance *                  instance,
+    FMIInstance                   *instance,
     fmi3String                     instantiationToken,
     fmi3String                     resourcePath,
     fmi3Boolean                    visible,
@@ -367,7 +367,7 @@ FMIStatus FMI3InstantiateCoSimulation(
 }
 
 FMIStatus FMI3InstantiateScheduledExecution(
-    FMIInstance *                instance,
+    FMIInstance                 *instance,
     fmi3String                   instantiationToken,
     fmi3String                   resourcePath,
     fmi3Boolean                  visible,
@@ -497,7 +497,7 @@ FMIStatus FMI3Reset(FMIInstance *instance)
 }
 
 /* Getting and setting variable values */
-FMIStatus FMI3GetFloat32(FMIInstance *            instance,
+FMIStatus FMI3GetFloat32(FMIInstance             *instance,
                          const fmi3ValueReference valueReferences[],
                          size_t                   nValueReferences,
                          fmi3Float32              values[],
@@ -506,7 +506,7 @@ FMIStatus FMI3GetFloat32(FMIInstance *            instance,
   CALL_ARRAY(Get, Float32);
 }
 
-FMIStatus FMI3GetFloat64(FMIInstance *            instance,
+FMIStatus FMI3GetFloat64(FMIInstance             *instance,
                          const fmi3ValueReference valueReferences[],
                          size_t                   nValueReferences,
                          fmi3Float64              values[],
@@ -515,7 +515,7 @@ FMIStatus FMI3GetFloat64(FMIInstance *            instance,
   CALL_ARRAY(Get, Float64);
 }
 
-FMIStatus FMI3GetInt8(FMIInstance *            instance,
+FMIStatus FMI3GetInt8(FMIInstance             *instance,
                       const fmi3ValueReference valueReferences[],
                       size_t                   nValueReferences,
                       fmi3Int8                 values[],
@@ -524,7 +524,7 @@ FMIStatus FMI3GetInt8(FMIInstance *            instance,
   CALL_ARRAY(Get, Int8);
 }
 
-FMIStatus FMI3GetUInt8(FMIInstance *            instance,
+FMIStatus FMI3GetUInt8(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        fmi3UInt8                values[],
@@ -533,7 +533,7 @@ FMIStatus FMI3GetUInt8(FMIInstance *            instance,
   CALL_ARRAY(Get, UInt8);
 }
 
-FMIStatus FMI3GetInt16(FMIInstance *            instance,
+FMIStatus FMI3GetInt16(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        fmi3Int16                values[],
@@ -542,7 +542,7 @@ FMIStatus FMI3GetInt16(FMIInstance *            instance,
   CALL_ARRAY(Get, Int16);
 }
 
-FMIStatus FMI3GetUInt16(FMIInstance *            instance,
+FMIStatus FMI3GetUInt16(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         fmi3UInt16               values[],
@@ -551,7 +551,7 @@ FMIStatus FMI3GetUInt16(FMIInstance *            instance,
   CALL_ARRAY(Get, UInt16);
 }
 
-FMIStatus FMI3GetInt32(FMIInstance *            instance,
+FMIStatus FMI3GetInt32(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        fmi3Int32                values[],
@@ -560,7 +560,7 @@ FMIStatus FMI3GetInt32(FMIInstance *            instance,
   CALL_ARRAY(Get, Int32);
 }
 
-FMIStatus FMI3GetUInt32(FMIInstance *            instance,
+FMIStatus FMI3GetUInt32(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         fmi3UInt32               values[],
@@ -569,7 +569,7 @@ FMIStatus FMI3GetUInt32(FMIInstance *            instance,
   CALL_ARRAY(Get, UInt32);
 }
 
-FMIStatus FMI3GetInt64(FMIInstance *            instance,
+FMIStatus FMI3GetInt64(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        fmi3Int64                values[],
@@ -578,7 +578,7 @@ FMIStatus FMI3GetInt64(FMIInstance *            instance,
   CALL_ARRAY(Get, Int64);
 }
 
-FMIStatus FMI3GetUInt64(FMIInstance *            instance,
+FMIStatus FMI3GetUInt64(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         fmi3UInt64               values[],
@@ -587,7 +587,7 @@ FMIStatus FMI3GetUInt64(FMIInstance *            instance,
   CALL_ARRAY(Get, UInt64);
 }
 
-FMIStatus FMI3GetBoolean(FMIInstance *            instance,
+FMIStatus FMI3GetBoolean(FMIInstance             *instance,
                          const fmi3ValueReference valueReferences[],
                          size_t                   nValueReferences,
                          fmi3Boolean              values[],
@@ -596,7 +596,7 @@ FMIStatus FMI3GetBoolean(FMIInstance *            instance,
   CALL_ARRAY(Get, Boolean);
 }
 
-FMIStatus FMI3GetString(FMIInstance *            instance,
+FMIStatus FMI3GetString(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         fmi3String               values[],
@@ -605,7 +605,7 @@ FMIStatus FMI3GetString(FMIInstance *            instance,
   CALL_ARRAY(Get, String);
 }
 
-FMIStatus FMI3GetBinary(FMIInstance *            instance,
+FMIStatus FMI3GetBinary(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         size_t                   sizes[],
@@ -624,7 +624,7 @@ FMIStatus FMI3GetBinary(FMIInstance *            instance,
   return status;
 }
 
-FMIStatus FMI3GetClock(FMIInstance *            instance,
+FMIStatus FMI3GetClock(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        fmi3Clock                values[])
@@ -641,7 +641,7 @@ FMIStatus FMI3GetClock(FMIInstance *            instance,
   return status;
 }
 
-FMIStatus FMI3SetFloat32(FMIInstance *            instance,
+FMIStatus FMI3SetFloat32(FMIInstance             *instance,
                          const fmi3ValueReference valueReferences[],
                          size_t                   nValueReferences,
                          const fmi3Float32        values[],
@@ -650,7 +650,7 @@ FMIStatus FMI3SetFloat32(FMIInstance *            instance,
   CALL_ARRAY(Set, Float32);
 }
 
-FMIStatus FMI3SetFloat64(FMIInstance *            instance,
+FMIStatus FMI3SetFloat64(FMIInstance             *instance,
                          const fmi3ValueReference valueReferences[],
                          size_t                   nValueReferences,
                          const fmi3Float64        values[],
@@ -659,7 +659,7 @@ FMIStatus FMI3SetFloat64(FMIInstance *            instance,
   CALL_ARRAY(Set, Float64);
 }
 
-FMIStatus FMI3SetInt8(FMIInstance *            instance,
+FMIStatus FMI3SetInt8(FMIInstance             *instance,
                       const fmi3ValueReference valueReferences[],
                       size_t                   nValueReferences,
                       const fmi3Int8           values[],
@@ -668,7 +668,7 @@ FMIStatus FMI3SetInt8(FMIInstance *            instance,
   CALL_ARRAY(Set, Int8);
 }
 
-FMIStatus FMI3SetUInt8(FMIInstance *            instance,
+FMIStatus FMI3SetUInt8(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        const fmi3UInt8          values[],
@@ -677,7 +677,7 @@ FMIStatus FMI3SetUInt8(FMIInstance *            instance,
   CALL_ARRAY(Set, UInt8);
 }
 
-FMIStatus FMI3SetInt16(FMIInstance *            instance,
+FMIStatus FMI3SetInt16(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        const fmi3Int16          values[],
@@ -686,7 +686,7 @@ FMIStatus FMI3SetInt16(FMIInstance *            instance,
   CALL_ARRAY(Set, Int16);
 }
 
-FMIStatus FMI3SetUInt16(FMIInstance *            instance,
+FMIStatus FMI3SetUInt16(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         const fmi3UInt16         values[],
@@ -695,7 +695,7 @@ FMIStatus FMI3SetUInt16(FMIInstance *            instance,
   CALL_ARRAY(Set, UInt16);
 }
 
-FMIStatus FMI3SetInt32(FMIInstance *            instance,
+FMIStatus FMI3SetInt32(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        const fmi3Int32          values[],
@@ -704,7 +704,7 @@ FMIStatus FMI3SetInt32(FMIInstance *            instance,
   CALL_ARRAY(Set, Int32);
 }
 
-FMIStatus FMI3SetUInt32(FMIInstance *            instance,
+FMIStatus FMI3SetUInt32(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         const fmi3UInt32         values[],
@@ -713,7 +713,7 @@ FMIStatus FMI3SetUInt32(FMIInstance *            instance,
   CALL_ARRAY(Set, UInt32);
 }
 
-FMIStatus FMI3SetInt64(FMIInstance *            instance,
+FMIStatus FMI3SetInt64(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        const fmi3Int64          values[],
@@ -722,7 +722,7 @@ FMIStatus FMI3SetInt64(FMIInstance *            instance,
   CALL_ARRAY(Set, Int64);
 }
 
-FMIStatus FMI3SetUInt64(FMIInstance *            instance,
+FMIStatus FMI3SetUInt64(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         const fmi3UInt64         values[],
@@ -731,7 +731,7 @@ FMIStatus FMI3SetUInt64(FMIInstance *            instance,
   CALL_ARRAY(Set, UInt64);
 }
 
-FMIStatus FMI3SetBoolean(FMIInstance *            instance,
+FMIStatus FMI3SetBoolean(FMIInstance             *instance,
                          const fmi3ValueReference valueReferences[],
                          size_t                   nValueReferences,
                          const fmi3Boolean        values[],
@@ -740,7 +740,7 @@ FMIStatus FMI3SetBoolean(FMIInstance *            instance,
   CALL_ARRAY(Set, Boolean);
 }
 
-FMIStatus FMI3SetString(FMIInstance *            instance,
+FMIStatus FMI3SetString(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         const fmi3String         values[],
@@ -749,7 +749,7 @@ FMIStatus FMI3SetString(FMIInstance *            instance,
   CALL_ARRAY(Set, String);
 }
 
-FMIStatus FMI3SetBinary(FMIInstance *            instance,
+FMIStatus FMI3SetBinary(FMIInstance             *instance,
                         const fmi3ValueReference valueReferences[],
                         size_t                   nValueReferences,
                         const size_t             sizes[],
@@ -768,7 +768,7 @@ FMIStatus FMI3SetBinary(FMIInstance *            instance,
   return status;
 }
 
-FMIStatus FMI3SetClock(FMIInstance *            instance,
+FMIStatus FMI3SetClock(FMIInstance             *instance,
                        const fmi3ValueReference valueReferences[],
                        size_t                   nValueReferences,
                        const fmi3Clock          values[])
@@ -786,14 +786,14 @@ FMIStatus FMI3SetClock(FMIInstance *            instance,
 }
 
 /* Getting Variable Dependency Information */
-FMIStatus FMI3GetNumberOfVariableDependencies(FMIInstance *      instance,
+FMIStatus FMI3GetNumberOfVariableDependencies(FMIInstance       *instance,
                                               fmi3ValueReference valueReference,
-                                              size_t *           nDependencies)
+                                              size_t            *nDependencies)
 {
   CALL_ARGS(GetNumberOfVariableDependencies, "valueReference=%u, nDependencies=0x%p", valueReference, nDependencies);
 }
 
-FMIStatus FMI3GetVariableDependencies(FMIInstance *      instance,
+FMIStatus FMI3GetVariableDependencies(FMIInstance       *instance,
                                       fmi3ValueReference dependent,
                                       size_t             elementIndicesOfDependent[],
                                       fmi3ValueReference independents[],
@@ -823,7 +823,7 @@ FMIStatus FMI3FreeFMUState(FMIInstance *instance, fmi3FMUState *FMUState)
 
 FMIStatus FMI3SerializedFMUStateSize(FMIInstance *instance,
                                      fmi3FMUState FMUState,
-                                     size_t *     size)
+                                     size_t      *size)
 {
   FMIStatus status = (FMIStatus) instance->fmi3Functions->fmi3SerializedFMUStateSize(instance->component, FMUState, size);
   if (instance->logFunctionCall) {
@@ -840,16 +840,16 @@ FMIStatus FMI3SerializeFMUState(FMIInstance *instance,
   CALL_ARGS(SerializeFMUState, "FMUstate=0x%p, serializedState=0x%p, size=%zu", FMUState, serializedState, size);
 }
 
-FMIStatus FMI3DeserializeFMUState(FMIInstance *  instance,
+FMIStatus FMI3DeserializeFMUState(FMIInstance   *instance,
                                   const fmi3Byte serializedState[],
                                   size_t         size,
-                                  fmi3FMUState * FMUState)
+                                  fmi3FMUState  *FMUState)
 {
   CALL_ARGS(DeserializeFMUState, "serializedState=0x%p, size=%zu, FMUState=0x%p", serializedState, size, FMUState);
 }
 
 /* Getting partial derivatives */
-FMIStatus FMI3GetDirectionalDerivative(FMIInstance *            instance,
+FMIStatus FMI3GetDirectionalDerivative(FMIInstance             *instance,
                                        const fmi3ValueReference unknowns[],
                                        size_t                   nUnknowns,
                                        const fmi3ValueReference knowns[],
@@ -864,7 +864,7 @@ FMIStatus FMI3GetDirectionalDerivative(FMIInstance *            instance,
             unknowns, nUnknowns, knowns, nKnowns, seed, nSeed, sensitivity, nSensitivity);
 }
 
-FMIStatus FMI3GetAdjointDerivative(FMIInstance *            instance,
+FMIStatus FMI3GetAdjointDerivative(FMIInstance             *instance,
                                    const fmi3ValueReference unknowns[],
                                    size_t                   nUnknowns,
                                    const fmi3ValueReference knowns[],
@@ -892,7 +892,7 @@ FMIStatus FMI3ExitConfigurationMode(FMIInstance *instance)
 
 /* Clock related functions */
 
-FMI_STATIC FMIStatus FMI3GetIntervalDecimal(FMIInstance *            instance,
+FMI_STATIC FMIStatus FMI3GetIntervalDecimal(FMIInstance             *instance,
                                             const fmi3ValueReference valueReferences[],
                                             size_t                   nValueReferences,
                                             fmi3Float64              intervals[],
@@ -903,7 +903,7 @@ FMI_STATIC FMIStatus FMI3GetIntervalDecimal(FMIInstance *            instance,
             valueReferences, nValueReferences, intervals, qualifiers);
 }
 
-FMIStatus FMI3GetIntervalFraction(FMIInstance *            instance,
+FMIStatus FMI3GetIntervalFraction(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   fmi3UInt64               intervalCounters[],
@@ -915,7 +915,7 @@ FMIStatus FMI3GetIntervalFraction(FMIInstance *            instance,
             valueReferences, nValueReferences, intervalCounters, resolutions, qualifiers);
 }
 
-FMIStatus FMI3GetShiftDecimal(FMIInstance *            instance,
+FMIStatus FMI3GetShiftDecimal(FMIInstance             *instance,
                               const fmi3ValueReference valueReferences[],
                               size_t                   nValueReferences,
                               fmi3Float64              shifts[])
@@ -925,7 +925,7 @@ FMIStatus FMI3GetShiftDecimal(FMIInstance *            instance,
             valueReferences, nValueReferences, shifts);
 }
 
-FMIStatus FMI3GetShiftFraction(FMIInstance *            instance,
+FMIStatus FMI3GetShiftFraction(FMIInstance             *instance,
                                const fmi3ValueReference valueReferences[],
                                size_t                   nValueReferences,
                                fmi3UInt64               shiftCounters[],
@@ -936,7 +936,7 @@ FMIStatus FMI3GetShiftFraction(FMIInstance *            instance,
             valueReferences, nValueReferences, shiftCounters, resolutions);
 }
 
-FMIStatus FMI3SetIntervalDecimal(FMIInstance *            instance,
+FMIStatus FMI3SetIntervalDecimal(FMIInstance             *instance,
                                  const fmi3ValueReference valueReferences[],
                                  size_t                   nValueReferences,
                                  const fmi3Float64        intervals[])
@@ -946,7 +946,7 @@ FMIStatus FMI3SetIntervalDecimal(FMIInstance *            instance,
             valueReferences, nValueReferences, intervals);
 }
 
-FMIStatus FMI3SetIntervalFraction(FMIInstance *            instance,
+FMIStatus FMI3SetIntervalFraction(FMIInstance             *instance,
                                   const fmi3ValueReference valueReferences[],
                                   size_t                   nValueReferences,
                                   const fmi3UInt64         intervalCounters[],
@@ -957,7 +957,7 @@ FMIStatus FMI3SetIntervalFraction(FMIInstance *            instance,
             valueReferences, nValueReferences, intervalCounters, resolutions);
 }
 
-FMIStatus FMI3SetShiftDecimal(FMIInstance *            instance,
+FMIStatus FMI3SetShiftDecimal(FMIInstance             *instance,
                               const fmi3ValueReference valueReferences[],
                               size_t                   nValueReferences,
                               const fmi3Float64        shifts[])
@@ -967,7 +967,7 @@ FMIStatus FMI3SetShiftDecimal(FMIInstance *            instance,
             valueReferences, nValueReferences, shifts);
 }
 
-FMIStatus FMI3SetShiftFraction(FMIInstance *            instance,
+FMIStatus FMI3SetShiftFraction(FMIInstance             *instance,
                                const fmi3ValueReference valueReferences[],
                                size_t                   nValueReferences,
                                const fmi3UInt64         shiftCounters[],
@@ -1037,7 +1037,7 @@ FMIStatus FMI3SetTime(FMIInstance *instance, fmi3Float64 time)
   CALL_ARGS(SetTime, "time=%.16g", time);
 }
 
-FMIStatus FMI3SetContinuousStates(FMIInstance *     instance,
+FMIStatus FMI3SetContinuousStates(FMIInstance      *instance,
                                   const fmi3Float64 continuousStates[],
                                   size_t            nContinuousStates)
 {
@@ -1114,13 +1114,13 @@ FMIStatus FMI3GetNominalsOfContinuousStates(FMIInstance *instance,
 }
 
 FMIStatus FMI3GetNumberOfEventIndicators(FMIInstance *instance,
-                                         size_t *     nEventIndicators)
+                                         size_t      *nEventIndicators)
 {
   CALL_ARGS(GetNumberOfEventIndicators, "nEventIndicators=0x%p", nEventIndicators);
 }
 
 FMIStatus FMI3GetNumberOfContinuousStates(FMIInstance *instance,
-                                          size_t *     nContinuousStates)
+                                          size_t      *nContinuousStates)
 {
   CALL_ARGS(GetNumberOfContinuousStates, "nContinuousStates=0x%p", nContinuousStates);
 }
@@ -1136,7 +1136,7 @@ FMIStatus FMI3EnterStepMode(FMIInstance *instance)
   CALL(EnterStepMode);
 }
 
-FMIStatus FMI3GetOutputDerivatives(FMIInstance *            instance,
+FMIStatus FMI3GetOutputDerivatives(FMIInstance             *instance,
                                    const fmi3ValueReference valueReferences[],
                                    size_t                   nValueReferences,
                                    const fmi3Int32          orders[],
@@ -1171,7 +1171,7 @@ FMIStatus FMI3DoStep(FMIInstance *instance,
   return status;
 }
 
-FMIStatus FMI3ActivateModelPartition(FMIInstance *      instance,
+FMIStatus FMI3ActivateModelPartition(FMIInstance       *instance,
                                      fmi3ValueReference clockReference,
                                      fmi3Float64        activationTime)
 {

--- a/oscillator/solver-fmi/fmu/src/cosimulation.c
+++ b/oscillator/solver-fmi/fmu/src/cosimulation.c
@@ -18,10 +18,10 @@
 ModelInstance *createModelInstance(
     loggerType             cbLogger,
     intermediateUpdateType intermediateUpdate,
-    void *                 componentEnvironment,
-    const char *           instanceName,
-    const char *           instantiationToken,
-    const char *           resourceLocation,
+    void                  *componentEnvironment,
+    const char            *instanceName,
+    const char            *instantiationToken,
+    const char            *resourceLocation,
     bool                   loggingOn,
     InterfaceType          interfaceType)
 {
@@ -203,7 +203,7 @@ static void logMessage(ModelInstance *comp, int status, const char *category, co
 
   va_list args1;
   size_t  len = 0;
-  char *  buf = "";
+  char   *buf = "";
 
   va_copy(args1, args);
   len = vsnprintf(buf, len, message, args1);

--- a/oscillator/solver-fmi/fmu/src/fmi3Functions.c
+++ b/oscillator/solver-fmi/fmu/src/fmi3Functions.c
@@ -860,7 +860,7 @@ fmi3Status fmi3SetClock(fmi3Instance             instance,
 
 fmi3Status fmi3GetNumberOfVariableDependencies(fmi3Instance       instance,
                                                fmi3ValueReference valueReference,
-                                               size_t *           nDependencies)
+                                               size_t            *nDependencies)
 {
   UNUSED(valueReference);
   UNUSED(nDependencies);
@@ -925,7 +925,7 @@ fmi3Status fmi3FreeFMUState(fmi3Instance instance, fmi3FMUState *FMUState)
 
 fmi3Status fmi3SerializedFMUStateSize(fmi3Instance instance,
                                       fmi3FMUState FMUState,
-                                      size_t *     size)
+                                      size_t      *size)
 {
 
   UNUSED(instance);
@@ -962,7 +962,7 @@ fmi3Status fmi3SerializeFMUState(fmi3Instance instance,
 fmi3Status fmi3DeserializeFMUState(fmi3Instance   instance,
                                    const fmi3Byte serializedState[],
                                    size_t         size,
-                                   fmi3FMUState * FMUState)
+                                   fmi3FMUState  *FMUState)
 {
 
   ASSERT_STATE(DeserializeFMUState);
@@ -1391,7 +1391,7 @@ fmi3Status fmi3GetNominalsOfContinuousStates(fmi3Instance instance,
 }
 
 fmi3Status fmi3GetNumberOfEventIndicators(fmi3Instance instance,
-                                          size_t *     nEventIndicators)
+                                          size_t      *nEventIndicators)
 {
 
   ASSERT_STATE(GetNumberOfEventIndicators);
@@ -1404,7 +1404,7 @@ fmi3Status fmi3GetNumberOfEventIndicators(fmi3Instance instance,
 }
 
 fmi3Status fmi3GetNumberOfContinuousStates(fmi3Instance instance,
-                                           size_t *     nContinuousStates)
+                                           size_t      *nContinuousStates)
 {
 
   ASSERT_STATE(GetNumberOfContinuousStates);

--- a/partitioned-heat-conduction/solver-openfoam/.clang-format
+++ b/partitioned-heat-conduction/solver-openfoam/.clang-format
@@ -1,0 +1,175 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+#
+# Proposed clang-format-11 style for OpenFOAM, trying to follow the OpenFOAM style guide:
+#   https://develop.openfoam.com/Development/openfoam/-/wikis/coding/style/style
+# Configuration developed for the OpenFOAM-preCICE adapter code:
+#   https://github.com/precice/openfoam-adapter
+# Contribute to the discussion at the respective OpenFOAM issue:
+#   https://develop.openfoam.com/Development/openfoam/-/issues/1634
+#
+# Keep `public:` at the first indentation level
+AccessModifierOffset: -4
+# Undocumented guideline: align arguments after an open bracket.
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+# Align operands after operators (+,*,<<) (see BreakBeforeBinaryOperators)
+AlignOperands: AlignAfterOperator
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Always
+AllowShortLoopsOnASingleLine: false
+# Guideline: Splitting return type and function name
+# (this guideline is apparently not strictly followed in OpenFOAM)
+# AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+# Covered by "BreakBeforeBraces"
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: true
+  BeforeWhile:     true
+  IndentBraces:    true
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+# Guideline (almost): Splitting long lines at an = sign. Indent after split.
+# Guideline (almost): Splitting formulae over several lines.
+BreakBeforeBinaryOperators: NonAssignment
+# Always break before braces: if, for, functions, classes, etc.
+BreakBeforeBraces: Allman
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+# Guideline (almost): Splitting logical tests over several lines.
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+# Undocumented guideline (almost): Have the initializer : in a new line.
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: true
+# Here we could set the 80 charactes limit, but that would lead to more aggressive changes.
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+# Undocumented guideline: add line after "public:" etc (since clang-format 12)
+# EmptyLineAfterAccessModifier: Always
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+# Guideline: Macro loops are like for loops, but without a space.
+ForEachMacros:
+  - forAllIters
+  - forAllConstIters
+  - forAllReverseIters
+  - forAllConstReverseIters
+  - forAll
+  - forAllReverse
+  - forAllIter
+  - forAllConstIter
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+# Guideline: The normal indentation is 4 spaces per logical level.
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+# Required to not change code following the guidelines
+# "Leave two empty lines between sections" and
+# "Use two empty lines between functions"
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+# Do not change the order of include statements (could be catastrophic for OpenFOAM)
+SortIncludes:    false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+# No "template <T>" (guideline already used, but not documented)
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+# No a{1} (no guideline)
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+# Guideline: Spaces in "if ()", "for ()", but not "forAll ()".
+SpaceBeforeParens: ControlStatementsExceptForEachMacros
+# Guideline: Range-based for should have a space surrounding the ':'.
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+# No "arr[3] = [ 1, 2, 3 ]" (no guideline).
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+# Treat the code as C++11 or later
+Standard:        Latest
+StatementMacros:
+TabWidth:        4
+UseCRLF:         false
+# Guideline: No tab characters - only use spaces for indentation.
+UseTab:          Never
+WhitespaceSensitiveMacros:
+...
+

--- a/partitioned-heat-conduction/solver-openfoam/createFields.H
+++ b/partitioned-heat-conduction/solver-openfoam/createFields.H
@@ -23,15 +23,16 @@ volScalarField DT(
     mesh,
     dimensionedScalar(dimViscosity, Zero));
 
-if (!DT.headerOk()) {
-  IOdictionary transportProperties(
-      IOobject(
-          "transportProperties",
-          runTime.constant(),
-          mesh,
-          IOobject::MUST_READ_IF_MODIFIED,
-          IOobject::NO_WRITE));
-  DT = dimensionedScalar("DT", dimViscosity, transportProperties);
+if (!DT.headerOk())
+{
+    IOdictionary transportProperties(
+        IOobject(
+            "transportProperties",
+            runTime.constant(),
+            mesh,
+            IOobject::MUST_READ_IF_MODIFIED,
+            IOobject::NO_WRITE));
+    DT = dimensionedScalar("DT", dimViscosity, transportProperties);
 }
 
 #include "createFvOptions.H"

--- a/partitioned-heat-conduction/solver-openfoam/heatTransfer.C
+++ b/partitioned-heat-conduction/solver-openfoam/heatTransfer.C
@@ -38,131 +38,134 @@
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 // Some helper functions in order to investigate this case
-namespace Functions {
+namespace Functions
+{
 double get_rhs(const double x, const double y, const double alpha, const double beta)
 {
-  return beta - 2 - 2 * alpha;
+    return beta - 2 - 2 * alpha;
 }
-double get_solution(const double x, const double y,
-                    const double alpha, const double beta, const double time)
+double get_solution(const double x, const double y, const double alpha, const double beta, const double time)
 {
-  return 1 + std::pow(x, 2) + (alpha * std::pow(y, 2)) + (beta * time);
+    return 1 + std::pow(x, 2) + (alpha * std::pow(y, 2)) + (beta * time);
 }
 
-void compute_and_print_errors(const Foam::fvMesh &mesh, const double alpha,
-                              const double beta, const double time)
+void compute_and_print_errors(const Foam::fvMesh& mesh, const double alpha, const double beta, const double time)
 {
-  double                      error = 0;
-  const Foam::volScalarField *T_(&mesh.lookupObject<volScalarField>("T"));
+    double error = 0;
+    const Foam::volScalarField* T_(&mesh.lookupObject<volScalarField>("T"));
 
-  double max_error = std::numeric_limits<double>::min();
+    double max_error = std::numeric_limits<double>::min();
 
-  // Get the locations of the volume centered mesh vertices
-  const vectorField &CellCenters      = mesh.C();
-  unsigned int       numDataLocations = CellCenters.size();
-  for (int i = 0; i < CellCenters.size(); i++) {
-    const double coord_x        = CellCenters[i].x();
-    const double coord_y        = CellCenters[i].y();
-    const double exact_solution = Functions::get_solution(coord_x, coord_y, alpha, beta, time);
-    const auto   result         = (exact_solution - T_->internalField()[i]) *
-                        (exact_solution - T_->internalField()[i]);
-    error += result;
-    max_error = std::max(result, max_error);
-  }
+    // Get the locations of the volume centered mesh vertices
+    const vectorField& CellCenters = mesh.C();
+    unsigned int numDataLocations = CellCenters.size();
+    for (int i = 0; i < CellCenters.size(); i++)
+    {
+        const double coord_x = CellCenters[i].x();
+        const double coord_y = CellCenters[i].y();
+        const double exact_solution = Functions::get_solution(coord_x, coord_y, alpha, beta, time);
+        const auto result = (exact_solution - T_->internalField()[i]) * (exact_solution - T_->internalField()[i]);
+        error += result;
+        max_error = std::max(result, max_error);
+    }
 
-  Info << "\nError metrics at t = " << time << "s:\n";
-  Info << "l2 error (sqrt(sum(err^2)/n)):\t\t" << std::sqrt(error / numDataLocations) << endl;
-  Info << "Maximum absolute error (max(err)):\t" << std::sqrt(max_error) << endl;
-  Info << "Global absolute error (sum(err^2)):\t" << error << "\n";
-  Info << endl;
+    Info << "\nError metrics at t = " << time << "s:\n";
+    Info << "l2 error (sqrt(sum(err^2)/n)):\t\t" << std::sqrt(error / numDataLocations) << endl;
+    Info << "Maximum absolute error (max(err)):\t" << std::sqrt(max_error) << endl;
+    Info << "Global absolute error (sum(err^2)):\t" << error << "\n";
+    Info << endl;
 }
 } // namespace Functions
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
-  argList::addNote(
-      "Laplace equation solver for a scalar quantity.");
+    argList::addNote(
+        "Laplace equation solver for a scalar quantity.");
 
 #include "postProcess.H"
 
 #include "addCheckCaseOptions.H"
-#include "createMesh.H"
-#include "createTime.H"
 #include "setRootCaseLists.H"
+#include "createTime.H"
+#include "createMesh.H"
 
-  simpleControl simple(mesh);
+    simpleControl simple(mesh);
 
 #include "createFields.H"
 
-  // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-  Info << "\nCalculating temperature distribution\n"
-       << endl;
+    Info << "\nCalculating temperature distribution\n"
+         << endl;
 
-  const double alpha = 3;
-  const double beta  = 1.2;
+    const double alpha = 3;
+    const double beta = 1.2;
 
-  // Initialize the RHS with zero
-  volScalarField f(
-      IOobject(
-          "RHS",
-          runTime.timeName(),
-          mesh,
-          IOobject::NO_READ,
-          IOobject::NO_WRITE),
-      mesh,
-      dimensionedScalar(
-          "Tdim",
-          dimensionSet(0, 0, -1, 1, 0, 0, 0),
-          Foam::scalar(0)));
+    // Initialize the RHS with zero
+    volScalarField f(
+        IOobject(
+            "RHS",
+            runTime.timeName(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE),
+        mesh,
+        dimensionedScalar(
+            "Tdim",
+            dimensionSet(0, 0, -1, 1, 0, 0, 0),
+            Foam::scalar(0)));
 
-  // Now assign the respective values to the RHS
-  //(strictly speaking not required here, only for space-dependent RHS functions)
-  // Get the locations of the volume centered mesh vertices
-  const vectorField &CellCenters = mesh.C();
-  for (int i = 0; i < CellCenters.size(); i++) {
-    const double coord_x = CellCenters[i].x();
-    const double coord_y = CellCenters[i].y();
-    f.ref()[i]           = Functions::get_rhs(coord_x, coord_y, alpha, beta);
-  }
-
-  for (int j = 0; j < mesh.boundaryMesh().size() - 1; ++j) {
-    // Get the face centers of the current patch
-    const vectorField faceCenters =
-        mesh.boundaryMesh()[j].faceCentres();
-
-    // Assign the (x,y,z) locations to the vertices
-    for (int i = 0; i < faceCenters.size(); i++) {
-      const double coord_x       = faceCenters[i].x();
-      const double coord_y       = faceCenters[i].y();
-      f.boundaryFieldRef()[j][i] = Functions::get_rhs(coord_x, coord_y, alpha, beta);
+    // Now assign the respective values to the RHS
+    //(strictly speaking not required here, only for space-dependent RHS functions)
+    // Get the locations of the volume centered mesh vertices
+    const vectorField& CellCenters = mesh.C();
+    for (int i = 0; i < CellCenters.size(); i++)
+    {
+        const double coord_x = CellCenters[i].x();
+        const double coord_y = CellCenters[i].y();
+        f.ref()[i] = Functions::get_rhs(coord_x, coord_y, alpha, beta);
     }
-  }
 
-  Functions::compute_and_print_errors(mesh, alpha, beta, runTime.value());
+    for (int j = 0; j < mesh.boundaryMesh().size() - 1; ++j)
+    {
+        // Get the face centers of the current patch
+        const vectorField faceCenters =
+            mesh.boundaryMesh()[j].faceCentres();
 
-  while (simple.loop()) {
-    Info << "Time = " << runTime.timeName() << nl << endl;
-
-    while (simple.correctNonOrthogonal()) {
-      fvScalarMatrix TEqn(
-          fvm::ddt(T) - fvm::laplacian(DT, T) - fvm::Su(f, T) ==
-          fvOptions(T));
-
-      fvOptions.constrain(TEqn);
-      TEqn.solve();
-      fvOptions.correct(T);
+        // Assign the (x,y,z) locations to the vertices
+        for (int i = 0; i < faceCenters.size(); i++)
+        {
+            const double coord_x = faceCenters[i].x();
+            const double coord_y = faceCenters[i].y();
+            f.boundaryFieldRef()[j][i] = Functions::get_rhs(coord_x, coord_y, alpha, beta);
+        }
     }
+
+    Functions::compute_and_print_errors(mesh, alpha, beta, runTime.value());
+
+    while (simple.loop())
+    {
+        Info << "Time = " << runTime.timeName() << nl << endl;
+
+        while (simple.correctNonOrthogonal())
+        {
+            fvScalarMatrix TEqn(
+                fvm::ddt(T) - fvm::laplacian(DT, T) - fvm::Su(f, T)
+                == fvOptions(T));
+
+            fvOptions.constrain(TEqn);
+            TEqn.solve();
+            fvOptions.correct(T);
+        }
 
 #include "write.H"
 
-    runTime.printExecutionTime(Info);
-  }
+        runTime.printExecutionTime(Info);
+    }
 
-  Info << "End\n"
-       << endl;
+    Info << "End\n"
+         << endl;
 
-  return 0;
+    return 0;
 }
-
 // ************************************************************************* //

--- a/partitioned-heat-conduction/solver-openfoam/write.H
+++ b/partitioned-heat-conduction/solver-openfoam/write.H
@@ -2,85 +2,88 @@
 // as the condition only returns true in the very first coupling iteration
 // if (runTime.writeTime())
 {
-  volVectorField gradT(fvc::grad(T));
+    volVectorField gradT(fvc::grad(T));
 
-  volScalarField gradTx(
-      IOobject(
-          "gradTx",
-          runTime.timeName(),
-          mesh,
-          IOobject::NO_READ,
-          IOobject::AUTO_WRITE),
-      gradT.component(vector::X));
+    volScalarField gradTx(
+        IOobject(
+            "gradTx",
+            runTime.timeName(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::AUTO_WRITE),
+        gradT.component(vector::X));
 
-  volScalarField gradTy(
-      IOobject(
-          "gradTy",
-          runTime.timeName(),
-          mesh,
-          IOobject::NO_READ,
-          IOobject::AUTO_WRITE),
-      gradT.component(vector::Y));
+    volScalarField gradTy(
+        IOobject(
+            "gradTy",
+            runTime.timeName(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::AUTO_WRITE),
+        gradT.component(vector::Y));
 
-  volScalarField gradTz(
-      IOobject(
-          "gradTz",
-          runTime.timeName(),
-          mesh,
-          IOobject::NO_READ,
-          IOobject::AUTO_WRITE),
-      gradT.component(vector::Z));
+    volScalarField gradTz(
+        IOobject(
+            "gradTz",
+            runTime.timeName(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::AUTO_WRITE),
+        gradT.component(vector::Z));
 
-  volVectorField DTgradT(
-      IOobject(
-          "flux",
-          runTime.timeName(),
-          mesh,
-          IOobject::NO_READ,
-          IOobject::AUTO_WRITE),
-      DT * gradT);
-  volScalarField error_total(
-      IOobject(
-          "error",
-          runTime.timeName(),
-          mesh,
-          IOobject::NO_READ,
-          IOobject::AUTO_WRITE),
-      DT * 0);
+    volVectorField DTgradT(
+        IOobject(
+            "flux",
+            runTime.timeName(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::AUTO_WRITE),
+        DT * gradT);
+    volScalarField error_total(
+        IOobject(
+            "error",
+            runTime.timeName(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::AUTO_WRITE),
+        DT * 0);
 
-  // Print error metrics
-  Functions::compute_and_print_errors(mesh, alpha, beta, runTime.value());
+    // Print error metrics
+    Functions::compute_and_print_errors(mesh, alpha, beta, runTime.value());
 
-  // compute and store the error also in a paraView field
-  {
-    const Foam::volScalarField *T_(&mesh.lookupObject<volScalarField>("T"));
+    // compute and store the error also in a paraView field
+    {
+        const Foam::volScalarField* T_(&mesh.lookupObject<volScalarField>("T"));
 
-    // Get the locations of the volume centered mesh vertices
-    const vectorField &CellCenters = mesh.C();
+        // Get the locations of the volume centered mesh vertices
+        const vectorField& CellCenters = mesh.C();
 
-    for (int i = 0; i < CellCenters.size(); i++) {
-      const double coord_x        = CellCenters[i].x();
-      const double coord_y        = CellCenters[i].y();
-      const double exact_solution = Functions::get_solution(coord_x, coord_y, alpha, beta, runTime.value());
+        for (int i = 0; i < CellCenters.size(); i++)
+        {
+            const double coord_x = CellCenters[i].x();
+            const double coord_y = CellCenters[i].y();
+            const double exact_solution = Functions::get_solution(coord_x, coord_y, alpha, beta, runTime.value());
 
-      error_total.ref()[i] = std::abs((exact_solution - T_->internalField()[i]));
+            error_total.ref()[i] = std::abs((exact_solution - T_->internalField()[i]));
+        }
+
+        T.correctBoundaryConditions();
+        for (int j = 0; j < mesh.boundaryMesh().size() - 1; ++j)
+        {
+            // Get the face centers of the current patch
+            const vectorField faceCenters =
+                mesh.boundaryMesh()[j].faceCentres();
+
+            // Assign the (x,y,z) locations to the vertices
+            for (int i = 0; i < faceCenters.size(); i++)
+            {
+                const double coord_x = faceCenters[i].x();
+                const double coord_y = faceCenters[i].y();
+                const double exact_solution = Functions::get_solution(coord_x, coord_y, alpha, beta, runTime.value());
+                error_total.boundaryFieldRef()[j][i] = std::abs(exact_solution - T_->boundaryField()[j][i]);
+            }
+        }
     }
 
-    T.correctBoundaryConditions();
-    for (int j = 0; j < mesh.boundaryMesh().size() - 1; ++j) {
-      // Get the face centers of the current patch
-      const vectorField faceCenters =
-          mesh.boundaryMesh()[j].faceCentres();
-
-      // Assign the (x,y,z) locations to the vertices
-      for (int i = 0; i < faceCenters.size(); i++) {
-        const double coord_x                 = faceCenters[i].x();
-        const double coord_y                 = faceCenters[i].y();
-        const double exact_solution          = Functions::get_solution(coord_x, coord_y, alpha, beta, runTime.value());
-        error_total.boundaryFieldRef()[j][i] = std::abs(exact_solution - T_->boundaryField()[j][i]);
-      }
-    }
-  }
-
-  runTime.write();
+    runTime.write();
 }

--- a/perpendicular-flap/solid-openfoam/solidDisplacementFoamForce/solidDisplacementFoamForceFvPatchVectorField.C
+++ b/perpendicular-flap/solid-openfoam/solidDisplacementFoamForce/solidDisplacementFoamForceFvPatchVectorField.C
@@ -10,7 +10,7 @@ namespace Foam {
 
 solidDisplacementFoamForceFvPatchVectorField::
     solidDisplacementFoamForceFvPatchVectorField(
-        const fvPatch &                          p,
+        const fvPatch                           &p,
         const DimensionedField<vector, volMesh> &iF)
     : fixedGradientFvPatchVectorField(p, iF),
       force_(p.size(), vector::zero),
@@ -18,14 +18,14 @@ solidDisplacementFoamForceFvPatchVectorField::
       curTimeIndex_(-1)
 {
   fvPatchVectorField::operator=(patchInternalField());
-  gradient()                  = vector::zero;
+  gradient() = vector::zero;
 }
 
 solidDisplacementFoamForceFvPatchVectorField::
     solidDisplacementFoamForceFvPatchVectorField(
-        const fvPatch &                          p,
+        const fvPatch                           &p,
         const DimensionedField<vector, volMesh> &iF,
-        const dictionary &                       dict)
+        const dictionary                        &dict)
     : fixedGradientFvPatchVectorField(p, iF),
       force_(p.size(), vector::zero),
       forceFieldPtr_(),
@@ -71,9 +71,9 @@ solidDisplacementFoamForceFvPatchVectorField::
 solidDisplacementFoamForceFvPatchVectorField::
     solidDisplacementFoamForceFvPatchVectorField(
         const solidDisplacementFoamForceFvPatchVectorField &stpvf,
-        const fvPatch &                                     p,
-        const DimensionedField<vector, volMesh> &           iF,
-        const fvPatchFieldMapper &                          mapper)
+        const fvPatch                                      &p,
+        const DimensionedField<vector, volMesh>            &iF,
+        const fvPatchFieldMapper                           &mapper)
     : fixedGradientFvPatchVectorField(stpvf, p, iF, mapper),
 #ifdef OPENFOAMFOUNDATION
       force_(mapper(stpvf.force_)),
@@ -98,7 +98,7 @@ solidDisplacementFoamForceFvPatchVectorField::solidDisplacementFoamForceFvPatchV
 
 solidDisplacementFoamForceFvPatchVectorField::solidDisplacementFoamForceFvPatchVectorField(
     const solidDisplacementFoamForceFvPatchVectorField &stpvf,
-    const DimensionedField<vector, volMesh> &           iF)
+    const DimensionedField<vector, volMesh>            &iF)
     : fixedGradientFvPatchVectorField(stpvf, iF),
       force_(stpvf.force_),
       forceFieldPtr_(),
@@ -123,7 +123,7 @@ void solidDisplacementFoamForceFvPatchVectorField::autoMap(
 // Reverse-map the given fvPatchField onto this fvPatchField
 void solidDisplacementFoamForceFvPatchVectorField::rmap(
     const fvPatchVectorField &ptf,
-    const labelList &         addr)
+    const labelList          &addr)
 {
   fixedGradientFvPatchVectorField::rmap(ptf, addr);
 
@@ -216,7 +216,7 @@ void solidDisplacementFoamForceFvPatchVectorField::write(Ostream &os) const
   // Bug-fix: courtesy of Michael@UW at https://www.cfd-online.com/Forums/
   // openfoam-cc-toolkits-fluid-structure-interaction/221892-solved-paraview
   // -cant-read-solids-files-duplicate-entries-keyword-value.html#post762325
-  //fixedGradientFvPatchVectorField::write(os);
+  // fixedGradientFvPatchVectorField::write(os);
   fvPatchVectorField::write(os);
 
   if (forceFieldPtr_.valid()) {

--- a/perpendicular-flap/solid-openfoam/solidDisplacementFoamForce/solidDisplacementFoamForceFvPatchVectorField.H
+++ b/perpendicular-flap/solid-openfoam/solidDisplacementFoamForce/solidDisplacementFoamForceFvPatchVectorField.H
@@ -21,7 +21,7 @@ Description
     Obviously, for a uniform force field, the total force applied to the patch
     as the mesh is refined as the force per face stays constant.
 
-    The primary motivation for this condition is for FSI cases using 
+    The primary motivation for this condition is for FSI cases using
     solidDisplacementFoam and the preCICE coupling library.
 
     The force field can be directly specified or specified via a "force"

--- a/quickstart/solid-cpp/rigid_body_solver.cpp
+++ b/quickstart/solid-cpp/rigid_body_solver.cpp
@@ -46,9 +46,9 @@ public:
   void
   solve(const Vector &forces,
         const Vector &initial_vertices,
-        Vector &      vertices,
-        double &      theta,
-        double &      theta_dot,
+        Vector       &vertices,
+        double       &theta,
+        double       &theta_dot,
         const double  spring_constant,
         const double  delta_t) const
   {

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -296,8 +296,8 @@ int main(int argc, char **argv)
       couplingParticipant.advance(dt);
       preciceDt = couplingParticipant.getMaxTimeStepSize();
       dt        = std::min(preciceDt, std::min(nonLinearSolver.suggestTimeStepSize(
-                                            timeLoop->timeStepSize()),
-                                        getParam<Scalar>("TimeLoop.MaxDt")));
+                                                   timeLoop->timeStepSize()),
+                                               getParam<Scalar>("TimeLoop.MaxDt")));
       if (preciceDt != dt) {
         std::cout << "preciceDt too large. We currently assume fixed timestep "
                      "size but timesteps no longer correspond: preciceDt = "

--- a/two-scale-heat-conduction/macro-dumux/appl/myenergyvolumevariables.hh
+++ b/two-scale-heat-conduction/macro-dumux/appl/myenergyvolumevariables.hh
@@ -88,7 +88,7 @@ public:
   //! The phase enthalpy is zero for isothermal models
   //! This is needed for completing the fluid state
   template <class FluidState, class ParameterCache>
-  static Scalar enthalpy(const FluidState &    fluidState,
+  static Scalar enthalpy(const FluidState     &fluidState,
                          const ParameterCache &paramCache, const int phaseIdx)
   {
     return 0;
@@ -99,8 +99,8 @@ public:
   void updateEffectiveThermalConductivity(const ElemSol &elemSol,
                                           const Problem &problem,
                                           const Element &element,
-                                          const Scv &    scv,
-                                          SolidState &   solidState) {}
+                                          const Scv     &scv,
+                                          SolidState    &solidState) {}
 };
 
 //! The non-isothermal implicit volume variables base class
@@ -187,8 +187,8 @@ public:
   void updateEffectiveThermalConductivity(const ElemSol &elemSol,
                                           const Problem &problem,
                                           const Element &element,
-                                          const Scv &    scv,
-                                          SolidState &   solidState)
+                                          const Scv     &scv,
+                                          SolidState    &solidState)
   {
     lambdaEff_ =
         solidThermalConductivity_(elemSol, problem, element, scv, solidState);
@@ -268,7 +268,7 @@ public:
   //! The phase enthalpy is zero for isothermal models
   //! This is needed for completing the fluid state
   template <class ParameterCache>
-  static Scalar enthalpy(const FluidState &    fluidState,
+  static Scalar enthalpy(const FluidState     &fluidState,
                          const ParameterCache &paramCache, const int phaseIdx)
   {
     return FluidSystem::enthalpy(fluidState, paramCache, phaseIdx);

--- a/two-scale-heat-conduction/macro-dumux/appl/spatialparams.hh
+++ b/two-scale-heat-conduction/macro-dumux/appl/spatialparams.hh
@@ -81,7 +81,7 @@ public:
    * \brief Defines the conductivity tensor \f$ K \f$.
    */
 
-  DimWorldMatrix solidThermalConductivity(const Element &         element,
+  DimWorldMatrix solidThermalConductivity(const Element          &element,
                                           const SubControlVolume &scv) const
   {
     DimWorldMatrix K;

--- a/two-scale-heat-conduction/micro-dumux/appl/cell_problem/localresidual.hh
+++ b/two-scale-heat-conduction/micro-dumux/appl/cell_problem/localresidual.hh
@@ -71,9 +71,9 @@ public:
    * \param scv The sub control volume
    * \param volVars The current or previous volVars
    */
-  NumEqVector computeStorage(const Problem &         problem,
+  NumEqVector computeStorage(const Problem          &problem,
                              const SubControlVolume &scv,
-                             const VolumeVariables & volVars) const
+                             const VolumeVariables  &volVars) const
   {
     NumEqVector storage(0.0);
     return storage;
@@ -97,10 +97,10 @@ public:
   template <class Problem, class ElementVolumeVariables,
             class ElementFluxVarsCache>
   NumEqVector computeFlux(const Problem &problem, const Element &element,
-                          const FVElementGeometry &     fvGeometry,
+                          const FVElementGeometry      &fvGeometry,
                           const ElementVolumeVariables &elemVolVars,
-                          const SubControlVolumeFace &  scvf,
-                          const ElementFluxVarsCache &  elemFluxVarsCache) const
+                          const SubControlVolumeFace   &scvf,
+                          const ElementFluxVarsCache   &elemFluxVarsCache) const
   {
     NumEqVector flux;
 
@@ -158,9 +158,9 @@ public:
   template <class Problem, class ElementVolumeVariables>
   static Scalar
   calculateTransmissibility(const Problem &problem, const Element &element,
-                            const FVElementGeometry &     fvGeometry,
+                            const FVElementGeometry      &fvGeometry,
                             const ElementVolumeVariables &elemVolVars,
-                            const SubControlVolumeFace &  scvf)
+                            const SubControlVolumeFace   &scvf)
   {
     Scalar tij;
 
@@ -182,8 +182,8 @@ public:
       const auto outsideScvIdx = scvf.outsideScvIdx();
       // as we assemble fluxes from the neighbor to our element
       // the outside index refers to the scv of our element
-      const auto & outsideScv     = fvGeometry.scv(outsideScvIdx);
-      const auto & outsideVolVars = elemVolVars[outsideScvIdx];
+      const auto  &outsideScv     = fvGeometry.scv(outsideScvIdx);
+      const auto  &outsideVolVars = elemVolVars[outsideScvIdx];
       const Scalar tj =
           fvGeometry.gridGeometry().isPeriodic()
               ? computeTpfaTransmissibility(

--- a/two-scale-heat-conduction/micro-dumux/appl/micro_sim.cpp
+++ b/two-scale-heat-conduction/micro-dumux/appl/micro_sim.cpp
@@ -69,8 +69,8 @@ public:
   // solve takes python dict for macro_write data, dt, and returns python dict for macro_read data
   py::dict solve(py::dict macro_write_data, double dt);
 
-  //void save_checkpoint();
-  //void reload_checkpoint();
+  // void save_checkpoint();
+  // void reload_checkpoint();
 
   void      setState(py::tuple phi);
   py::tuple getState() const;
@@ -83,11 +83,11 @@ private:
   double       _k_11;
   double       _porosity;
 
-  ACSolutionVector _phi;    //Solution of Allen Cahn Problem
-  ACSolutionVector _phiOld; //for checkpointing
-  CPSolutionVector _psi;    //Solutions(s) of Cell Problem
+  ACSolutionVector _phi;    // Solution of Allen Cahn Problem
+  ACSolutionVector _phiOld; // for checkpointing
+  CPSolutionVector _psi;    // Solutions(s) of Cell Problem
 
-  //shared pointers are necessary due to partitioned nature of micro simulation
+  // shared pointers are necessary due to partitioned nature of micro simulation
   std::shared_ptr<ACNewtonSolver>                    _acNonLinearSolver;
   std::shared_ptr<LinearSolver>                      _acLinearSolver;
   std::shared_ptr<CPLinearSolver>                    _cpLinearSolver;
@@ -183,7 +183,7 @@ MicroSimulation::MicroSimulation(int simulationID)
 // Initialize micro-data to be used in initial adaptivity
 py::dict MicroSimulation::initialize()
 {
-  //update Phi in the cell problem
+  // update Phi in the cell problem
   _cpProblem->spatialParams().updatePhi(_phi);
 
   // solve the cell problems
@@ -192,10 +192,10 @@ py::dict MicroSimulation::initialize()
   // calculate porosity
   _porosity = _acProblem->calculatePorosity(_phi);
 
-  //compute the psi derivatives (required for conductivity tensor)
+  // compute the psi derivatives (required for conductivity tensor)
   _cpProblem->computePsiDerivatives(*_cpProblem, *_cpAssembler, *_cpGridVariables, _psi);
 
-  //calculate the conductivity tensor
+  // calculate the conductivity tensor
   _k_00 = _cpProblem->calculateConductivityTensorComponent(0, 0);
   _k_11 = _cpProblem->calculateConductivityTensorComponent(1, 1);
 
@@ -236,7 +236,7 @@ py::dict MicroSimulation::solve(py::dict macro_write_data, double dt)
   // linearize & solve the allen cahn problem
   _acNonLinearSolver->solve(_phi, *_timeLoop);
 
-  //u pdate Phi in the cell problem
+  // u pdate Phi in the cell problem
   _cpProblem->spatialParams().updatePhi(_phi);
 
   // solve the cell problems
@@ -247,10 +247,10 @@ py::dict MicroSimulation::solve(py::dict macro_write_data, double dt)
   // calculate porosity
   _porosity = _acProblem->calculatePorosity(_phi);
 
-  //compute the psi derivatives (required for conductivity tensor)
+  // compute the psi derivatives (required for conductivity tensor)
   _cpProblem->computePsiDerivatives(*_cpProblem, *_cpAssembler, *_cpGridVariables, _psi);
 
-  //calculate the conductivity tensor
+  // calculate the conductivity tensor
   _k_00 = _cpProblem->calculateConductivityTensorComponent(0, 0);
   _k_10 = _cpProblem->calculateConductivityTensorComponent(1, 0);
   _k_01 = _cpProblem->calculateConductivityTensorComponent(0, 1);

--- a/two-scale-heat-conduction/micro-dumux/appl/problem_allencahn.hh
+++ b/two-scale-heat-conduction/micro-dumux/appl/problem_allencahn.hh
@@ -94,10 +94,10 @@ public:
    * \brief The source term is calculated as \f$ -\omega *P'(Phi) - 4*xi_ * Phi
    * * (1-Phi)*F(T)\f$.
    */
-  NumEqVector source(const Element &               element,
-                     const FVElementGeometry &     fvGeometry,
+  NumEqVector source(const Element                &element,
+                     const FVElementGeometry      &fvGeometry,
                      const ElementVolumeVariables &elemVolVars,
-                     const SubControlVolume &      scv) const
+                     const SubControlVolume       &scv) const
   {
     NumEqVector source;
 

--- a/two-scale-heat-conduction/micro-dumux/appl/problem_cellproblem.hh
+++ b/two-scale-heat-conduction/micro-dumux/appl/problem_cellproblem.hh
@@ -92,7 +92,7 @@ public:
    * \param scv The sub-control volume
    */
   std::bitset<numEq>
-  hasInternalDirichletConstraint(const Element &         element,
+  hasInternalDirichletConstraint(const Element          &element,
                                  const SubControlVolume &scv) const
   {
     // the pure Neumann problem is only defined up to a constant
@@ -112,7 +112,7 @@ public:
    * freedom. \param element The finite element \param scv The sub-control
    * volume
    */
-  PrimaryVariables internalDirichlet(const Element &         element,
+  PrimaryVariables internalDirichlet(const Element          &element,
                                      const SubControlVolume &scv) const
   {
     return PrimaryVariables(1.0);
@@ -178,7 +178,7 @@ public:
   template <class Problem, class Assembler, class GridVariables,
             class SolutionVector>
   void computePsiDerivatives(const Problem &problem, const Assembler &assembler,
-                             const GridVariables & gridVars,
+                             const GridVariables  &gridVars,
                              const SolutionVector &psi)
   {
     const auto &gridGeometry = this->gridGeometry();


### PR DESCRIPTION
Takes over the clang format we have in the adapter. The default clang-format is not compatible with the way OpenFOAM code looks like. The adapter style guide is also more readable (compare e.g. the `while` loop, where the physics are solved). 