### PR TITLE
Simplify time stepping schemes and add type hints and documentation

### DIFF
--- a/oscillator/solver-python/mypy.ini
+++ b/oscillator/solver-python/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+
+[mypy-scipy.*]
+ignore_missing_imports = True
+
+[mypy-precice.*]
+ignore_missing_imports = True

--- a/oscillator/solver-python/oscillator.py
+++ b/oscillator/solver-python/oscillator.py
@@ -32,9 +32,9 @@ args = parser.parse_args()
 
 participant_name = args.participantName
 
-this_mass: problemDefinition.Mass
-other_mass: problemDefinition.Mass
-this_spring: problemDefinition.Spring
+this_mass: Type[problemDefinition.Mass]
+other_mass: Type[problemDefinition.Mass]
+this_spring: Type[problemDefinition.Spring]
 connecting_spring = problemDefinition.SpringMiddle
 
 if participant_name == Participant.MASS_LEFT.value:
@@ -42,18 +42,18 @@ if participant_name == Participant.MASS_LEFT.value:
     read_data_name = 'Force-Right'
     mesh_name = 'Mass-Left-Mesh'
 
-    this_mass = problemDefinition.MassLeft()
-    this_spring = problemDefinition.SpringLeft()
-    other_mass = problemDefinition.MassRight()
+    this_mass = problemDefinition.MassLeft
+    this_spring = problemDefinition.SpringLeft
+    other_mass = problemDefinition.MassRight
 
 elif participant_name == Participant.MASS_RIGHT.value:
     read_data_name = 'Force-Left'
     write_data_name = 'Force-Right'
     mesh_name = 'Mass-Right-Mesh'
 
-    this_mass = problemDefinition.MassRight()
-    this_spring = problemDefinition.SpringRight()
-    other_mass = problemDefinition.MassLeft()
+    this_mass = problemDefinition.MassRight
+    this_spring = problemDefinition.SpringRight
+    other_mass = problemDefinition.MassLeft
 
 else:
     raise Exception(f"wrong participant name: {participant_name}")

--- a/oscillator/solver-python/problemDefinition.py
+++ b/oscillator/solver-python/problemDefinition.py
@@ -3,19 +3,31 @@ from numpy.linalg import eig
 from typing import Callable
 
 
-class SpringLeft:
+class Spring:
+    k: float
+
+
+class SpringLeft(Spring):
     k = 4 * np.pi**2
 
 
-class SpringMiddle:
+class SpringMiddle(Spring):
     k = 16 * (np.pi**2)
 
 
-class SpringRight:
+class SpringRight(Spring):
     k = 4 * np.pi**2
 
 
-class MassLeft:
+class Mass:
+    m: float
+    u0: float
+    v0: float
+    u_analytical: Callable[[float | np.ndarray], float | np.ndarray]
+    v_analytical: Callable[[float | np.ndarray], float | np.ndarray]
+
+
+class MassLeft(Mass):
     # mass
     m = 1
 
@@ -24,12 +36,8 @@ class MassLeft:
     u0 = 1.0
     v0 = 0.0
 
-    # will be defined below
-    u_analytical: Callable[[float | np.ndarray], float | np.ndarray]
-    v_analytical: Callable[[float | np.ndarray], float | np.ndarray]
 
-
-class MassRight:
+class MassRight(Mass):
     # mass
     m = 1
 
@@ -37,10 +45,6 @@ class MassRight:
     # solution allows arbitrary u0, but requires v0 = 0)
     u0 = 0.0
     v0 = 0.0
-
-    # will be defined below
-    u_analytical: Callable[[float | np.ndarray], float | np.ndarray]
-    v_analytical: Callable[[float | np.ndarray], float | np.ndarray]
 
 
 # Mass matrix

--- a/oscillator/solver-python/problemDefinition.py
+++ b/oscillator/solver-python/problemDefinition.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.linalg import eig
+from typing import Callable
 
 
 class SpringLeft:
@@ -23,7 +24,9 @@ class MassLeft:
     u0 = 1.0
     v0 = 0.0
 
-    u_analytical, v_analytical = None, None  # will be defined below
+    # will be defined below
+    u_analytical: Callable[[float | np.ndarray], float | np.ndarray]
+    v_analytical: Callable[[float | np.ndarray], float | np.ndarray]
 
 
 class MassRight:
@@ -35,7 +38,9 @@ class MassRight:
     u0 = 0.0
     v0 = 0.0
 
-    u_analytical, v_analytical = None, None  # will be defined below
+    # will be defined below
+    u_analytical: Callable[[float | np.ndarray], float | np.ndarray]
+    v_analytical: Callable[[float | np.ndarray], float | np.ndarray]
 
 
 # Mass matrix

--- a/oscillator/solver-python/timeSteppers.py
+++ b/oscillator/solver-python/timeSteppers.py
@@ -30,7 +30,7 @@ class GeneralizedAlpha():
         self.stiffness = stiffness
         self.mass = mass
 
-    def do_step(self, u, v, a, rhs, dt) -> Tuple[float, float, float]:
+    def do_step(self, u0, v0, a0, rhs, dt) -> Tuple[float, float, float]:
         f = rhs((1 - self.alpha_f) * dt)
 
         m = 3 * [None]
@@ -42,17 +42,17 @@ class GeneralizedAlpha():
 
         # do generalized alpha step
         if (type(self.stiffness)) is np.ndarray:
-            u_new = np.linalg.solve(
+            u1 = np.linalg.solve(
                 k_bar,
-                (f - self.alpha_f * self.stiffness.dot(u) + self.mass.dot((m[0] * u + m[1] * v + m[2] * a)))
+                (f - self.alpha_f * self.stiffness.dot(u0) + self.mass.dot((m[0] * u0 + m[1] * v0 + m[2] * a0)))
             )
         else:
-            u_new = (f - self.alpha_f * self.stiffness * u + self.mass * (m[0] * u + m[1] * v + m[2] * a)) / k_bar
+            u1 = (f - self.alpha_f * self.stiffness * u0 + self.mass * (m[0] * u0 + m[1] * v0 + m[2] * a0)) / k_bar
 
-        a_new = 1.0 / (self.beta * dt**2) * (u_new - u - dt * v) - (1 - 2 * self.beta) / (2 * self.beta) * a
-        v_new = v + dt * ((1 - self.gamma) * a + self.gamma * a_new)
+        a1 = 1.0 / (self.beta * dt**2) * (u1 - u0 - dt * v0) - (1 - 2 * self.beta) / (2 * self.beta) * a0
+        v1 = v0 + dt * ((1 - self.gamma) * a0 + self.gamma * a1)
 
-        return u_new, v_new, a_new
+        return u1, v1, a1
 
 
 class RungeKutta4():
@@ -67,41 +67,35 @@ class RungeKutta4():
         self.ode_system = ode_system
         pass
 
-    def do_step(self, u, v, a, rhs, dt) -> Tuple[float, float, float]:
-        assert (isinstance(u, type(v)))
+    def do_step(self, u0, v0, _, rhs, dt) -> Tuple[float, float, float]:
+        assert (isinstance(u0, type(v0)))
 
-        n_stages = 4
+        k = 4 * [None]  # store stages in list
 
-        if isinstance(u, np.ndarray):
-            x = np.concatenate([u, v])
-            def f(t): return np.concatenate([np.array([0, 0]), rhs(t)])
-        elif isinstance(u, numbers.Number):
-            x = np.array([u, v])
-            def f(t): return np.array([0, rhs(t)])
+        if isinstance(u0, np.ndarray):
+            x0 = np.concatenate([u0, v0])
+            def f(t,x): return self.ode_system.dot(x) + np.concatenate([np.array([0, 0]), rhs(t)])
+        elif isinstance(u0, numbers.Number):
+            x0 = np.array([u0, v0])
+            def f(t,x): return self.ode_system.dot(x) + np.array([0, rhs(t)])
         else:
-            raise Exception(f"Cannot handle input type {type(u)} of u and v")
+            raise Exception(f"Cannot handle input type {type(u0)} of u and v")
 
-        s = n_stages * [None]
-        s[0] = self.ode_system.dot(x) + f(self.c[0] * dt)
-        s[1] = self.ode_system.dot(x + self.a[1, 0] * s[0] * dt) + f(self.c[1] * dt)
-        s[2] = self.ode_system.dot(x + self.a[2, 1] * s[1] * dt) + f(self.c[2] * dt)
-        s[3] = self.ode_system.dot(x + self.a[3, 2] * s[2] * dt) + f(self.c[3] * dt)
+        k[0] = f(self.c[0] * dt, x0)
+        k[1] = f(self.c[1] * dt, x0 + self.a[1, 0] * k[0] * dt)
+        k[2] = f(self.c[2] * dt, x0 + self.a[2, 1] * k[1] * dt)
+        k[3] = f(self.c[3] * dt, x0 + self.a[3, 2] * k[2] * dt)
 
-        x_new = x
+        x1 = x0 + dt * sum(b_i * k_i for k_i, b_i in zip(k, self.b))
 
-        for i in range(n_stages):
-            x_new += dt * self.b[i] * s[i]
+        if isinstance(u0, np.ndarray):
+            u1 = x1[0:2]
+            v1 = x1[2:4]
+        elif isinstance(u0, numbers.Number):
+            u1 = x1[0]
+            v1 = x1[1]
 
-        if isinstance(u, np.ndarray):
-            u_new = x_new[0:2]
-            v_new = x_new[2:4]
-        elif isinstance(u, numbers.Number):
-            u_new = x_new[0]
-            v_new = x_new[1]
-
-        a_new = None
-
-        return u_new, v_new, a_new
+        return u1, v1, None
 
 
 class RadauIIA():
@@ -109,33 +103,27 @@ class RadauIIA():
         self.ode_system = ode_system
         pass
 
-    def do_step(self, u, v, a, rhs, dt) -> Tuple[float, float, float]:
+    def do_step(self, u0, v0, _, rhs, dt) -> Tuple[float, float, float]:
+        assert (isinstance(u0, type(v0)))
+
         t0 = 0
 
-        assert (isinstance(u, type(v)))
-
-        if isinstance(u, np.ndarray):
-            x0 = np.concatenate([u, v])
-            f = np.array(f)
-            assert (u.shape[0] == f.shape[1])
-            def rhs_fun(t): return np.concatenate([np.array([np.zeros_like(t), np.zeros_like(t)]), rhs(t)])
-        elif isinstance(u, numbers.Number):
-            x0 = np.array([u, v])
-            def rhs_fun(t): return np.array([np.zeros_like(t), rhs(t)])
+        if isinstance(u0, np.ndarray):
+            x0 = np.concatenate([u0, v0])
+            def f(t,x): return self.ode_system.dot(x) + np.concatenate([np.array([np.zeros_like(t), np.zeros_like(t)]), rhs(t)])
+        elif isinstance(u0, numbers.Number):
+            x0 = np.array([u0, v0])
+            def f(t,x): return self.ode_system.dot(x) + np.array([np.zeros_like(t), rhs(t)])
         else:
-            raise Exception(f"Cannot handle input type {type(u)} of u and v")
-
-        def fun(t, x):
-            return self.ode_system.dot(x) + rhs_fun(t)
+            raise Exception(f"Cannot handle input type {type(u0)} of u and v")
 
         # use adaptive time stepping; dense_output=True allows us to sample from continuous function later
-        ret = sp.integrate.solve_ivp(fun, [t0, t0 + dt], x0, method="Radau",
+        ret = sp.integrate.solve_ivp(f, [t0, t0 + dt], x0, method="Radau",
                                      dense_output=True, rtol=10e-5, atol=10e-9)
 
-        a_new = None
-        if isinstance(u, np.ndarray):
-            u_new, v_new = ret.y[0:2, -1], ret.y[2:4, -1]
-        elif isinstance(u, numbers.Number):
-            u_new, v_new = ret.y[:, -1]
+        if isinstance(u0, np.ndarray):
+            u1, v1 = ret.y[0:2, -1], ret.y[2:4, -1]
+        elif isinstance(u0, numbers.Number):
+            u1, v1 = ret.y[:, -1]
 
-        return u_new, v_new, a_new, ret.sol
+        return u1, v1, None, ret.sol

--- a/oscillator/solver-python/timeSteppers.py
+++ b/oscillator/solver-python/timeSteppers.py
@@ -53,8 +53,8 @@ class TimeStepper:
 class GeneralizedAlpha(TimeStepper):
     """TimeStepper implementing generalized Alpha or Newmark Beta scheme (depends on parameters alpha_f and alpha_m set in constructor)
     """
-    alpha_f:float
-    alpha_m:float
+    alpha_f: float
+    alpha_m: float
 
     def __init__(self, stiffness: float, mass: float, alpha_f: float = 0.4, alpha_m: float = 0.2) -> None:
         self.alpha_f = alpha_f


### PR DESCRIPTION
* Remove support for monolithic case (with vector valued displacement and velocity) from time stepping schemes. This is not needed and removing this feature considerably simplifies the code.
* Improve readability by using standard names (e.g. stages are $k_i$ in literature, not $s$).
* Add type hints and make sure mypy works without problems.

Checklist:

- [x] ~~I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.~~ no user-facing changes
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
