### PR TITLE
Add setuptools to Nutils-related requirements.txt

### DIFF
--- a/channel-transport/fluid-nutils/requirements.txt
+++ b/channel-transport/fluid-nutils/requirements.txt
@@ -1,3 +1,4 @@
+setuptools # required by nutils
 nutils==7
 numpy >1, <2
 pyprecice~=3.0

--- a/channel-transport/transport-nutils/requirements.txt
+++ b/channel-transport/transport-nutils/requirements.txt
@@ -1,3 +1,4 @@
+setuptools # required by nutils
 nutils==7
 numpy >1, <2
 pyprecice~=3.0

--- a/flow-over-heated-plate/solid-nutils/requirements.txt
+++ b/flow-over-heated-plate/solid-nutils/requirements.txt
@@ -1,3 +1,4 @@
+setuptools # required by nutils
 nutils==7
 numpy >1, <2
 pyprecice~=3.0

--- a/partitioned-heat-conduction-direct/dirichlet-nutils/requirements.txt
+++ b/partitioned-heat-conduction-direct/dirichlet-nutils/requirements.txt
@@ -1,3 +1,4 @@
+setuptools # required by nutils
 nutils==7
 numpy >1, <2
 pyprecice~=3.0

--- a/partitioned-heat-conduction-direct/neumann-nutils/requirements.txt
+++ b/partitioned-heat-conduction-direct/neumann-nutils/requirements.txt
@@ -1,3 +1,4 @@
+setuptools # required by nutils
 nutils==7
 numpy >1, <2
 pyprecice~=3.0

--- a/partitioned-heat-conduction/dirichlet-nutils/requirements.txt
+++ b/partitioned-heat-conduction/dirichlet-nutils/requirements.txt
@@ -1,3 +1,4 @@
+setuptools # required by nutils
 nutils==7
 numpy >1, <2
 pyprecice~=3.0

--- a/partitioned-heat-conduction/neumann-nutils/requirements.txt
+++ b/partitioned-heat-conduction/neumann-nutils/requirements.txt
@@ -1,3 +1,4 @@
+setuptools # required by nutils
 nutils==7
 numpy >1, <2
 pyprecice~=3.0

--- a/perpendicular-flap/fluid-nutils/requirements.txt
+++ b/perpendicular-flap/fluid-nutils/requirements.txt
@@ -1,3 +1,4 @@
+setuptools # required by nutils
 nutils==6
 numpy >1, <2
 pyprecice~=3.0

--- a/perpendicular-flap/solid-nutils/requirements.txt
+++ b/perpendicular-flap/solid-nutils/requirements.txt
@@ -1,3 +1,4 @@
+setuptools # required by nutils
 nutils>=8.5
 numpy >1, <2
 pyprecice~=3.0

--- a/two-scale-heat-conduction/macro-nutils/requirements.txt
+++ b/two-scale-heat-conduction/macro-nutils/requirements.txt
@@ -1,3 +1,4 @@
+setuptools # required by nutils
 nutils==7
 numpy >1, <2
 pyprecice~=3.0

--- a/two-scale-heat-conduction/micro-nutils/requirements.txt
+++ b/two-scale-heat-conduction/micro-nutils/requirements.txt
@@ -1,3 +1,4 @@
+setuptools # required by nutils
 nutils==7
 numpy >1, <2
 pyprecice~=3.0


### PR DESCRIPTION
@fsimonis tells me in https://github.com/precice/tutorials/pull/599#discussion_r1867678913 that we now need to specify `setuptools` as a requirement whenever we also specify `nutils` for newer PIP versions.

I have not verified this, but here is a PR to at least not forget (but it should not harm anyway).

Checklist:

- I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`. -> N/A
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
