### PR TITLE
Create a venv for SU2 tutorials

### DIFF
--- a/changelog-entries/593.md
+++ b/changelog-entries/593.md
@@ -1,0 +1,1 @@
+- Added a requirements.txt for the SU2 tutorials.

--- a/flow-over-heated-plate/fluid-su2/requirements.txt
+++ b/flow-over-heated-plate/fluid-su2/requirements.txt
@@ -1,0 +1,2 @@
+numpy >1, <2
+pyprecice~=3.0

--- a/flow-over-heated-plate/fluid-su2/run.sh
+++ b/flow-over-heated-plate/fluid-su2/run.sh
@@ -1,4 +1,13 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -e -u
 
+. ../../tools/log.sh
+exec > >(tee --append "$LOGFILE") 2>&1
+
+python3 -m venv --system-site-packages .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+
 SU2_preCICE_CHT.py -f laminar_config_unsteady.cfg -r --parallel
+
+close_log

--- a/perpendicular-flap/fluid-su2/requirements.txt
+++ b/perpendicular-flap/fluid-su2/requirements.txt
@@ -1,0 +1,2 @@
+numpy >1, <2
+pyprecice~=3.0

--- a/perpendicular-flap/fluid-su2/run.sh
+++ b/perpendicular-flap/fluid-su2/run.sh
@@ -4,6 +4,10 @@ set -e -u
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 
+python3 -m venv --system-site-packages .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+
 SU2_preCICE_FSI.py -f euler_config_unsteady.cfg --parallel
 
 close_log


### PR DESCRIPTION
A first attempt to fix https://github.com/precice/su2-adapter/issues/44 (here, to avoid understanding the structure and installation process of SU2 for now). I would keep the original issue open to find a better solution.

The ugly part is that this provides a `requirements.txt` for a directory that does not provide a code.

@IshaanDesai this seems to work in the system tests (at least for the perpendicular-flap, I have not tried out the flow-over-heated-plate). Do you see anything wrong in the code?

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
