### PR TITLE
Fix shebangs to `#!/usr/bin/env bash` in all .sh files

### DIFF
--- a/aste-turbine/clean.sh
+++ b/aste-turbine/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../tools/cleaning-tools.sh

--- a/breaking-dam-2d/fluid-openfoam/clean.sh
+++ b/breaking-dam-2d/fluid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/breaking-dam-2d/fluid-openfoam/run.sh
+++ b/breaking-dam-2d/fluid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/breaking-dam-2d/solid-calculix/clean.sh
+++ b/breaking-dam-2d/solid-calculix/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/breaking-dam-2d/solid-calculix/run.sh
+++ b/breaking-dam-2d/solid-calculix/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/channel-transport-reaction/chemical-fenics/clean.sh
+++ b/channel-transport-reaction/chemical-fenics/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/channel-transport-reaction/chemical-fenics/run.sh
+++ b/channel-transport-reaction/chemical-fenics/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/channel-transport-reaction/clean-tutorial.sh
+++ b/channel-transport-reaction/clean-tutorial.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 # shellcheck disable=SC1091

--- a/channel-transport-reaction/fluid-fenics/clean.sh
+++ b/channel-transport-reaction/fluid-fenics/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/channel-transport-reaction/fluid-fenics/run.sh
+++ b/channel-transport-reaction/fluid-fenics/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/channel-transport/fluid-nutils/clean.sh
+++ b/channel-transport/fluid-nutils/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/channel-transport/fluid-nutils/run.sh
+++ b/channel-transport/fluid-nutils/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/channel-transport/fluid-openfoam/clean.sh
+++ b/channel-transport/fluid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/channel-transport/fluid-openfoam/run.sh
+++ b/channel-transport/fluid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/channel-transport/transport-nutils/clean.sh
+++ b/channel-transport/transport-nutils/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/channel-transport/transport-nutils/run.sh
+++ b/channel-transport/transport-nutils/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/clean-all.sh
+++ b/clean-all.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 echo "Cleaning up all tutorials..."

--- a/elastic-tube-1d/fluid-cpp/clean.sh
+++ b/elastic-tube-1d/fluid-cpp/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/elastic-tube-1d/fluid-cpp/run.sh
+++ b/elastic-tube-1d/fluid-cpp/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/elastic-tube-1d/fluid-python/clean.sh
+++ b/elastic-tube-1d/fluid-python/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/elastic-tube-1d/fluid-python/run.sh
+++ b/elastic-tube-1d/fluid-python/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/elastic-tube-1d/fluid-rust/clean.sh
+++ b/elastic-tube-1d/fluid-rust/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/elastic-tube-1d/fluid-rust/run.sh
+++ b/elastic-tube-1d/fluid-rust/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/elastic-tube-1d/plot-all.sh
+++ b/elastic-tube-1d/plot-all.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 gnuplot -p << EOF
   set grid

--- a/elastic-tube-1d/plot-diameter.sh
+++ b/elastic-tube-1d/plot-diameter.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 # File check solution from: https://stackoverflow.com/questions/91368/checking-from-shell-script-if-a-directory-contains-files

--- a/elastic-tube-1d/solid-cpp/clean.sh
+++ b/elastic-tube-1d/solid-cpp/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/elastic-tube-1d/solid-cpp/run.sh
+++ b/elastic-tube-1d/solid-cpp/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/elastic-tube-1d/solid-python/clean.sh
+++ b/elastic-tube-1d/solid-python/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/elastic-tube-1d/solid-python/run.sh
+++ b/elastic-tube-1d/solid-python/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/elastic-tube-1d/solid-rust/clean.sh
+++ b/elastic-tube-1d/solid-rust/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/elastic-tube-1d/solid-rust/run.sh
+++ b/elastic-tube-1d/solid-rust/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/elastic-tube-3d/fluid-openfoam/clean.sh
+++ b/elastic-tube-3d/fluid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/elastic-tube-3d/fluid-openfoam/run.sh
+++ b/elastic-tube-3d/fluid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/elastic-tube-3d/plot-all-displacements.sh
+++ b/elastic-tube-3d/plot-all-displacements.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
  
 gnuplot -p << EOF                                                               
 	set grid                                                                        

--- a/elastic-tube-3d/plot-displacements.sh
+++ b/elastic-tube-3d/plot-displacements.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if [ "${1:-}" = "" ]; then
     echo "No target directory specified. Please specify the directory of the solid participant containing the watchpoint, e.g. ./plot-displacements.sh solid-calculix."

--- a/elastic-tube-3d/solid-calculix/clean.sh
+++ b/elastic-tube-3d/solid-calculix/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/elastic-tube-3d/solid-calculix/run.sh
+++ b/elastic-tube-3d/solid-calculix/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/elastic-tube-3d/solid-fenics/clean.sh
+++ b/elastic-tube-3d/solid-fenics/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/elastic-tube-3d/solid-fenics/run.sh
+++ b/elastic-tube-3d/solid-fenics/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 python3 solid.py

--- a/flow-around-controlled-moving-cylinder/clean-tutorial.sh
+++ b/flow-around-controlled-moving-cylinder/clean-tutorial.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 # shellcheck disable=SC1091

--- a/flow-around-controlled-moving-cylinder/controller-fmi/clean.sh
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-around-controlled-moving-cylinder/controller-fmi/run.sh
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-around-controlled-moving-cylinder/fluid-openfoam/clean.sh
+++ b/flow-around-controlled-moving-cylinder/fluid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-around-controlled-moving-cylinder/fluid-openfoam/run.sh
+++ b/flow-around-controlled-moving-cylinder/fluid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-around-controlled-moving-cylinder/plot-watchpoint.sh
+++ b/flow-around-controlled-moving-cylinder/plot-watchpoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if [ "${1:-}" = "" ]; then
     echo "No target directory specified. Please specify the directory of the Solid participant containing the watchpoint, e.g. ./plot-watchpoint.sh solid-python."

--- a/flow-around-controlled-moving-cylinder/solid-python/clean.sh
+++ b/flow-around-controlled-moving-cylinder/solid-python/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 . ../../tools/cleaning-tools.sh
 

--- a/flow-around-controlled-moving-cylinder/solid-python/run.sh
+++ b/flow-around-controlled-moving-cylinder/solid-python/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/clean.sh
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/run.sh
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/clean.sh
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/run.sh
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate-partitioned-flow/fluid1-openfoam/clean.sh
+++ b/flow-over-heated-plate-partitioned-flow/fluid1-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate-partitioned-flow/fluid1-openfoam/run.sh
+++ b/flow-over-heated-plate-partitioned-flow/fluid1-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate-partitioned-flow/fluid2-openfoam/clean.sh
+++ b/flow-over-heated-plate-partitioned-flow/fluid2-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate-partitioned-flow/fluid2-openfoam/run.sh
+++ b/flow-over-heated-plate-partitioned-flow/fluid2-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate-partitioned-flow/solid-openfoam/clean.sh
+++ b/flow-over-heated-plate-partitioned-flow/solid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate-partitioned-flow/solid-openfoam/run.sh
+++ b/flow-over-heated-plate-partitioned-flow/solid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate-steady-state/fluid-openfoam/clean.sh
+++ b/flow-over-heated-plate-steady-state/fluid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate-steady-state/fluid-openfoam/run.sh
+++ b/flow-over-heated-plate-steady-state/fluid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate-steady-state/solid-codeaster/clean.sh
+++ b/flow-over-heated-plate-steady-state/solid-codeaster/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate-steady-state/solid-codeaster/run.sh
+++ b/flow-over-heated-plate-steady-state/solid-codeaster/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate-two-meshes/fluid-openfoam/clean.sh
+++ b/flow-over-heated-plate-two-meshes/fluid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate-two-meshes/fluid-openfoam/run.sh
+++ b/flow-over-heated-plate-two-meshes/fluid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate-two-meshes/solid-calculix/clean.sh
+++ b/flow-over-heated-plate-two-meshes/solid-calculix/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate-two-meshes/solid-calculix/run.sh
+++ b/flow-over-heated-plate-two-meshes/solid-calculix/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate/fluid-openfoam/clean.sh
+++ b/flow-over-heated-plate/fluid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate/fluid-openfoam/run.sh
+++ b/flow-over-heated-plate/fluid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate/fluid-su2/clean.sh
+++ b/flow-over-heated-plate/fluid-su2/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate/fluid-su2/run.sh
+++ b/flow-over-heated-plate/fluid-su2/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 SU2_preCICE_CHT.py -f laminar_config_unsteady.cfg -r --parallel

--- a/flow-over-heated-plate/solid-dunefem/clean.sh
+++ b/flow-over-heated-plate/solid-dunefem/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate/solid-dunefem/run.sh
+++ b/flow-over-heated-plate/solid-dunefem/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate/solid-fenics/clean.sh
+++ b/flow-over-heated-plate/solid-fenics/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate/solid-fenics/run.sh
+++ b/flow-over-heated-plate/solid-fenics/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate/solid-nutils/clean.sh
+++ b/flow-over-heated-plate/solid-nutils/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate/solid-nutils/run.sh
+++ b/flow-over-heated-plate/solid-nutils/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/flow-over-heated-plate/solid-openfoam/clean.sh
+++ b/flow-over-heated-plate/solid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/flow-over-heated-plate/solid-openfoam/run.sh
+++ b/flow-over-heated-plate/solid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/heat-exchanger-simplified/fluid-bottom-openfoam/clean.sh
+++ b/heat-exchanger-simplified/fluid-bottom-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/heat-exchanger-simplified/fluid-bottom-openfoam/run.sh
+++ b/heat-exchanger-simplified/fluid-bottom-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/heat-exchanger-simplified/fluid-top-openfoam/clean.sh
+++ b/heat-exchanger-simplified/fluid-top-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/heat-exchanger-simplified/fluid-top-openfoam/run.sh
+++ b/heat-exchanger-simplified/fluid-top-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/heat-exchanger-simplified/solid-calculix/clean.sh
+++ b/heat-exchanger-simplified/solid-calculix/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/heat-exchanger-simplified/solid-calculix/run.sh
+++ b/heat-exchanger-simplified/solid-calculix/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/heat-exchanger/download-meshes.sh
+++ b/heat-exchanger/download-meshes.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 echo "This tutorial is based on a case prepared with SimScale."
 echo "Since the mesh files are several MB large, we don't store them in the Git repository."

--- a/heat-exchanger/fluid-inner-openfoam/clean.sh
+++ b/heat-exchanger/fluid-inner-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/heat-exchanger/fluid-inner-openfoam/run.sh
+++ b/heat-exchanger/fluid-inner-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/heat-exchanger/fluid-outer-openfoam/clean.sh
+++ b/heat-exchanger/fluid-outer-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/heat-exchanger/fluid-outer-openfoam/run.sh
+++ b/heat-exchanger/fluid-outer-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/heat-exchanger/solid-calculix/clean.sh
+++ b/heat-exchanger/solid-calculix/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/heat-exchanger/solid-calculix/run.sh
+++ b/heat-exchanger/solid-calculix/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/multiple-perpendicular-flaps/fluid-openfoam/clean.sh
+++ b/multiple-perpendicular-flaps/fluid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/multiple-perpendicular-flaps/fluid-openfoam/run.sh
+++ b/multiple-perpendicular-flaps/fluid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/multiple-perpendicular-flaps/solid-downstream-dealii/clean.sh
+++ b/multiple-perpendicular-flaps/solid-downstream-dealii/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/multiple-perpendicular-flaps/solid-downstream-dealii/plot-displacement.sh
+++ b/multiple-perpendicular-flaps/solid-downstream-dealii/plot-displacement.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 gnuplot -p << EOF
 set grid
 set title 'Displacement of the Flap Tip'

--- a/multiple-perpendicular-flaps/solid-upstream-dealii/clean.sh
+++ b/multiple-perpendicular-flaps/solid-upstream-dealii/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/multiple-perpendicular-flaps/solid-upstream-dealii/plot-displacement.sh
+++ b/multiple-perpendicular-flaps/solid-upstream-dealii/plot-displacement.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 gnuplot -p << EOF
 set grid
 set title 'Displacement of the Flap Tip'

--- a/oscillator-overlap/mass-left-python/clean.sh
+++ b/oscillator-overlap/mass-left-python/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/oscillator-overlap/mass-left-python/run.sh
+++ b/oscillator-overlap/mass-left-python/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/oscillator-overlap/mass-right-python/clean.sh
+++ b/oscillator-overlap/mass-right-python/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/oscillator-overlap/mass-right-python/run.sh
+++ b/oscillator-overlap/mass-right-python/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/oscillator/mass-left-fmi/clean.sh
+++ b/oscillator/mass-left-fmi/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/oscillator/mass-left-fmi/run.sh
+++ b/oscillator/mass-left-fmi/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/oscillator/mass-left-python/clean.sh
+++ b/oscillator/mass-left-python/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/oscillator/mass-left-python/run.sh
+++ b/oscillator/mass-left-python/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/oscillator/mass-right-fmi/clean.sh
+++ b/oscillator/mass-right-fmi/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/oscillator/mass-right-fmi/run.sh
+++ b/oscillator/mass-right-fmi/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/oscillator/mass-right-python/clean.sh
+++ b/oscillator/mass-right-python/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/oscillator/mass-right-python/run.sh
+++ b/oscillator/mass-right-python/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-backwards-facing-step/fluid1-openfoam/clean.sh
+++ b/partitioned-backwards-facing-step/fluid1-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-backwards-facing-step/fluid1-openfoam/run.sh
+++ b/partitioned-backwards-facing-step/fluid1-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-backwards-facing-step/fluid2-openfoam/clean.sh
+++ b/partitioned-backwards-facing-step/fluid2-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-backwards-facing-step/fluid2-openfoam/run.sh
+++ b/partitioned-backwards-facing-step/fluid2-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-elastic-beam/dirichlet-calculix/clean.sh
+++ b/partitioned-elastic-beam/dirichlet-calculix/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-elastic-beam/dirichlet-calculix/run.sh
+++ b/partitioned-elastic-beam/dirichlet-calculix/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-elastic-beam/neumann-calculix/clean.sh
+++ b/partitioned-elastic-beam/neumann-calculix/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-elastic-beam/neumann-calculix/run.sh
+++ b/partitioned-elastic-beam/neumann-calculix/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction-complex/dirichlet-fenics/clean.sh
+++ b/partitioned-heat-conduction-complex/dirichlet-fenics/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-heat-conduction-complex/dirichlet-fenics/run.sh
+++ b/partitioned-heat-conduction-complex/dirichlet-fenics/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction-complex/neumann-fenics/clean.sh
+++ b/partitioned-heat-conduction-complex/neumann-fenics/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-heat-conduction-complex/neumann-fenics/run.sh
+++ b/partitioned-heat-conduction-complex/neumann-fenics/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction-direct/clean-tutorial.sh
+++ b/partitioned-heat-conduction-direct/clean-tutorial.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 # shellcheck disable=SC1091

--- a/partitioned-heat-conduction-direct/dirichlet-nutils/clean.sh
+++ b/partitioned-heat-conduction-direct/dirichlet-nutils/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-heat-conduction-direct/dirichlet-nutils/run.sh
+++ b/partitioned-heat-conduction-direct/dirichlet-nutils/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction-direct/neumann-nutils/clean.sh
+++ b/partitioned-heat-conduction-direct/neumann-nutils/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-heat-conduction-direct/neumann-nutils/run.sh
+++ b/partitioned-heat-conduction-direct/neumann-nutils/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction-overlap/left-fenics/clean.sh
+++ b/partitioned-heat-conduction-overlap/left-fenics/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-heat-conduction-overlap/left-fenics/run.sh
+++ b/partitioned-heat-conduction-overlap/left-fenics/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction-overlap/right-fenics/clean.sh
+++ b/partitioned-heat-conduction-overlap/right-fenics/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-heat-conduction-overlap/right-fenics/run.sh
+++ b/partitioned-heat-conduction-overlap/right-fenics/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction/dirichlet-fenics/clean.sh
+++ b/partitioned-heat-conduction/dirichlet-fenics/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-heat-conduction/dirichlet-fenics/run.sh
+++ b/partitioned-heat-conduction/dirichlet-fenics/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction/dirichlet-nutils/clean.sh
+++ b/partitioned-heat-conduction/dirichlet-nutils/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-heat-conduction/dirichlet-nutils/run.sh
+++ b/partitioned-heat-conduction/dirichlet-nutils/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction/dirichlet-openfoam/clean.sh
+++ b/partitioned-heat-conduction/dirichlet-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-heat-conduction/dirichlet-openfoam/run.sh
+++ b/partitioned-heat-conduction/dirichlet-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction/neumann-fenics/clean.sh
+++ b/partitioned-heat-conduction/neumann-fenics/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-heat-conduction/neumann-fenics/run.sh
+++ b/partitioned-heat-conduction/neumann-fenics/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction/neumann-nutils/clean.sh
+++ b/partitioned-heat-conduction/neumann-nutils/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-heat-conduction/neumann-nutils/run.sh
+++ b/partitioned-heat-conduction/neumann-nutils/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction/neumann-openfoam/clean.sh
+++ b/partitioned-heat-conduction/neumann-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-heat-conduction/neumann-openfoam/run.sh
+++ b/partitioned-heat-conduction/neumann-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction/solver-openfoam/clean.sh
+++ b/partitioned-heat-conduction/solver-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 wclean

--- a/partitioned-pipe-two-phase/fluid1-openfoam/clean.sh
+++ b/partitioned-pipe-two-phase/fluid1-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-pipe-two-phase/fluid1-openfoam/run.sh
+++ b/partitioned-pipe-two-phase/fluid1-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-pipe-two-phase/fluid2-openfoam/clean.sh
+++ b/partitioned-pipe-two-phase/fluid2-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-pipe-two-phase/fluid2-openfoam/run.sh
+++ b/partitioned-pipe-two-phase/fluid2-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-pipe-two-phase/monolithic/clean.sh
+++ b/partitioned-pipe-two-phase/monolithic/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-pipe-two-phase/monolithic/run.sh
+++ b/partitioned-pipe-two-phase/monolithic/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-pipe/fluid1-openfoam-pimplefoam/clean.sh
+++ b/partitioned-pipe/fluid1-openfoam-pimplefoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-pipe/fluid1-openfoam-pimplefoam/run.sh
+++ b/partitioned-pipe/fluid1-openfoam-pimplefoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/clean.sh
+++ b/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/run.sh
+++ b/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-pipe/fluid2-openfoam-pimplefoam/clean.sh
+++ b/partitioned-pipe/fluid2-openfoam-pimplefoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-pipe/fluid2-openfoam-pimplefoam/run.sh
+++ b/partitioned-pipe/fluid2-openfoam-pimplefoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/clean.sh
+++ b/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/run.sh
+++ b/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/perpendicular-flap/fluid-fake/run.sh
+++ b/perpendicular-flap/fluid-fake/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 python3 -m venv .venv

--- a/perpendicular-flap/fluid-nutils/clean.sh
+++ b/perpendicular-flap/fluid-nutils/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/perpendicular-flap/fluid-nutils/run.sh
+++ b/perpendicular-flap/fluid-nutils/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/perpendicular-flap/fluid-openfoam/clean.sh
+++ b/perpendicular-flap/fluid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/perpendicular-flap/fluid-openfoam/run.sh
+++ b/perpendicular-flap/fluid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/perpendicular-flap/fluid-su2/clean.sh
+++ b/perpendicular-flap/fluid-su2/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/perpendicular-flap/fluid-su2/run.sh
+++ b/perpendicular-flap/fluid-su2/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/perpendicular-flap/plot-all-displacements.sh
+++ b/perpendicular-flap/plot-all-displacements.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # This script cannot be used as-is and is meant to generate the picture
 # images/tutorials-perpendicular-flap-displacement-all-watchpoints.png

--- a/perpendicular-flap/plot-displacement.sh
+++ b/perpendicular-flap/plot-displacement.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 if [ "${1:-}" = "" ]; then
     echo "No target directory specified. Please specify the directory of the solid participant containing the watchpoint, e.g. ./plot-displacement.sh solid-fenics."

--- a/perpendicular-flap/solid-calculix/clean.sh
+++ b/perpendicular-flap/solid-calculix/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/perpendicular-flap/solid-calculix/run.sh
+++ b/perpendicular-flap/solid-calculix/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/perpendicular-flap/solid-dealii/clean.sh
+++ b/perpendicular-flap/solid-dealii/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/perpendicular-flap/solid-dune/clean.sh
+++ b/perpendicular-flap/solid-dune/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/perpendicular-flap/solid-dune/run.sh
+++ b/perpendicular-flap/solid-dune/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/perpendicular-flap/solid-fenics/clean.sh
+++ b/perpendicular-flap/solid-fenics/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/perpendicular-flap/solid-fenics/run.sh
+++ b/perpendicular-flap/solid-fenics/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/perpendicular-flap/solid-nutils/clean.sh
+++ b/perpendicular-flap/solid-nutils/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/perpendicular-flap/solid-nutils/run.sh
+++ b/perpendicular-flap/solid-nutils/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/perpendicular-flap/solid-openfoam/clean.sh
+++ b/perpendicular-flap/solid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/perpendicular-flap/solid-openfoam/run.sh
+++ b/perpendicular-flap/solid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1

--- a/perpendicular-flap/solid-solids4foam/clean.sh
+++ b/perpendicular-flap/solid-solids4foam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/perpendicular-flap/solid-solids4foam/run.sh
+++ b/perpendicular-flap/solid-solids4foam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1

--- a/quickstart/fluid-openfoam/clean.sh
+++ b/quickstart/fluid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/quickstart/fluid-openfoam/run.sh
+++ b/quickstart/fluid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/quickstart/solid-cpp/clean.sh
+++ b/quickstart/solid-cpp/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/quickstart/solid-cpp/run.sh
+++ b/quickstart/solid-cpp/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/tools/check-links-to-precice.sh
+++ b/tools/check-links-to-precice.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 sed -i "s/http:\/\/precice.org/https:\/\/precice.org/g" "$@"

--- a/tools/check-size.sh
+++ b/tools/check-size.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run this script at the root of the repository to check the size of images
 
 CODE=0

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run this script at the root of the repository to check images and permalinks
 
 CODE=0

--- a/tools/clean-tutorial-base.sh
+++ b/tools/clean-tutorial-base.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 # shellcheck disable=SC1091

--- a/tools/cleaning-tools.sh
+++ b/tools/cleaning-tools.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 error() {
     echo "Error: $1" >&2

--- a/tools/log.sh
+++ b/tools/log.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 CASENAME="$(pwd | xargs basename)"

--- a/tools/run-dealii.sh
+++ b/tools/run-dealii.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 EXE=""

--- a/tools/run-openfoam.sh
+++ b/tools/run-openfoam.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e # Not setting -u as it gets triggered by the OpenFOAM RunFunctions
 
 # Prepare an (intentionally empty) .foam file for the ParaView OpenFOAM reader

--- a/tools/visualize-configs.sh
+++ b/tools/visualize-configs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run this script at the root of the repository to generate PNG files from each precice-config.xml
 
 set -e -u

--- a/turek-hron-fsi3/fluid-openfoam/clean.sh
+++ b/turek-hron-fsi3/fluid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/turek-hron-fsi3/fluid-openfoam/run.sh
+++ b/turek-hron-fsi3/fluid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/turek-hron-fsi3/plot-displacement.sh
+++ b/turek-hron-fsi3/plot-displacement.sh
@@ -1,4 +1,4 @@
-#!/bin/sh                                                                    
+#!/usr/bin/env sh                                                                    
 gnuplot -p << EOF                                                               
 	set grid                                                                        
 	set title 'y-displacement of the flap tip'                                        

--- a/turek-hron-fsi3/solid-dealii/clean.sh
+++ b/turek-hron-fsi3/solid-dealii/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/two-scale-heat-conduction/compile-dumux-cases.sh
+++ b/two-scale-heat-conduction/compile-dumux-cases.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 cd macro-dumux/build-cmake/appl

--- a/two-scale-heat-conduction/macro-dumux/clean.sh
+++ b/two-scale-heat-conduction/macro-dumux/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/two-scale-heat-conduction/macro-dumux/run.sh
+++ b/two-scale-heat-conduction/macro-dumux/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/two-scale-heat-conduction/macro-nutils/clean.sh
+++ b/two-scale-heat-conduction/macro-nutils/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/two-scale-heat-conduction/macro-nutils/run.sh
+++ b/two-scale-heat-conduction/macro-nutils/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/two-scale-heat-conduction/micro-dumux/clean.sh
+++ b/two-scale-heat-conduction/micro-dumux/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/two-scale-heat-conduction/micro-dumux/run.sh
+++ b/two-scale-heat-conduction/micro-dumux/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/two-scale-heat-conduction/micro-nutils/clean.sh
+++ b/two-scale-heat-conduction/micro-nutils/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/two-scale-heat-conduction/micro-nutils/run.sh
+++ b/two-scale-heat-conduction/micro-nutils/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/two-scale-heat-conduction/setup-dumux.sh
+++ b/two-scale-heat-conduction/setup-dumux.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 # This script sets up a DUNE environment in the working directory to solve the two-scale-heat-conduction problem with DuMuX on one or both scales

--- a/volume-coupled-diffusion/drain-fenics/clean.sh
+++ b/volume-coupled-diffusion/drain-fenics/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/volume-coupled-diffusion/drain-fenics/run.sh
+++ b/volume-coupled-diffusion/drain-fenics/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/volume-coupled-diffusion/source-fenics/clean.sh
+++ b/volume-coupled-diffusion/source-fenics/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/volume-coupled-diffusion/source-fenics/run.sh
+++ b/volume-coupled-diffusion/source-fenics/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/volume-coupled-flow/fluid-openfoam/clean.sh
+++ b/volume-coupled-flow/fluid-openfoam/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/volume-coupled-flow/fluid-openfoam/run.sh
+++ b/volume-coupled-flow/fluid-openfoam/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/volume-coupled-flow/source-nutils/clean.sh
+++ b/volume-coupled-flow/source-nutils/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e -u
 
 . ../../tools/cleaning-tools.sh

--- a/volume-coupled-flow/source-nutils/run.sh
+++ b/volume-coupled-flow/source-nutils/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh


### PR DESCRIPTION
<!-- Please submit your Pull Request to the `develop` branch.

It may help to have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

This allows all scripts to be run without hardcoding `/bin/bash` as an interpreter.
Maybe this is an improvement, maybe not.
Someone should take a look at https://unix.stackexchange.com/a/29620 and document a decision for/against `/bin/(ba)sh` vs `/usr/bin/env bash`

Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`. -> will probably not affect many users (at least not any users using debian/ubuntu)
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.