### PR TITLE
Fix crash for FEniCS-OpenFOAM perpendicular flap example with subcycling 

### DIFF
--- a/changelog-entries/554.md
+++ b/changelog-entries/554.md
@@ -1,0 +1,1 @@
+- Use `assign` function instead of directly accessing vectors in perpendicular-flap/solid-fenics. Fixes problem with checkpointing.

--- a/perpendicular-flap/solid-fenics/solid.py
+++ b/perpendicular-flap/solid-fenics/solid.py
@@ -77,7 +77,7 @@ precice = Adapter(adapter_config_filename="precice-adapter-config-fsi-s.json")
 precice.initialize(coupling_boundary, read_function_space=V, write_object=V, fixed_boundary=fixed_boundary)
 
 precice_dt = precice.get_max_time_step_size()
-fenics_dt = precice_dt / 10  # if fenics_dt == precice_dt, no subcycling is applied
+fenics_dt = precice_dt  # if fenics_dt == precice_dt, no subcycling is applied
 # n_substeps = 5  # number of substeps per window
 # fenics_dt = precice_dt / n_substeps  # if fenics_dt < precice_dt, subcycling is applied
 dt = Constant(np.min([precice_dt, fenics_dt]))


### PR DESCRIPTION
Addresses the crashes when using subcycling as described in https://github.com/precice/fenics-adapter/pull/172.

The current implementation of `solid-fenics.py` operates directly on the dof vectors of `u`, `a` and `v` at one point. This also changes the values stored in the checkpoint which ultimately leads to the crash described in the PR above.
Updating values of a function object via `assign()`, does not change the values stored in a checkpoint, since the old dof vector of the function to be updated is overwritten by calling `assign()` .