### PR TITLE
`oscillator-overlap`: Make consistent with `oscillator`

### DIFF
--- a/changelog-entries/500.md
+++ b/changelog-entries/500.md
@@ -1,1 +1,1 @@
-- Offer adaptive black-box time-stepping with RadauIIA scheme in oscillator case. Demonstrates use of time interpolation and dense output.
+- Offer adaptive black-box time-stepping with RadauIIA scheme in oscillator and oscillator-overlap case. Demonstrates use of time interpolation and dense output.

--- a/changelog-entries/500.md
+++ b/changelog-entries/500.md
@@ -1,1 +1,1 @@
-- Offer adaptive black-box time-stepping with RadauIIA scheme in oscillator and oscillator-overlap case. Demonstrates use of time interpolation and dense output.
+- Offer adaptive black-box time-stepping with RadauIIA scheme in oscillator case. Demonstrates use of time interpolation and dense output.

--- a/changelog-entries/597.md
+++ b/changelog-entries/597.md
@@ -1,0 +1,1 @@
+- Offer Runge-Kutta 4 scheme and black-box time-stepping with RadauIIA scheme in oscillator-overlap case. Demonstrates use of time interpolation and dense output.

--- a/changelog-entries/597.md
+++ b/changelog-entries/597.md
@@ -1,1 +1,1 @@
-- Offer Runge-Kutta 4 scheme and black-box time-stepping with RadauIIA scheme in oscillator-overlap case. Demonstrates use of time interpolation and dense output.
+- Added Runge-Kutta 4 scheme and black-box time-stepping with RadauIIA scheme as options to oscillator-overlap case. This demonstrates use of time interpolation and dense output.

--- a/oscillator-overlap/precice-config.xml
+++ b/oscillator-overlap/precice-config.xml
@@ -54,12 +54,14 @@
       mesh="Mass-Left-Mesh"
       from="Mass-Left"
       to="Mass-Right"
-      initialize="true" />
+      initialize="true"
+      substeps="true" />
     <exchange
       data="Displacement-Right"
       mesh="Mass-Left-Mesh"
       from="Mass-Right"
       to="Mass-Left"
-      initialize="true" />
+      initialize="true"
+      substeps="true" />
   </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/oscillator-overlap/solver-python/oscillator.py
+++ b/oscillator-overlap/solver-python/oscillator.py
@@ -182,12 +182,6 @@ while participant.is_coupling_ongoing():
         t_write.append(t)
 
 # store final result
-u = u_new
-v = v_new
-a = a_new
-u_write.append(u)
-v_write.append(v)
-t_write.append(t)
 positions += u_write
 velocities += v_write
 times += t_write

--- a/oscillator-overlap/solver-python/oscillator.py
+++ b/oscillator-overlap/solver-python/oscillator.py
@@ -74,7 +74,7 @@ dimensions = participant.get_mesh_dimensions(mesh_name)
 
 vertex = np.zeros(dimensions)
 read_data = np.zeros(num_vertices)
-write_data = connecting_spring.k * u0 * np.ones(num_vertices)
+write_data = u0 * np.ones(num_vertices)
 
 vertex_ids = [participant.set_mesh_vertex(mesh_name, vertex)]
 

--- a/oscillator-overlap/solver-python/oscillator.py
+++ b/oscillator-overlap/solver-python/oscillator.py
@@ -83,7 +83,7 @@ if participant.requires_initial_data():
 
 participant.initialize()
 precice_dt = participant.get_max_time_step_size()
-my_dt = precice_dt  # use my_dt < precice_dt for subcycling
+my_dt = precice_dt / 4  # use my_dt < precice_dt for subcycling
 
 # Initial Conditions
 a0 = (f0 - stiffness * u0) / mass

--- a/oscillator-overlap/solver-python/oscillator.py
+++ b/oscillator-overlap/solver-python/oscillator.py
@@ -130,13 +130,14 @@ while participant.is_coupling_ongoing():
     precice_dt = participant.get_max_time_step_size()
     dt = np.min([precice_dt, my_dt])
 
-    def f(t: float) -> float: return connecting_spring.k * participant.read_data(mesh_name, read_data_name, vertex_ids, t)[0]
-    
+    def f(t: float) -> float: return connecting_spring.k * \
+        participant.read_data(mesh_name, read_data_name, vertex_ids, t)[0]
+
     # do time step, write data, and advance
     u_new, v_new, a_new = time_stepper.do_step(u, v, a, f, dt)
 
     t_new = t + dt
-    
+
     # RadauIIA time stepper provides dense output. Do multiple write calls per time step.
     if isinstance(time_stepper, RadauIIA):
         # create n samples_per_step of time stepping scheme. Degree of dense

--- a/oscillator-overlap/solver-python/oscillator.py
+++ b/oscillator-overlap/solver-python/oscillator.py
@@ -6,13 +6,10 @@ import precice
 from enum import Enum
 import csv
 import os
+from typing import Type
 
 import problemDefinition
-
-
-class Scheme(Enum):
-    NEWMARK_BETA = "Newmark_beta"
-    GENERALIZED_ALPHA = "generalized_alpha"
+from timeSteppers import TimeStepper, TimeSteppingSchemes, GeneralizedAlpha, RungeKutta4, RadauIIA
 
 
 class Participant(Enum):
@@ -22,11 +19,22 @@ class Participant(Enum):
 
 parser = argparse.ArgumentParser()
 parser.add_argument("participantName", help="Name of the solver.", type=str, choices=[p.value for p in Participant])
-parser.add_argument("-ts", "--time-stepping", help="Time stepping scheme being used.", type=str,
-                    choices=[s.value for s in Scheme], default=Scheme.NEWMARK_BETA.value)
+parser.add_argument(
+    "-ts",
+    "--time-stepping",
+    help="Time stepping scheme being used.",
+    type=str,
+    choices=[
+        s.value for s in TimeSteppingSchemes],
+    default=TimeSteppingSchemes.NEWMARK_BETA.value)
 args = parser.parse_args()
 
 participant_name = args.participantName
+
+this_mass: Type[problemDefinition.Mass]
+other_mass: Type[problemDefinition.Mass]
+this_spring: Type[problemDefinition.Spring]
+connecting_spring = problemDefinition.SpringMiddle
 
 if participant_name == Participant.MASS_LEFT.value:
     write_data_name = 'Displacement-Left'
@@ -35,7 +43,6 @@ if participant_name == Participant.MASS_LEFT.value:
 
     this_mass = problemDefinition.MassLeft
     this_spring = problemDefinition.SpringLeft
-    connecting_spring = problemDefinition.SpringMiddle
     other_mass = problemDefinition.MassRight
 
 elif participant_name == Participant.MASS_RIGHT.value:
@@ -45,7 +52,6 @@ elif participant_name == Participant.MASS_RIGHT.value:
 
     this_mass = problemDefinition.MassRight
     this_spring = problemDefinition.SpringRight
-    connecting_spring = problemDefinition.SpringMiddle
     other_mass = problemDefinition.MassLeft
 
 else:
@@ -86,16 +92,20 @@ v = v0
 a = a0
 t = 0
 
-# Generalized Alpha Parameters
-if args.time_stepping == Scheme.GENERALIZED_ALPHA.value:
-    alpha_f = 0.4
-    alpha_m = 0.2
-elif args.time_stepping == Scheme.NEWMARK_BETA.value:
-    alpha_f = 0.0
-    alpha_m = 0.0
-m = 3 * [None]  # will be computed for each timestep depending on dt
-gamma = 0.5 - alpha_m + alpha_f
-beta = 0.25 * (gamma + 0.5)
+time_stepper: TimeStepper
+
+if args.time_stepping == TimeSteppingSchemes.GENERALIZED_ALPHA.value:
+    time_stepper = GeneralizedAlpha(stiffness=stiffness, mass=mass, alpha_f=0.4, alpha_m=0.2)
+elif args.time_stepping == TimeSteppingSchemes.NEWMARK_BETA.value:
+    time_stepper = GeneralizedAlpha(stiffness=stiffness, mass=mass, alpha_f=0.0, alpha_m=0.0)
+elif args.time_stepping == TimeSteppingSchemes.RUNGE_KUTTA_4.value:
+    time_stepper = RungeKutta4(stiffness=stiffness, mass=mass)
+elif args.time_stepping == TimeSteppingSchemes.Radau_IIA.value:
+    time_stepper = RadauIIA(stiffness=stiffness, mass=mass)
+else:
+    raise Exception(
+        f"Invalid time stepping scheme {args.time_stepping}. Please use one of {[ts.value for ts in TimeSteppingSchemes]}")
+
 
 positions = []
 velocities = []
@@ -119,25 +129,35 @@ while participant.is_coupling_ongoing():
     # compute time step size for this time step
     precice_dt = participant.get_max_time_step_size()
     dt = np.min([precice_dt, my_dt])
-    read_time = (1 - alpha_f) * dt
-    read_data = participant.read_data(mesh_name, read_data_name, vertex_ids, read_time)
-    f = connecting_spring.k * read_data[0]
 
-    # do generalized alpha step
-    m[0] = (1 - alpha_m) / (beta * dt**2)
-    m[1] = (1 - alpha_m) / (beta * dt)
-    m[2] = (1 - alpha_m - 2 * beta) / (2 * beta)
-    k_bar = stiffness * (1 - alpha_f) + m[0] * mass
-    u_new = (f - alpha_f * stiffness * u + mass * (m[0] * u + m[1] * v + m[2] * a)) / k_bar
-    a_new = 1.0 / (beta * dt**2) * (u_new - u - dt * v) - (1 - 2 * beta) / (2 * beta) * a
-    v_new = v + dt * ((1 - gamma) * a + gamma * a_new)
+    def f(t: float) -> float: return connecting_spring.k * participant.read_data(mesh_name, read_data_name, vertex_ids, t)[0]
+    
+    # do time step, write data, and advance
+    u_new, v_new, a_new = time_stepper.do_step(u, v, a, f, dt)
+
     t_new = t + dt
+    
+    # RadauIIA time stepper provides dense output. Do multiple write calls per time step.
+    if isinstance(time_stepper, RadauIIA):
+        # create n samples_per_step of time stepping scheme. Degree of dense
+        # interpolating function is usually larger 1 and, therefore, we need
+        # multiple samples per step.
+        samples_per_step = 5
+        n_time_steps = len(time_stepper.dense_output.ts)  # number of time steps performed by adaptive time stepper
+        n_pseudo = samples_per_step * n_time_steps  # samples_per_step times no. time steps per window.
+        t_pseudo = 0
+        for i in range(n_pseudo):
+            # perform n_pseudo pseudosteps
+            dt_pseudo = dt / n_pseudo
+            t_pseudo += dt_pseudo
+            write_data = np.array([time_stepper.dense_output(t_pseudo)[0]])
+            participant.write_data(mesh_name, write_data_name, vertex_ids, write_data)
+            participant.advance(dt_pseudo)
 
-    write_data = [u_new]
-
-    participant.write_data(mesh_name, write_data_name, vertex_ids, write_data)
-
-    participant.advance(dt)
+    else:  # simple time stepping without dense output; only a single write call per time step
+        write_data = np.array([u_new])
+        participant.write_data(mesh_name, write_data_name, vertex_ids, write_data)
+        participant.advance(dt)
 
     if participant.requires_reading_checkpoint():
         u = u_cp

--- a/oscillator-overlap/solver-python/problemDefinition.py
+++ b/oscillator-overlap/solver-python/problemDefinition.py
@@ -1,20 +1,33 @@
 import numpy as np
 from numpy.linalg import eig
+from typing import Callable
 
 
-class SpringLeft:
+class Spring:
+    k: float
+
+
+class SpringLeft(Spring):
     k = 4 * np.pi**2
 
 
-class SpringMiddle:
+class SpringMiddle(Spring):
     k = 16 * (np.pi**2)
 
 
-class SpringRight:
+class SpringRight(Spring):
     k = 4 * np.pi**2
 
 
-class MassLeft:
+class Mass:
+    m: float
+    u0: float
+    v0: float
+    u_analytical: Callable[[float | np.ndarray], float | np.ndarray]
+    v_analytical: Callable[[float | np.ndarray], float | np.ndarray]
+
+
+class MassLeft(Mass):
     # mass
     m = 1
 
@@ -23,10 +36,8 @@ class MassLeft:
     u0 = 1.0
     v0 = 0.0
 
-    u_analytical, v_analytical = None, None  # will be defined below
 
-
-class MassRight:
+class MassRight(Mass):
     # mass
     m = 1
 
@@ -34,8 +45,6 @@ class MassRight:
     # solution allows arbitrary u0, but requires v0 = 0)
     u0 = 0.0
     v0 = 0.0
-
-    u_analytical, v_analytical = None, None  # will be defined below
 
 
 # Mass matrix

--- a/oscillator-overlap/solver-python/timeSteppers.py
+++ b/oscillator-overlap/solver-python/timeSteppers.py
@@ -1,0 +1,168 @@
+from typing import Tuple, Callable
+import numpy as np
+import scipy as sp
+from scipy.integrate import OdeSolution
+from enum import Enum
+
+
+class TimeSteppingSchemes(Enum):
+    NEWMARK_BETA = "Newmark_beta"
+    GENERALIZED_ALPHA = "generalized_alpha"
+    RUNGE_KUTTA_4 = "runge_kutta_4"
+    Radau_IIA = "radauIIA"  # 5th order implicit
+
+
+class TimeStepper:
+    """Time stepper for a mass spring system with given mass and spring stiffness
+    """
+
+    def __init__(self,
+                 stiffness: float,
+                 mass: float) -> None:
+        """Initializes time stepper with parameters describing mass spring system
+
+        Args:
+            stiffness (float): the stiffness of the spring connected to the mass
+            mass (float): the mass
+        """
+        raise NotImplementedError()
+
+    def do_step(self,
+                u0: float,
+                v0: float,
+                a0: float,
+                rhs: Callable[[float], float],
+                dt: float
+                ) -> Tuple[float, float, float]:
+        """Perform a time step of size dt with given time stepper
+
+        Args:
+            u0 (float): displacement at time t0
+            v0 (float): velocity at time t0
+            a0 (float): acceleration at time t0
+            rhs (Callable[[float],float]): time dependent right-hand side
+            dt (float): time step size
+
+        Returns:
+            Tuple[float, float, float]: returns computed displacement, velocity, and acceleration at time t1 = t0 + dt.
+        """
+        raise NotImplementedError()
+
+
+class GeneralizedAlpha(TimeStepper):
+    """TimeStepper implementing generalized Alpha or Newmark Beta scheme (depends on parameters alpha_f and alpha_m set in constructor)
+    """
+    alpha_f: float
+    alpha_m: float
+
+    def __init__(self, stiffness: float, mass: float, alpha_f: float = 0.4, alpha_m: float = 0.2) -> None:
+        self.alpha_f = alpha_f
+        self.alpha_m = alpha_m
+
+        self.gamma = 0.5 - self.alpha_m + self.alpha_f
+        self.beta = 0.25 * (self.gamma + 0.5)
+
+        self.stiffness = stiffness
+        self.mass = mass
+
+    def do_step(self,
+                u0: float,
+                v0: float,
+                a0: float,
+                rhs: Callable[[float], float],
+                dt: float
+                ) -> Tuple[float, float, float]:
+        f = rhs((1.0 - self.alpha_f) * dt)
+
+        m = [(1 - self.alpha_m) / (self.beta * dt**2),
+             (1 - self.alpha_m) / (self.beta * dt),
+             (1 - self.alpha_m - 2 * self.beta) / (2 * self.beta)]
+
+        k_bar = self.stiffness * (1 - self.alpha_f) + m[0] * self.mass
+
+        # do generalized alpha step
+        u1 = (f - self.alpha_f * self.stiffness * u0 + self.mass * (m[0] * u0 + m[1] * v0 + m[2] * a0)) / k_bar
+        a1 = 1.0 / (self.beta * dt**2) * (u1 - u0 - dt * v0) - (1 - 2 * self.beta) / (2 * self.beta) * a0
+        v1 = v0 + dt * ((1 - self.gamma) * a0 + self.gamma * a1)
+
+        return u1, v1, a1
+
+
+class RungeKutta4(TimeStepper):
+    """TimeStepper implementing classic Runge Kutta scheme (4 stages)
+    """
+    # parameters from Butcher tableau of classic Runge Kutta scheme (RK4)
+    a = np.array([[0, 0, 0, 0],
+                  [0.5, 0, 0, 0],
+                  [0, 0.5, 0, 0],
+                  [0, 0, 1.0, 0]])
+    b = np.array([1 / 6, 1 / 3, 1 / 3, 1 / 6])
+    c = np.array([0, 0.5, 0.5, 1])
+
+    def __init__(self, stiffness: float, mass: float) -> None:
+        self.ode_system = np.array([
+            [0, 1],  # du
+            [-stiffness / mass, 0],  # dv
+        ])
+
+    def do_step(self,
+                u0: float,
+                v0: float,
+                _: float,
+                rhs: Callable[[float], float],
+                dt: float
+                ) -> Tuple[float, float, float]:
+        k = 4 * [None]  # store stages in list
+
+        x0 = np.array([u0, v0])
+        def f(t, x): return self.ode_system.dot(x) + np.array([0, rhs(t)])
+
+        k[0] = f(self.c[0] * dt, x0)
+        k[1] = f(self.c[1] * dt, x0 + self.a[1, 0] * k[0] * dt)
+        k[2] = f(self.c[2] * dt, x0 + self.a[2, 1] * k[1] * dt)
+        k[3] = f(self.c[3] * dt, x0 + self.a[3, 2] * k[2] * dt)
+
+        x1 = x0 + dt * sum(b_i * k_i for k_i, b_i in zip(k, self.b))
+
+        return x1[0], x1[1], f(dt, x1)[1]
+
+
+class RadauIIA(TimeStepper):
+    """Perform a step with the adaptive RadauIIA time stepper of scipy.integrate
+    """
+    _dense_output: OdeSolution
+
+    def __init__(self, stiffness: float, mass: float) -> None:
+        self.ode_system = np.array([
+            [0, 1],  # du
+            [-stiffness / mass, 0],  # dv
+        ])
+
+    def do_step(self,
+                u0: float,
+                v0: float,
+                _: float,
+                rhs: Callable[[float], float],
+                dt: float
+                ) -> Tuple[float, float, float]:
+        t0, t1 = 0, dt
+
+        x0 = np.array([u0, v0])
+        def f(t, x): return self.ode_system.dot(x) + np.array([np.zeros_like(t), rhs(t)])
+
+        # use adaptive time stepping; dense_output=True allows us to sample from continuous function later
+        ret = sp.integrate.solve_ivp(f, [t0, t1], x0, method="Radau",
+                                     dense_output=True, rtol=10e-5, atol=10e-9)
+
+        self._dense_output = ret.sol  # store dense output in class
+
+        return ret.y[0, -1], ret.y[1, -1], f(dt, ret.y[:, -1])[1]
+
+    @property
+    def dense_output(self) -> OdeSolution:
+        """Returns dense output created for the last call of do_step
+
+        Returns:
+            OdeSolution: dense output
+        """
+        return self._dense_output


### PR DESCRIPTION
Updates `oscillator-overlap` to use time stepping schemes and typing like in `oscillator`

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
