### PR TITLE
Set NumPy version requirement for Nutils cases

### DIFF
--- a/channel-transport/fluid-nutils/requirements.txt
+++ b/channel-transport/fluid-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+numpy >1, <2
 pyprecice==3

--- a/channel-transport/transport-nutils/requirements.txt
+++ b/channel-transport/transport-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+numpy >1, <2
 pyprecice==3

--- a/flow-over-heated-plate/solid-nutils/requirements.txt
+++ b/flow-over-heated-plate/solid-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+numpy >1, <2
 pyprecice==3

--- a/partitioned-heat-conduction-direct/dirichlet-nutils/requirements.txt
+++ b/partitioned-heat-conduction-direct/dirichlet-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+numpy >1, <2
 pyprecice==3

--- a/partitioned-heat-conduction-direct/neumann-nutils/requirements.txt
+++ b/partitioned-heat-conduction-direct/neumann-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+numpy >1, <2
 pyprecice==3

--- a/partitioned-heat-conduction/dirichlet-nutils/requirements.txt
+++ b/partitioned-heat-conduction/dirichlet-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+numpy >1, <2
 pyprecice==3

--- a/partitioned-heat-conduction/neumann-nutils/requirements.txt
+++ b/partitioned-heat-conduction/neumann-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+numpy >1, <2
 pyprecice==3

--- a/perpendicular-flap/fluid-fake/requirements.txt
+++ b/perpendicular-flap/fluid-fake/requirements.txt
@@ -1,2 +1,2 @@
-numpy
+numpy >1, <2
 pyprecice==3

--- a/perpendicular-flap/fluid-nutils/requirements.txt
+++ b/perpendicular-flap/fluid-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==6
+numpy >1, <2
 pyprecice==3

--- a/perpendicular-flap/solid-nutils/requirements.txt
+++ b/perpendicular-flap/solid-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils>=8.5
+numpy >1, <2
 pyprecice==3

--- a/two-scale-heat-conduction/macro-nutils/requirements.txt
+++ b/two-scale-heat-conduction/macro-nutils/requirements.txt
@@ -1,2 +1,3 @@
 nutils==7
+numpy >1, <2
 pyprecice==3

--- a/two-scale-heat-conduction/micro-nutils/requirements.txt
+++ b/two-scale-heat-conduction/micro-nutils/requirements.txt
@@ -1,3 +1,4 @@
 nutils==7
+numpy >1, <2
 pyprecice==3
 micro-manager-precice==0.4.0


### PR DESCRIPTION
Our Nutils cases implicitly depend on NumPy 1. NumPy 2 was recently released, which breaks such installations. This adds a `numpy >1, <2` in all `requirements.txt` that also specify Nutils.

This brings up the issue that we should add `requirements.txt` for all other Python examples as well (in a separate PR). See #547

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`. -> N/A
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
