### PR TITLE
Name uploaded artifacts based on run id and attempt

### DIFF
--- a/.github/workflows/generate_reference_results_workflow.yml
+++ b/.github/workflows/generate_reference_results_workflow.yml
@@ -71,6 +71,6 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: runs
+        name: system_tests_run_${{ github.run_id }}_${{ github.run_number }}_reference
         path: |
           runs/*

--- a/.github/workflows/generate_reference_results_workflow.yml
+++ b/.github/workflows/generate_reference_results_workflow.yml
@@ -71,6 +71,6 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: system_tests_run_${{ github.run_id }}_${{ github.run_number }}_reference
+        name: system_tests_run_${{ github.run_id }}_${{ github.run_attempt }}_reference
         path: |
           runs/*

--- a/.github/workflows/run_testsuite_workflow.yml
+++ b/.github/workflows/run_testsuite_workflow.yml
@@ -65,7 +65,7 @@ jobs:
       if: ${{  failure() || inputs.upload_artifacts == 'TRUE' }}
       uses: actions/upload-artifact@v4
       with:
-        name: runs
+        name: system_tests_run_${{ github.run_id }}_${{ github.run_number }}
         path: |
           runs/*
     - name: tidy up the docker

--- a/.github/workflows/run_testsuite_workflow.yml
+++ b/.github/workflows/run_testsuite_workflow.yml
@@ -65,7 +65,7 @@ jobs:
       if: ${{  failure() || inputs.upload_artifacts == 'TRUE' }}
       uses: actions/upload-artifact@v4
       with:
-        name: system_tests_run_${{ github.run_id }}_${{ github.run_number }}
+        name: system_tests_run_${{ github.run_id }}_${{ github.run_attempt }}
         path: |
           runs/*
     - name: tidy up the docker


### PR DESCRIPTION
The archives are currently named `runs.zip`, which is vague and always the same, without including any information to find out more information about the origin of the file.

This PR:

- adds context that this comes from the system tests
- adds the `run_id` and the `run_attempt` in the name to make each archive unique
- uses this information instead of datetime as:
  - datetime requires more effort to extract and is more fragile
  - the `run_id` is the part that appears in the URL, so the user can find the job again
- distinguishes between a normal run and a run that generates reference results, but keeps the lexicographic order based on the run id.  