### PR TITLE
Include "history.csv" in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ REPE_OUT/
 restart_flow_*.dat
 forces_breakdown.dat
 surface_flow_*.csv
-history_*.csv
+history*.csv
 
 # ASTE
 result.stats.json


### PR DESCRIPTION
For non-restart SU2 simulations, a history.csv file is outputted. This PR simply ensures that these are ignored.

Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
