### PR TITLE
Add missing `requirements.txt` to oscillator and oscillator-overlap tutorial

### DIFF
--- a/oscillator-overlap/mass-left-python/requirements.txt
+++ b/oscillator-overlap/mass-left-python/requirements.txt
@@ -1,0 +1,3 @@
+numpy >1, <2
+pyprecice~=3.0
+scipy

--- a/oscillator-overlap/mass-left-python/run.sh
+++ b/oscillator-overlap/mass-left-python/run.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e -u
 
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 

--- a/oscillator-overlap/mass-right-python/requirements.txt
+++ b/oscillator-overlap/mass-right-python/requirements.txt
@@ -1,0 +1,3 @@
+numpy >1, <2
+pyprecice~=3.0
+scipy

--- a/oscillator-overlap/mass-right-python/run.sh
+++ b/oscillator-overlap/mass-right-python/run.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e -u
 
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 

--- a/oscillator/mass-left-python/requirements.txt
+++ b/oscillator/mass-left-python/requirements.txt
@@ -1,0 +1,2 @@
+numpy >1, <2
+pyprecice~=3.0

--- a/oscillator/mass-left-python/requirements.txt
+++ b/oscillator/mass-left-python/requirements.txt
@@ -1,2 +1,3 @@
 numpy >1, <2
 pyprecice~=3.0
+scipy

--- a/oscillator/mass-left-python/run.sh
+++ b/oscillator/mass-left-python/run.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e -u
 
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 

--- a/oscillator/mass-right-python/requirements.txt
+++ b/oscillator/mass-right-python/requirements.txt
@@ -1,0 +1,2 @@
+numpy >1, <2
+pyprecice~=3.0

--- a/oscillator/mass-right-python/requirements.txt
+++ b/oscillator/mass-right-python/requirements.txt
@@ -1,2 +1,3 @@
 numpy >1, <2
 pyprecice~=3.0
+scipy

--- a/oscillator/mass-right-python/run.sh
+++ b/oscillator/mass-right-python/run.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e -u
 
+python3 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 


### PR DESCRIPTION
This PR adds the `requirements.txt` files for both python solvers of this tutorial, that were missing.