### PR TITLE
Make Nutils participant `micro-nutils` in the two-scale-heat-conduction tutorial faster

### DIFF
--- a/two-scale-heat-conduction/micro-nutils/micro-manager-config.json
+++ b/two-scale-heat-conduction/micro-nutils/micro-manager-config.json
@@ -9,7 +9,7 @@
     },
     "simulation_params": {
       "macro_domain_bounds": [0.0, 1.0, 0.0, 0.5],
-      "decomposition": [4, 1],
+      "decomposition": [2, 1],
       "adaptivity": {
         "type": "global",
         "data": ["k_00", "k_11", "porosity", "concentration"],

--- a/two-scale-heat-conduction/micro-nutils/micro-manager-config.json
+++ b/two-scale-heat-conduction/micro-nutils/micro-manager-config.json
@@ -9,7 +9,7 @@
     },
     "simulation_params": {
       "macro_domain_bounds": [0.0, 1.0, 0.0, 0.5],
-      "decomposition": [2, 1],
+      "decomposition": [4, 1],
       "adaptivity": {
         "type": "global",
         "data": ["k_00", "k_11", "porosity", "concentration"],

--- a/two-scale-heat-conduction/micro-nutils/micro.py
+++ b/two-scale-heat-conduction/micro-nutils/micro.py
@@ -85,7 +85,8 @@ class MicroSimulation:
         #    psi = self._get_avg_porosity(self._topo, solphi)
 
         self._solphi = solphi  # Save solution of phi
-        #self._psi_nm1 = psi  # Average porosity value of last time step
+        psi = self._get_avg_porosity(self._topo, solphi)
+        self._psi_nm1 = psi  # Average porosity value of last time step
 
         # Solve the heat cell problem
         solu = self._solve_heat_cell_problem(self._topo, solphi)
@@ -96,8 +97,7 @@ class MicroSimulation:
         output_data = dict()
         output_data["k_00"] = k[0][0]
         output_data["k_11"] = k[1][1]
-        #output_data["porosity"] = psi
-        output_data["porosity"] = self._get_avg_porosity(self._topo, solphi)
+        output_data["porosity"] = psi
 
         return output_data
 

--- a/two-scale-heat-conduction/micro-nutils/micro.py
+++ b/two-scale-heat-conduction/micro-nutils/micro.py
@@ -75,14 +75,13 @@ class MicroSimulation:
         target_porosity = 1 - math.pi * self._r_initial ** 2
         print("Target amount of void space = {}".format(target_porosity))
 
-        #dt_initial = 1E-3
-
         # Solve Allen-Cahn equation till we reach target porosity value
-        #psi = 0
-        #while psi < target_porosity:
-        #    print("Solving Allen-Cahn equation to achieve initial target grain structure")
-        #    solphi = self._solve_allen_cahn(self._topo, solphi, 0.5, dt_initial)
-        #    psi = self._get_avg_porosity(self._topo, solphi)
+        # dt_initial = 1E-3
+        # psi = 0
+        # while psi < target_porosity:
+        #     print("Solving Allen-Cahn equation to achieve initial target grain structure")
+        #     solphi = self._solve_allen_cahn(self._topo, solphi, 0.5, dt_initial)
+        #     psi = self._get_avg_porosity(self._topo, solphi)
 
         self._solphi = solphi  # Save solution of phi
         psi = self._get_avg_porosity(self._topo, solphi)

--- a/two-scale-heat-conduction/micro-nutils/micro.py
+++ b/two-scale-heat-conduction/micro-nutils/micro.py
@@ -75,17 +75,17 @@ class MicroSimulation:
         target_porosity = 1 - math.pi * self._r_initial ** 2
         print("Target amount of void space = {}".format(target_porosity))
 
-        dt_initial = 1E-3
+        #dt_initial = 1E-3
 
         # Solve Allen-Cahn equation till we reach target porosity value
-        psi = 0
-        while psi < target_porosity:
-            print("Solving Allen-Cahn equation to achieve initial target grain structure")
-            solphi = self._solve_allen_cahn(self._topo, solphi, 0.5, dt_initial)
-            psi = self._get_avg_porosity(self._topo, solphi)
+        #psi = 0
+        #while psi < target_porosity:
+        #    print("Solving Allen-Cahn equation to achieve initial target grain structure")
+        #    solphi = self._solve_allen_cahn(self._topo, solphi, 0.5, dt_initial)
+        #    psi = self._get_avg_porosity(self._topo, solphi)
 
         self._solphi = solphi  # Save solution of phi
-        self._psi_nm1 = psi  # Average porosity value of last time step
+        #self._psi_nm1 = psi  # Average porosity value of last time step
 
         # Solve the heat cell problem
         solu = self._solve_heat_cell_problem(self._topo, solphi)
@@ -96,7 +96,8 @@ class MicroSimulation:
         output_data = dict()
         output_data["k_00"] = k[0][0]
         output_data["k_11"] = k[1][1]
-        output_data["porosity"] = psi
+        #output_data["porosity"] = psi
+        output_data["porosity"] = self._get_avg_porosity(self._topo, solphi)
 
         return output_data
 

--- a/two-scale-heat-conduction/micro-nutils/micro.py
+++ b/two-scale-heat-conduction/micro-nutils/micro.py
@@ -127,7 +127,7 @@ class MicroSimulation:
 
     @staticmethod
     def _analytical_phasefield(x, y, r, lam):
-        return 1. / (1. + np.exp(-4. / lam * (np.sqrt(x ** 2 + y ** 2) - r + 0.001)))
+        return 1. / (1. + np.exp(-4. / lam * (np.sqrt(x ** 2 + y ** 2) - r)))
 
     @staticmethod
     def _get_analytical_phasefield(topo, ns, degree_phi, lam, r):


### PR DESCRIPTION
This PR removes the initial correction calculation of the phase field in the `micro-nutils` participant of the two-scale-heat-conduction tutorial. This calculation was originally implemented so that the micro simulation will start with a very accurate grain description. However, if the micro structure (grain) is not represented extremely accurately, the resultant phase field and the average porosity will still yield sensible values. Therefore this calculation can be commented out to cut down the initialization time and make the `micro-nutils` participant faster.

## Approximate runtime

- On 4 processors: 6.5 minutes
- On 2 processors: 10.5 minutes