### PR TITLE
Add multigrid settings to flow-over-heated-plate SU2 config

### DIFF
--- a/flow-over-heated-plate/fluid-su2/laminar_config_unsteady.cfg
+++ b/flow-over-heated-plate/fluid-su2/laminar_config_unsteady.cfg
@@ -148,6 +148,30 @@ LINEAR_SOLVER_ERROR= 1E-6
 % Max number of iterations of the linear solver for the implicit formulation
 LINEAR_SOLVER_ITER= 10
 
+% -------------------------- MULTIGRID PARAMETERS -----------------------------%
+%
+% Multi-grid levels (0 = no multi-grid)
+MGLEVEL= 3
+%
+% Multi-grid cycle (V_CYCLE, W_CYCLE, FULLMG_CYCLE)
+MGCYCLE= V_CYCLE
+%
+% Multi-grid pre-smoothing level
+MG_PRE_SMOOTH= ( 1, 2, 3, 3 )
+%
+% Multi-grid post-smoothing level
+MG_POST_SMOOTH= ( 0, 0, 0, 0 )
+%
+% Jacobi implicit smoothing of the correction
+MG_CORRECTION_SMOOTH= ( 0, 0, 0, 0 )
+%
+% Damping factor for the residual restriction
+MG_DAMP_RESTRICTION= 0.75
+%
+% Damping factor for the correction prolongation
+MG_DAMP_PROLONGATION= 0.75
+
+
 % -------------------- FLOW NUMERICAL METHOD DEFINITION -----------------------%
 %
 % Convective numerical method (JST, LAX-FRIEDRICH, CUSP, ROE, AUSM, HLLC,


### PR DESCRIPTION
This PR adds multigrid settings to the flow-over-heated-plate SU2 config file, speeding up runtime.

Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
