### PR TITLE
System tests: Do not install fenics-ufl

### DIFF
--- a/tools/tests/dockerfiles/ubuntu_2204/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2204/Dockerfile
@@ -94,7 +94,6 @@ RUN add-apt-repository -y ppa:fenics-packages/fenics && \
     apt-get -qq update && \
     apt-get -qq install --no-install-recommends fenics
 USER precice
-RUN pip3 install --user fenics-ufl
 ARG FENICS_ADAPTER_REF
 # Building fenics-adapter
 RUN pip3 install --user git+https://github.com/precice/fenics-adapter.git@${FENICS_ADAPTER_REF}


### PR DESCRIPTION
A specific, compatible version of `fenics-ufl` is now installed by the FEniCS adapter / each FEniCS-related tutorial. Keeping it installed like this leads to compatibility issues.

Checklist:

- I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`. -> N/A
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
