### PR TITLE
System tests: Ignore missing reference files and export diff

### DIFF
--- a/tools/tests/docker-compose.field_compare.template.yaml
+++ b/tools/tests/docker-compose.field_compare.template.yaml
@@ -7,7 +7,4 @@ services:
     command:
       - /runs/{{ tutorial_folder }}/{{ precice_output_folder }}
       - /runs/{{ tutorial_folder }}/{{ reference_output_folder }}
-      - "-rtol 3e-7"
-
-# Currently its really hard to estimate the impact of compiling and executing in a different platform (like github actions)
-# 3e-7 might not be the thightest we can afford and we want to have but its an okayish guestimation for now. 
+      - "-rtol 3e-7 --ignore-missing-reference-files --diff"


### PR DESCRIPTION
New preCICE versions might add new types of exported files, which should not trigger an error. This already happened with the `.vtk.series` files. Related to https://github.com/precice/precice/pull/2052. Opened an issue in fieldcompare as well: https://gitlab.com/dglaeser/fieldcompare/-/issues/68

Adding also the new `--diff` option to export the differences of the files.

Checklist:

- I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`. -> N/A
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
