### PR TITLE
Directly use micro_manager in two-scale- tutorial

### DIFF
--- a/two-scale-heat-conduction/micro-dumux/run.sh
+++ b/two-scale-heat-conduction/micro-dumux/run.sh
@@ -9,16 +9,16 @@ usage() { echo "Usage: cmd [-s] [-p n]" 1>&2; exit 1; }
 # Check if no input argument was provided
 if [ -z "$*" ] ; then
   echo "No input argument provided. Micro Manager is launched in serial"
-  python3 run_micro_manager.py params.input
+  micro_manager micro-manager-config.json
 fi
 
 while getopts ":sp" opt; do
   case ${opt} in
   s)
-    python3 run_micro_manager.py params.input
+    micro_manager micro-manager-config.json
     ;;
   p)
-    mpiexec -n "$2" python3 run_micro_manager.py params.input
+    mpiexec -n "$2" micro_manager micro-manager-config.json
     ;;
   *)
     usage

--- a/two-scale-heat-conduction/micro-dumux/run_micro_manager.py
+++ b/two-scale-heat-conduction/micro-dumux/run_micro_manager.py
@@ -1,9 +1,0 @@
-"""
-Script to run the Micro Manager
-"""
-
-from micro_manager import MicroManager
-
-manager = MicroManager("micro-manager-config.json")
-
-manager.solve()

--- a/two-scale-heat-conduction/micro-nutils/run.sh
+++ b/two-scale-heat-conduction/micro-nutils/run.sh
@@ -13,16 +13,16 @@ pip install -r requirements.txt
 # Check if no input argument was provided
 if [ -z "$*" ] ; then
   echo "No input argument provided. Micro Manager is launched in serial"
-  python3 run_micro_manager.py
+  micro_manager micro-manager-config.json
 fi
 
 while getopts ":sp" opt; do
   case ${opt} in
   s)
-    python3 run_micro_manager.py
+    micro_manager micro-manager-config.json
     ;;
   p)
-    mpiexec -n "$2" python3 run_micro_manager.py
+    mpiexec -n "$2" micro_manager micro-manager-config.json
     ;;
   *)
     usage

--- a/two-scale-heat-conduction/micro-nutils/run_micro_manager.py
+++ b/two-scale-heat-conduction/micro-nutils/run_micro_manager.py
@@ -1,9 +1,0 @@
-"""
-Script to run the Micro Manager
-"""
-
-from micro_manager import MicroManager
-
-manager = MicroManager("micro-manager-config.json")
-
-manager.solve()


### PR DESCRIPTION
This tutorial directly uses the micro_manager binary. This allows using the tutorial with a pipx-installed mirco-manager.

Related to https://github.com/precice/vm/pull/94 https://github.com/precice/tutorials/issues/526

Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
