### PR TITLE
Relax FEniCS requirements.

### DIFF
--- a/changelog-entries/590.md
+++ b/changelog-entries/590.md
@@ -1,0 +1,1 @@
+- Relax FEniCS requirements. Don't require fixed version (e.g. fenics-dolfin==2019.2.0.13.dev0) but only a compatible one (e.g. fenics-dolfin~=2019.0).

--- a/channel-transport-reaction/chemical-fenics/requirements.txt
+++ b/channel-transport-reaction/chemical-fenics/requirements.txt
@@ -3,9 +3,9 @@ fenicsprecice~=2.0
 
 # Assuming FEniCS from ppa:fenics-packages/fenics was installed https://fenicsproject.org/download/archive/
 # Use --system-site-packages in venv
-fenics-dijitso==2019.2.0.dev0
-fenics-dolfin==2019.2.0.13.dev0
-fenics-ffc==2019.2.0.dev0
-fenics-fiat==2019.2.0.dev0
-fenics-ufl-legacy==2022.3.0
+fenics-dijitso~=2019.0
+fenics-dolfin~=2019.0
+fenics-ffc~=2019.0
+fenics-fiat~=2019.0
+fenics-ufl-legacy~=2022.0
 

--- a/channel-transport-reaction/fluid-fenics/requirements.txt
+++ b/channel-transport-reaction/fluid-fenics/requirements.txt
@@ -3,8 +3,8 @@ fenicsprecice~=2.0
 
 # Assuming FEniCS from ppa:fenics-packages/fenics was installed https://fenicsproject.org/download/archive/
 # Use --system-site-packages in venv
-fenics-dijitso==2019.2.0.dev0
-fenics-dolfin==2019.2.0.13.dev0
-fenics-ffc==2019.2.0.dev0
-fenics-fiat==2019.2.0.dev0
-fenics-ufl-legacy==2022.3.0
+fenics-dijitso~=2019.0
+fenics-dolfin~=2019.0
+fenics-ffc~=2019.0
+fenics-fiat~=2019.0
+fenics-ufl-legacy~=2022.0

--- a/elastic-tube-3d/solid-fenics/requirements.txt
+++ b/elastic-tube-3d/solid-fenics/requirements.txt
@@ -3,8 +3,8 @@ numpy  >1, <2
 
 # Assuming FEniCS from ppa:fenics-packages/fenics was installed https://fenicsproject.org/download/archive/
 # Use --system-site-packages in venv
-fenics-dijitso==2019.2.0.dev0
-fenics-dolfin==2019.2.0.13.dev0
-fenics-ffc==2019.2.0.dev0
-fenics-fiat==2019.2.0.dev0
-fenics-ufl-legacy==2022.3.0
+fenics-dijitso~=2019.0
+fenics-dolfin~=2019.0
+fenics-ffc~=2019.0
+fenics-fiat~=2019.0
+fenics-ufl-legacy~=2022.0

--- a/flow-over-heated-plate/solid-fenics/requirements.txt
+++ b/flow-over-heated-plate/solid-fenics/requirements.txt
@@ -3,8 +3,8 @@ numpy >1, <2
 
 # Assuming FEniCS from ppa:fenics-packages/fenics was installed https://fenicsproject.org/download/archive/
 # Use --system-site-packages in venv
-fenics-dijitso==2019.2.0.dev0
-fenics-dolfin==2019.2.0.13.dev0
-fenics-ffc==2019.2.0.dev0
-fenics-fiat==2019.2.0.dev0
-fenics-ufl-legacy==2022.3.0
+fenics-dijitso~=2019.0
+fenics-dolfin~=2019.0
+fenics-ffc~=2019.0
+fenics-fiat~=2019.0
+fenics-ufl-legacy~=2022.0

--- a/partitioned-heat-conduction-complex/solver-fenics/requirements.txt
+++ b/partitioned-heat-conduction-complex/solver-fenics/requirements.txt
@@ -4,8 +4,8 @@ sympy
 
 # Assuming FEniCS from ppa:fenics-packages/fenics was installed https://fenicsproject.org/download/archive/
 # Use --system-site-packages in venv
-fenics-dijitso==2019.2.0.dev0
-fenics-dolfin==2019.2.0.13.dev0
-fenics-ffc==2019.2.0.dev0
-fenics-fiat==2019.2.0.dev0
-fenics-ufl-legacy==2022.3.0
+fenics-dijitso~=2019.0
+fenics-dolfin~=2019.0
+fenics-ffc~=2019.0
+fenics-fiat~=2019.0
+fenics-ufl-legacy~=2022.0

--- a/partitioned-heat-conduction-overlap/solver-fenics/requirements.txt
+++ b/partitioned-heat-conduction-overlap/solver-fenics/requirements.txt
@@ -3,8 +3,8 @@ numpy >1, <2
 
 # Assuming FEniCS from ppa:fenics-packages/fenics was installed https://fenicsproject.org/download/archive/
 # Use --system-site-packages in venv
-fenics-dijitso==2019.2.0.dev0
-fenics-dolfin==2019.2.0.13.dev0
-fenics-ffc==2019.2.0.dev0
-fenics-fiat==2019.2.0.dev0
-fenics-ufl-legacy==2022.3.0
+fenics-dijitso~=2019.0
+fenics-dolfin~=2019.0
+fenics-ffc~=2019.0
+fenics-fiat~=2019.0
+fenics-ufl-legacy~=2022.0

--- a/partitioned-heat-conduction/solver-fenics/requirements.txt
+++ b/partitioned-heat-conduction/solver-fenics/requirements.txt
@@ -4,8 +4,8 @@ scipy
 
 # Assuming FEniCS from ppa:fenics-packages/fenics was installed https://fenicsproject.org/download/archive/
 # Use --system-site-packages in venv
-fenics-dijitso==2019.2.0.dev0
-fenics-dolfin==2019.2.0.13.dev0
-fenics-ffc==2019.2.0.dev0
-fenics-fiat==2019.2.0.dev0
-fenics-ufl-legacy==2022.3.0
+fenics-dijitso~=2019.0
+fenics-dolfin~=2019.0
+fenics-ffc~=2019.0
+fenics-fiat~=2019.0
+fenics-ufl-legacy~=2022.0

--- a/perpendicular-flap/solid-fenics/requirements.txt
+++ b/perpendicular-flap/solid-fenics/requirements.txt
@@ -4,8 +4,8 @@ matplotlib
 
 # Assuming FEniCS from ppa:fenics-packages/fenics was installed https://fenicsproject.org/download/archive/
 # Use --system-site-packages in venv
-fenics-dijitso==2019.2.0.dev0
-fenics-dolfin==2019.2.0.13.dev0
-fenics-ffc==2019.2.0.dev0
-fenics-fiat==2019.2.0.dev0
-fenics-ufl-legacy==2022.3.0
+fenics-dijitso~=2019.0
+fenics-dolfin~=2019.0
+fenics-ffc~=2019.0
+fenics-fiat~=2019.0
+fenics-ufl-legacy~=2022.0

--- a/volume-coupled-diffusion/solver-fenics/requirements.txt
+++ b/volume-coupled-diffusion/solver-fenics/requirements.txt
@@ -3,8 +3,8 @@ numpy >1, <2
 
 # Assuming FEniCS from ppa:fenics-packages/fenics was installed https://fenicsproject.org/download/archive/
 # Use --system-site-packages in venv
-fenics-dijitso==2019.2.0.dev0
-fenics-dolfin==2019.2.0.13.dev0
-fenics-ffc==2019.2.0.dev0
-fenics-fiat==2019.2.0.dev0
-fenics-ufl-legacy==2022.3.0
+fenics-dijitso~=2019.0
+fenics-dolfin~=2019.0
+fenics-ffc~=2019.0
+fenics-fiat~=2019.0
+fenics-ufl-legacy~=2022.0


### PR DESCRIPTION
The required FEniCS versions in the `requirements.txt` files were too strict. I relaxed the requirements now to allow for updates.

Closes #589 

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
