### PR TITLE
System tests: Enable uploading artifacts by default

### DIFF
--- a/.github/workflows/run_testsuite_manual.yml
+++ b/.github/workflows/run_testsuite_manual.yml
@@ -28,7 +28,7 @@ on:
             - 'CRITICAL'
       upload_artifacts:
         description: 'Upload artifacts also on success (not only on failure)'
-        default: 'FALSE'
+        default: 'TRUE'
         type: choice
         options:
             - 'FALSE'

--- a/.github/workflows/run_testsuite_workflow.yml
+++ b/.github/workflows/run_testsuite_workflow.yml
@@ -21,8 +21,8 @@ on:
         required: false
         type: string
       upload_artifacts:
-          description: 'TRUE or FALSE (Default: FALSE -> Upload only when the workflow fails)'
-          default: 'FALSE'
+          description: 'TRUE or FALSE (FALSE -> Upload only when the workflow fails)'
+          default: 'TRUE'
           type: string
 jobs:
   run_testsuite:


### PR DESCRIPTION
Until users of the system tests form a mental model of how the tests work and what they do, I think it would be useful to keep this option enabled by default.