### PR TITLE
Cleanup Docker cache before generating reference results

### DIFF
--- a/.github/workflows/generate_reference_results_workflow.yml
+++ b/.github/workflows/generate_reference_results_workflow.yml
@@ -45,6 +45,11 @@ jobs:
     - name: Install Python dependencies
       run: |
         pip install --user -r tools/tests/requirements.txt
+    - name: Cleanup Docker cache
+      # Remove all Docker containers, images, and build caches
+      # to ensure consistent results and as storage cleanup
+      run: |
+        docker system prune --all --force
     - name: Run tests
       run: |
         cd tools/tests


### PR DESCRIPTION
Adds a step to do a

```
docker system prune --all --force
```

in the GitHub Actions workflow that generates the reference results.

Closes #588.

