### PR TITLE
Add default profiling explicitly in xml configs

### DIFF
--- a/breaking-dam-2d/precice-config.xml
+++ b/breaking-dam-2d/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:vector name="Force" />
   <data:vector name="Displacement" />
 

--- a/changelog-entries/618.md
+++ b/changelog-entries/618.md
@@ -1,0 +1,1 @@
+- Added (the default) profiling configuration in all our `precice-config.xml`.

--- a/channel-transport-reaction/precice-config.xml
+++ b/channel-transport-reaction/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:vector name="Velocity" />
 
   <mesh name="Flow-Mesh" dimensions="2">

--- a/channel-transport/precice-config.xml
+++ b/channel-transport/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:vector name="Velocity" />
 
   <mesh name="Fluid-Mesh" dimensions="2">

--- a/elastic-tube-1d/precice-config.xml
+++ b/elastic-tube-1d/precice-config.xml
@@ -4,6 +4,8 @@
     <sink filter="%Severity% > debug" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Pressure" />
   <data:scalar name="CrossSectionLength" />
 

--- a/elastic-tube-3d/precice-config.xml
+++ b/elastic-tube-3d/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:vector name="Force" />
   <data:vector name="DisplacementDelta" />
 

--- a/flow-around-controlled-moving-cylinder/precice-config.xml
+++ b/flow-around-controlled-moving-cylinder/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:vector name="Displacement-Cylinder" />
   <data:vector name="Displacement-Spring" />
   <data:vector name="Force" />

--- a/flow-over-heated-plate-nearest-projection/precice-config.xml
+++ b/flow-over-heated-plate-nearest-projection/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Temperature" />
   <data:scalar name="Heat-Flux" />
 

--- a/flow-over-heated-plate-partitioned-flow/precice-config.xml
+++ b/flow-over-heated-plate-partitioned-flow/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Temperature-Solid" />
   <data:scalar name="Heat-Flux" />
   <data:vector name="VelocityGradient" />

--- a/flow-over-heated-plate-steady-state/precice-config.xml
+++ b/flow-over-heated-plate-steady-state/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Heat-Transfer-Coefficient-Solid" />
   <data:scalar name="Sink-Temperature-Solid" />
   <data:scalar name="Heat-Transfer-Coefficient-Fluid" />

--- a/flow-over-heated-plate-two-meshes/precice-config.xml
+++ b/flow-over-heated-plate-two-meshes/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Temperature" />
   <data:scalar name="Heat-Flux" />
 

--- a/flow-over-heated-plate/precice-config.xml
+++ b/flow-over-heated-plate/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Temperature" />
   <data:scalar name="Heat-Flux" />
 

--- a/heat-exchanger-simplified/precice-config.xml
+++ b/heat-exchanger-simplified/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Temperature-Top" />
   <data:scalar name="Heat-Flux-Top" />
   <data:scalar name="Temperature-Bottom" />

--- a/heat-exchanger/precice-config.xml
+++ b/heat-exchanger/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Heat-Transfer-Coefficient-Solid" />
   <data:scalar name="Sink-Temperature-Solid" />
   <data:scalar name="Heat-Transfer-Coefficient-Fluid-Inner" />

--- a/multiple-perpendicular-flaps/precice-config.xml
+++ b/multiple-perpendicular-flaps/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:vector name="Stress-Upstream" />
   <data:vector name="Displacement-Upstream" />
   <data:vector name="Stress-Downstream" />

--- a/oscillator-overlap/precice-config.xml
+++ b/oscillator-overlap/precice-config.xml
@@ -4,6 +4,8 @@
     <sink filter="%Severity% > debug" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Displacement-Left" />
   <data:scalar name="Displacement-Right" />
 

--- a/oscillator/precice-config.xml
+++ b/oscillator/precice-config.xml
@@ -4,6 +4,8 @@
     <sink filter="%Severity% > debug" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Force-Left" waveform-degree="3" />
   <data:scalar name="Force-Right" waveform-degree="3" />
 

--- a/partitioned-backwards-facing-step/precice-config.xml
+++ b/partitioned-backwards-facing-step/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Pressure" />
   <data:vector name="Velocity" />
   <data:scalar name="PressureBack" />

--- a/partitioned-elastic-beam/precice-config.xml
+++ b/partitioned-elastic-beam/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:vector name="Force0" />
   <data:vector name="Displacement0" />
 

--- a/partitioned-heat-conduction-complex/precice-config.xml
+++ b/partitioned-heat-conduction-complex/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Temperature" />
   <data:vector name="Heat-Flux" />
 

--- a/partitioned-heat-conduction-direct/precice-config.xml
+++ b/partitioned-heat-conduction-direct/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Temperature" />
   <data:scalar name="Heat-Flux" />
 

--- a/partitioned-heat-conduction-overlap/precice-config.xml
+++ b/partitioned-heat-conduction-overlap/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Temperature-Left" />
   <data:scalar name="Temperature-Right" />
 

--- a/partitioned-heat-conduction/precice-config.xml
+++ b/partitioned-heat-conduction/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Temperature" waveform-degree="1" />
   <data:scalar name="Heat-Flux" waveform-degree="1" />
 

--- a/partitioned-pipe-two-phase/precice-config.xml
+++ b/partitioned-pipe-two-phase/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Pressure" />
   <data:vector name="Velocity" />
   <data:vector name="VelocityGradient" />

--- a/partitioned-pipe/precice-config.xml
+++ b/partitioned-pipe/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Pressure" />
   <data:vector name="Velocity" />
 

--- a/perpendicular-flap/precice-config.xml
+++ b/perpendicular-flap/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:vector name="Force" />
   <data:vector name="Displacement" />
 

--- a/quickstart/precice-config.xml
+++ b/quickstart/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:vector name="Force" />
   <data:vector name="Displacement" />
 

--- a/turek-hron-fsi3/precice-config.xml
+++ b/turek-hron-fsi3/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:vector name="Stress" />
   <data:vector name="Displacement" />
 

--- a/two-scale-heat-conduction/precice-config.xml
+++ b/two-scale-heat-conduction/precice-config.xml
@@ -4,6 +4,8 @@
     <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="k_00" />
   <data:scalar name="k_01" />
   <data:scalar name="k_10" />

--- a/volume-coupled-diffusion/precice-config.xml
+++ b/volume-coupled-diffusion/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:scalar name="Drain-Data" />
   <data:scalar name="Source-Data" />
 

--- a/volume-coupled-flow/precice-config.xml
+++ b/volume-coupled-flow/precice-config.xml
@@ -7,6 +7,8 @@
       enabled="true" />
   </log>
 
+  <profiling mode="fundamental" synchronize="false" />
+
   <data:vector name="Velocity" />
 
   <mesh name="Fluid-Mesh" dimensions="2">


### PR DESCRIPTION
To raise awareness of this option and have a starting point for potential modifications.

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
