### PR TITLE
Use linearly increasing ramp as inflow BC

### DIFF
--- a/perpendicular-flap/fluid-openfoam/0/U
+++ b/perpendicular-flap/fluid-openfoam/0/U
@@ -8,14 +8,18 @@ FoamFile
 
 dimensions      [0 1 -1 0 0 0 0];
 
-internalField   uniform (10 0 0);
+internalField   uniform (0 0 0);
 
 boundaryField
 {
     inlet
     {
-        type            fixedValue;
-        value           $internalField;
+        type            uniformFixedValue;
+        uniformValue    table
+                        (
+                          (0 (0 0 0))
+                          (1 (10 0 0))
+                        );
     }
     outlet
     {

--- a/perpendicular-flap/fluid-openfoam/system/controlDict
+++ b/perpendicular-flap/fluid-openfoam/system/controlDict
@@ -17,7 +17,7 @@ stopAt          endTime;
 
 endTime         5;
 
-deltaT          0.01;
+deltaT          0.025;
 
 writeControl    adjustableRunTime;
 


### PR DESCRIPTION
Use a linearly ramp as initial condition: The inflow velocity starts for $$t=0$$ at $$u_x=0$$ and linearly increases to $$u_x=10$$ at $$t=1$$. For $$t>1$$ we use a constant inflow velocity of $$u_x=10$$.

Todos:

- [ ] Make sure that the state of the systemtests is clarified before merging #620, since it will influence the reference results.

Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
