### PR TITLE
Update Quickstart for OpenFOAM v2406 and adapter v1.3.1

### DIFF
--- a/changelog-entries/545.md
+++ b/changelog-entries/545.md
@@ -1,0 +1,1 @@
+- Updated the default suggested OpenFOAM version to v2406 [#545](https://github.com/precice/tutorials/pull/545).

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -39,10 +39,10 @@ To get a feeling what preCICE does, watch a [short presentation](https://www.you
     ```bash
     # Add the signing key, add the repository, update (check this):
     wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
-    # Install OpenFOAM v2312:
-    sudo apt install openfoam2312-dev
+    # Install OpenFOAM v2406:
+    sudo apt install openfoam2406-dev
     # Enable OpenFOAM by default in your system and apply now:
-    echo "source /usr/lib/openfoam/openfoam2312/etc/bashrc" >> ~/.bashrc
+    echo "source /usr/lib/openfoam/openfoam2406/etc/bashrc" >> ~/.bashrc
     source ~/.bashrc
     ```
 
@@ -55,9 +55,9 @@ To get a feeling what preCICE does, watch a [short presentation](https://www.you
 4. Download and install the [OpenFOAM-preCICE adapter](https://precice.org/adapter-openfoam-get.html):
 
     ```bash
-     wget https://github.com/precice/openfoam-adapter/archive/refs/tags/v1.3.0.tar.gz
-     tar -xzf v1.3.0.tar.gz 
-     cd openfoam-adapter-1.3.0/
+     wget https://github.com/precice/openfoam-adapter/archive/refs/tags/v1.3.1.tar.gz
+     tar -xzf v1.3.1.tar.gz 
+     cd openfoam-adapter-1.3.1/
      ./Allwmake
      cd ..
     ```


### PR DESCRIPTION
Follow-up of https://github.com/precice/openfoam-adapter/pull/332

Depends on the v1.3.1 release of the adapter (https://github.com/precice/openfoam-adapter/pull/333).

@davidscn anything else we need to update?

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
