### PR TITLE
Provide initial data for perpendicular flap case

### DIFF
--- a/perpendicular-flap/precice-config.xml
+++ b/perpendicular-flap/precice-config.xml
@@ -46,8 +46,8 @@
     <time-window-size value="0.01" />
     <max-time value="5" />
     <participants first="Fluid" second="Solid" />
-    <exchange data="Force" mesh="Solid-Mesh" from="Fluid" to="Solid" />
-    <exchange data="Displacement" mesh="Solid-Mesh" from="Solid" to="Fluid" />
+    <exchange data="Force" mesh="Solid-Mesh" from="Fluid" to="Solid" initialize="true" />
+    <exchange data="Displacement" mesh="Solid-Mesh" from="Solid" to="Fluid" initialize="true" />
     <max-iterations value="50" />
     <relative-convergence-measure limit="5e-3" data="Displacement" mesh="Solid-Mesh" />
     <relative-convergence-measure limit="5e-3" data="Force" mesh="Solid-Mesh" />

--- a/perpendicular-flap/solid-fenics/solid.py
+++ b/perpendicular-flap/solid-fenics/solid.py
@@ -74,7 +74,7 @@ fixed_boundary = AutoSubDomain(clamped_boundary)
 precice = Adapter(adapter_config_filename="precice-adapter-config-fsi-s.json")
 
 # Initialize the coupling interface
-precice.initialize(coupling_boundary, read_function_space=V, write_object=V, fixed_boundary=fixed_boundary)
+precice.initialize(coupling_boundary, read_function_space=V, write_object=u_n, fixed_boundary=fixed_boundary)
 
 precice_dt = precice.get_max_time_step_size()
 fenics_dt = precice_dt  # if fenics_dt == precice_dt, no subcycling is applied


### PR DESCRIPTION
When @NiklasVin and I evaluated the convergence order of the FEniCS-based solid solver using `fluid-fake` the missing initialization actually cost us quite some time. I think it is generally a good idea to initialize the data when using higher-order time stepping. If we want to generally apply initialization for this case, all adapters have to support this feature since otherwise the tutorial case might break for certain combinations.

This is also related to my comment [here](https://github.com/precice/preeco-orga/issues/7#issuecomment-2136920392) and to https://github.com/precice/precice/issues/2033.

Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
