### PR TITLE
Fix markdown-lint pre-commit exclusion rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,17 +8,9 @@ repos:
   rev: v0.30.0
   hooks:
     - id: markdownlint
-      exclude:  |
-            (?x)^(
-                changelog-entries|
-                .github/pull_request_template.md
-            )$
+      exclude: ^(.github/pull_request_template.md|changelog-entries)
     - id: markdownlint-fix
-      exclude:  |
-            (?x)^(
-                changelog-entries|
-                .github/pull_request_template.md
-            )$
+      exclude: ^(.github/pull_request_template.md|changelog-entries)
 - repo: https://github.com/hhatto/autopep8
   rev: v2.0.4
   hooks:


### PR DESCRIPTION
Checklist:

- I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`. -> N/A
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
