### PR TITLE
System tests: Run all elastic-tube-1d tests in release_test

### DIFF
--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -68,6 +68,16 @@ test_suites:
       - path: elastic-tube-1d
         case_combination:
           - fluid-cpp
+          - solid-cpp
+        reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-cpp.tar.gz
+      - path: elastic-tube-1d
+        case_combination:
+          - fluid-python
+          - solid-python
+        reference_result: ./elastic-tube-1d/reference-results/fluid-python_solid-python.tar.gz
+      - path: elastic-tube-1d
+        case_combination:
+          - fluid-cpp
           - solid-python
         reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-python.tar.gz
       - path: flow-over-heated-plate


### PR DESCRIPTION
This was previously only running the cpp-python combination, but we already found issues only appearing in the python-python.


Checklist:

- I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`. -> Not really applicable, we are anyway extending the tests
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
