### PR TITLE
Python-based tutorials: Log list of installed packages

### DIFF
--- a/changelog-entries/608.md
+++ b/changelog-entries/608.md
@@ -1,0 +1,1 @@
+- Added logging of installed Python packages for the Python-based tutorials into a file `pip-installed-packages.log`.

--- a/channel-transport-reaction/chemical-fenics/run.sh
+++ b/channel-transport-reaction/chemical-fenics/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv --system-site-package .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 python3 chemical-reaction-advection-diffusion.py
 

--- a/channel-transport-reaction/fluid-fenics/run.sh
+++ b/channel-transport-reaction/fluid-fenics/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv --system-site-package .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 
 python3 fluid.py

--- a/channel-transport/fluid-nutils/run.sh
+++ b/channel-transport/fluid-nutils/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 python3 fluid.py
 
 close_log

--- a/channel-transport/transport-nutils/run.sh
+++ b/channel-transport/transport-nutils/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 python3 transport.py "$@"
 
 close_log

--- a/elastic-tube-1d/fluid-python/run.sh
+++ b/elastic-tube-1d/fluid-python/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 python3 ./FluidSolver.py ../precice-config.xml
 

--- a/elastic-tube-1d/solid-python/run.sh
+++ b/elastic-tube-1d/solid-python/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 python3 ./SolidSolver.py ../precice-config.xml
 

--- a/elastic-tube-3d/solid-fenics/run.sh
+++ b/elastic-tube-3d/solid-fenics/run.sh
@@ -6,6 +6,6 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv --system-site-package .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 python3 solid.py

--- a/flow-around-controlled-moving-cylinder/controller-fmi/run.sh
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/run.sh
@@ -17,7 +17,7 @@ fi
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 fmiprecice ./fmi-settings.json ./precice-settings.json
 

--- a/flow-around-controlled-moving-cylinder/solid-python/run.sh
+++ b/flow-around-controlled-moving-cylinder/solid-python/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 python3 solid.py ../precice-config.xml
 

--- a/flow-over-heated-plate/fluid-su2/run.sh
+++ b/flow-over-heated-plate/fluid-su2/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv --system-site-packages .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 SU2_preCICE_CHT.py -f laminar_config_unsteady.cfg -r --parallel
 

--- a/flow-over-heated-plate/solid-dunefem/run.sh
+++ b/flow-over-heated-plate/solid-dunefem/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 python3 solid.py
 
 close_log

--- a/flow-over-heated-plate/solid-fenics/run.sh
+++ b/flow-over-heated-plate/solid-fenics/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv --system-site-packages .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 python3 solid.py
 

--- a/flow-over-heated-plate/solid-nutils/run.sh
+++ b/flow-over-heated-plate/solid-nutils/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 python3 solid.py
 
 close_log

--- a/oscillator/mass-left-fmi/run.sh
+++ b/oscillator/mass-left-fmi/run.sh
@@ -18,7 +18,7 @@ fi
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 fmiprecice fmi-settings.json precice-settings.json
 python3 ../solver-fmi/calculate-error.py ../mass-left-fmi/fmi-settings.json ../mass-left-fmi/precice-settings.json ../mass-right-fmi/fmi-settings.json ../mass-right-fmi/precice-settings.json Mass-Left

--- a/oscillator/mass-right-fmi/run.sh
+++ b/oscillator/mass-right-fmi/run.sh
@@ -18,7 +18,7 @@ fi
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 fmiprecice fmi-settings.json precice-settings.json
 python3 ../solver-fmi/calculate-error.py ../mass-left-fmi/fmi-settings.json ../mass-left-fmi/precice-settings.json ../mass-right-fmi/fmi-settings.json ../mass-right-fmi/precice-settings.json Mass-Right

--- a/partitioned-heat-conduction-direct/dirichlet-nutils/run.sh
+++ b/partitioned-heat-conduction-direct/dirichlet-nutils/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 rm -rf Dirichlet-*.vtk
 NUTILS_RICHOUTPUT=no python3 heat.py

--- a/partitioned-heat-conduction-direct/neumann-nutils/run.sh
+++ b/partitioned-heat-conduction-direct/neumann-nutils/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 rm -rf Neumann-*.vtk
 NUTILS_RICHOUTPUT=no python3 heat.py

--- a/partitioned-heat-conduction/dirichlet-nutils/run.sh
+++ b/partitioned-heat-conduction/dirichlet-nutils/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 rm -rf Dirichlet-*.vtk
 NUTILS_RICHOUTPUT=no python3 heat.py

--- a/partitioned-heat-conduction/neumann-nutils/run.sh
+++ b/partitioned-heat-conduction/neumann-nutils/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 rm -rf Neumann-*.vtk
 NUTILS_RICHOUTPUT=no python3 heat.py

--- a/perpendicular-flap/fluid-fake/run.sh
+++ b/perpendicular-flap/fluid-fake/run.sh
@@ -3,5 +3,5 @@ set -e -u
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 python3 fake.py

--- a/perpendicular-flap/fluid-nutils/run.sh
+++ b/perpendicular-flap/fluid-nutils/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 python3 fluid.py
 
 close_log

--- a/perpendicular-flap/fluid-su2/run.sh
+++ b/perpendicular-flap/fluid-su2/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv --system-site-packages .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 SU2_preCICE_FSI.py -f euler_config_unsteady.cfg --parallel
 

--- a/perpendicular-flap/solid-fake/run.sh
+++ b/perpendicular-flap/solid-fake/run.sh
@@ -3,5 +3,5 @@ set -e -u
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 python3 fake.py

--- a/perpendicular-flap/solid-fenics/run.sh
+++ b/perpendicular-flap/solid-fenics/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv --system-site-packages .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 python3 solid.py
 

--- a/perpendicular-flap/solid-nutils/run.sh
+++ b/perpendicular-flap/solid-nutils/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 python3 solid.py richoutput=no
 
 close_log

--- a/resonant-circuit/capacitor-python/run.sh
+++ b/resonant-circuit/capacitor-python/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 python3 capacitor.py
 
 close_log

--- a/resonant-circuit/coil-python/run.sh
+++ b/resonant-circuit/coil-python/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 python3 coil.py
 
 close_log

--- a/two-scale-heat-conduction/macro-nutils/run.sh
+++ b/two-scale-heat-conduction/macro-nutils/run.sh
@@ -6,7 +6,7 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 python3 macro.py richoutput=no
 
 close_log

--- a/two-scale-heat-conduction/micro-nutils/run.sh
+++ b/two-scale-heat-conduction/micro-nutils/run.sh
@@ -8,7 +8,7 @@ usage() { echo "Usage: cmd [-s] [-p n]" 1>&2; exit 1; }
 
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 
 # Check if no input argument was provided
 if [ -z "$*" ] ; then


### PR DESCRIPTION
In the `run.sh` of our Python-based tutorial, we create a venv and install packages. This PR adds a call to `pip freeze` that writes the list of installed packages (with their versions) into a file called `pip-installed-packages.log`. This additional information can increase reproducibility.

The log file is not touched by `clean.sh`, as the respective `.venv` is also not removed by it. It is also neither a case nor a preCICE log file, to be added to the respective cleaning functions.

This is related to #596.

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
