### PR TITLE
Fix two scale heat conduction

### DIFF
--- a/two-scale-heat-conduction/README.md
+++ b/two-scale-heat-conduction/README.md
@@ -27,12 +27,9 @@ At each Gauss point of the macro domain there exists a micro simulation. The mac
 
 ### DuMu<sup>x</sup> setup
 
-To solve either the macro or micro simulations with the DuMu<sup>x</sup> framework, the necessary DUNE modules need to be downloaded and set up. This is done by:
+To solve either the macro or micro simulations with the DuMu<sup>x</sup> framework, the necessary DUNE modules need to be downloaded and set up. This is done by running `sh setup-dumux.sh` in the tutorial folder.
 
-* Setting the environment variable `DUNE_CONTROL_PATH` to `.` (the current directory specified by a relative path).
-* Running `sh setup-dumux.sh` in the tutorial folder.
-
-Note that if the `DUNE_CONTROL_PATH` points to an existing installation of the `dune_common` module, this may lead to problems in running the `setup-dumux.sh` script.
+Note that if an existing installation of DUNE modules is detected in a default location, this may lead to problems in running the `setup-dumux.sh` script. The environment variable `DUNE_CONTROL_PATH` is suppressed by the script.
 
 ## Running the simulation
 

--- a/two-scale-heat-conduction/README.md
+++ b/two-scale-heat-conduction/README.md
@@ -24,7 +24,15 @@ At each Gauss point of the macro domain there exists a micro simulation. The mac
 * Both the macro and micro simulations can be solved using the finite element library [Nutils](https://nutils.org/install.html) v7 or the simulation framework [DuMu<sup>x</sup>](https://git.iws.uni-stuttgart.de/dumux-repositories/dumux/).
 * While using Nutils, the macro simulation is written in Python, so it requires the [Python bindings of preCICE](https://precice.org/installation-bindings-python.html).
 * The [Micro Manager](https://precice.org/tooling-micro-manager-installation.html) controls all micro-simulations and facilitates coupling via preCICE. Use the [develop](https://github.com/precice/micro-manager/tree/develop) branch of the Micro Manager.
-* To solve either the macro or micro simulations with the DuMu<sup>x</sup> framework, the necessary DUNE modules need to be downloaded and set up. Run `sh setup-dumux.sh` in the tutorial folder to set up the DUNE modules.
+
+### DuMu<sup>x</sup> setup
+
+To solve either the macro or micro simulations with the DuMu<sup>x</sup> framework, the necessary DUNE modules need to be downloaded and set up. This is done by:
+
+* Setting the environment variable `DUNE_CONTROL_PATH` to `.` (the current directory specified by a relative path).
+* Running `sh setup-dumux.sh` in the tutorial folder.
+
+Note that if the `DUNE_CONTROL_PATH` points to an existing installation of the `dune_common` module, this may lead to problems in running the `setup-dumux.sh` script.
 
 ## Running the simulation
 

--- a/two-scale-heat-conduction/micro-dumux/appl/micro_sim.cpp
+++ b/two-scale-heat-conduction/micro-dumux/appl/micro_sim.cpp
@@ -311,7 +311,7 @@ PYBIND11_MODULE(micro_sim, m)
   m.doc() = "pybind11 example plugin"; // optional module docstring
 
   py::class_<MicroSimulation>(m, "MicroSimulation")
-      .def(py::init())
+      .def(py::init<int>())
       .def("initialize", &MicroSimulation::initialize)
       .def("solve", &MicroSimulation::solve)
       //.def("save_checkpoint", &MicroSimulation::save_checkpoint)
@@ -328,7 +328,7 @@ PYBIND11_MODULE(micro_sim, m)
               throw std::runtime_error("Invalid state!");
 
             /* Create a new C++ instance */
-            MicroSimulation ms;
+            MicroSimulation ms(0);
             ms.initialize();
             ms.setState(t);
 

--- a/two-scale-heat-conduction/setup-dumux.sh
+++ b/two-scale-heat-conduction/setup-dumux.sh
@@ -10,11 +10,11 @@ rm -rfv install*
 
 # Get the DuMuX install script and install it
 wget https://git.iws.uni-stuttgart.de/dumux-repositories/dumux/-/raw/releases/3.7/bin/installdumux.py
-python3 installdumux.py
+DUNE_CONTROL_PATH=. python3 installdumux.py
 # clear build directories
 cd dumux
 rm -r dune-common/build-cmake/dune-env/lib/dunecontrol || true
-./dune-common/bin/dunecontrol exec rm -r build-cmake || true
+DUNE_CONTROL_PATH=. ./dune-common/bin/dunecontrol exec rm -r build-cmake
 cd ..
 
 # Take out all the module folders from the dumux/ folder and remove the dumux/ folder
@@ -28,10 +28,10 @@ git clone https://github.com/precice/dumux-adapter.git
 # DuMux phasefield implementation
 git clone -b cell_problems https://git.iws.uni-stuttgart.de/dumux-appl/dumux-phasefield.git
 # DUNE SPGrid for periodic boundary conditions
-python3 dumux/bin/installexternal.py spgrid
+DUNE_CONTROL_PATH=. python3 dumux/bin/installexternal.py spgrid
 
 # Re-build environment
-./dune-common/bin/dunecontrol --opts=./dumux/cmake.opts all
+DUNE_CONTROL_PATH=. ./dune-common/bin/dunecontrol --opts=./dumux/cmake.opts all
 
 # Compile and move macro-dumux and micro-dumux executables to the participant folder level
 ./compile-dumux-cases.sh

--- a/two-scale-heat-conduction/setup-dumux.sh
+++ b/two-scale-heat-conduction/setup-dumux.sh
@@ -11,6 +11,11 @@ rm -rfv install*
 # Get the DuMuX install script and install it
 wget https://git.iws.uni-stuttgart.de/dumux-repositories/dumux/-/raw/releases/3.7/bin/installdumux.py
 python3 installdumux.py
+# clear build directories
+cd dumux
+rm -r dune-common/build-cmake/dune-env/lib/dunecontrol || true
+./dune-common/bin/dunecontrol exec rm -r build-cmake || true
+cd ..
 
 # Take out all the module folders from the dumux/ folder and remove the dumux/ folder
 mv dumux dumux-install
@@ -25,8 +30,7 @@ git clone -b cell_problems https://git.iws.uni-stuttgart.de/dumux-appl/dumux-pha
 # DUNE SPGrid for periodic boundary conditions
 python3 dumux/bin/installexternal.py spgrid
 
-# Clear CMake caches and re-build environment
-./dune-common/bin/dunecontrol bexec rm -r CMakeFiles CMakeCache.txt
+# Re-build environment
 ./dune-common/bin/dunecontrol --opts=./dumux/cmake.opts all
 
 # Compile and move macro-dumux and micro-dumux executables to the participant folder level

--- a/two-scale-heat-conduction/setup-dumux.sh
+++ b/two-scale-heat-conduction/setup-dumux.sh
@@ -9,7 +9,7 @@ rm -rfv dune-*/
 rm -rfv install*
 
 # Get the DuMuX install script and install it
-wget https://git.iws.uni-stuttgart.de/dumux-repositories/dumux/-/raw/master/bin/installdumux.py
+wget https://git.iws.uni-stuttgart.de/dumux-repositories/dumux/-/raw/releases/3.7/bin/installdumux.py
 python3 installdumux.py
 
 # Take out all the module folders from the dumux/ folder and remove the dumux/ folder


### PR DESCRIPTION
<!-- Please submit your Pull Request to the `develop` branch.

It may help to have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

Some fixes to the two-scale-heat-conduction tutorial.
- Changes due to an update in the Micro-Manager (v0.4.0)
- Changes in the script `setup-dumux.sh` to make it more robust.