### PR TITLE
Create venv in participant folder, not in common solver folder.

### DIFF
--- a/partitioned-heat-conduction/dirichlet-fenics/run.sh
+++ b/partitioned-heat-conduction/dirichlet-fenics/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e -u
 
-python3 -m venv --system-site-packages ../solver-fenics/.venv
-. ../solver-fenics/.venv/bin/activate
+python3 -m venv --system-site-packages .venv
+. .venv/bin/activate
 pip install -r ../solver-fenics/requirements.txt
 
 . ../../tools/log.sh

--- a/partitioned-heat-conduction/neumann-fenics/run.sh
+++ b/partitioned-heat-conduction/neumann-fenics/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e -u
 
-python3 -m venv --system-site-packages ../solver-fenics/.venv
-. ../solver-fenics/.venv/bin/activate
+python3 -m venv --system-site-packages .venv
+. .venv/bin/activate
 pip install -r ../solver-fenics/requirements.txt
 
 . ../../tools/log.sh


### PR DESCRIPTION
I think the usage of the `venv` in #557 introduced some form of race condition if the participants try to create the `venv` at the same time at the same place (`../solver-fenics/.venv`). This happens, for example, in [this test](https://github.com/precice/fenics-adapter/blob/b3a9a280cb840aa91d6fa005adbb0a40f159e27f/.github/workflows/run-tutorials.yml#L35).

To avoid this race condition I would suggest to create the `venv` in the folder of the participant (`dirichlet/neumann-fenics`) but still keep the `requirements.txt` (to avoid duplication) in `solver-fenics`.

@NiklasVin this also applies to the other cases in #563. I would suggest to only deal with the partitioned heat conduction case here. If merging this PR fixes the test mentioned above we can roll out this improvement to all cases,
