### PR TITLE
Add a workflow for running the system tests nightly

### DIFF
--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -1,0 +1,101 @@
+name: System tests (latest components)
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    
+jobs:
+  gather-refs:
+    name: Map Git branches to latest refs
+    if: ${{ github.event.label.name == 'trigger-system-tests' }}
+    runs-on: ubuntu-latest
+    outputs:
+      ref-precice: ${{ steps.ref-precice.outputs.shorthash }}
+      ref-python-bindings: ${{ steps.ref-python-bindings.outputs.shorthash }}
+      ref-calculix-adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}
+      ref-fenics-adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}
+      ref-openfoam-adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }}
+      ref-su2-adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}
+      ref-tutorials: ${{ steps.ref-tutorials.outputs.shorthash }}
+    steps:
+      - id: ref-precice
+        name: Get preCICE ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: precice
+          branch: develop
+      - id: ref-python-bindings
+        name: Get Python bindings ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: python-bindings
+          branch: develop
+      - id: ref-calculix-adapter
+        name: Get CalculiX adapter ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: calculix-adapter
+          branch: develop
+      - id: ref-fenics-adapter
+        name: Get FEniCS adapter ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: fenics-adapter
+          branch: develop
+      - id: ref-openfoam-adapter
+        name: Get OpenFOAM adapter ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: openfoam-adapter
+          branch: develop
+      - id: ref-su2-adapter
+        name: Get SU2 adapter ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: su2-adapter
+          branch: develop
+      - id: ref-tutorials
+        name: Get tutorials ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: tutorials
+          branch: develop
+      - id: report-refs
+        name: Report Git refs
+        run: |
+          printf 'preCICE: ${{ steps.ref-precice.outputs.shorthash }}\n ${{ steps.ref-precice.outputs.description }}\n----------\n'
+          printf 'Python bindings: ${{ steps.ref-python-bindings.outputs.shorthash }}\n ${{ steps.ref-python-bindings.outputs.description }}\n----------\n'
+          printf 'CalculiX adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}\n ${{ steps.ref-calculix-adapter.outputs.description }}\n----------\n'
+          printf 'FEniCS adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}\n ${{ steps.ref-fenics-adapter.outputs.description }}\n----------\n'
+          printf 'OpenFOAM adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }} ${{ steps.ref-openfoam-adapter.outputs.description }}\n----------\n'
+          printf 'SU2 adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}\n ${{ steps.ref-su2-adapter.outputs.description }}\n----------\n'
+          printf 'Tutorials: ${{ steps.ref-tutorials.outputs.shorthash }} ${{ steps.ref-tutorials.outputs.description }}\n----------\n'
+
+  run-system-tests:
+    name: Trigger system tests
+    if: ${{ github.event.label.name == 'trigger-system-tests' }}
+    needs: gather-refs
+    uses: precice/tutorials/.github/workflows/run_testsuite_workflow.yml@develop
+    with:
+      suites: release_test
+      build_args: "PLATFORM:ubuntu_2404,\
+        PRECICE_REF:${{ needs.gather-refs.outputs.ref-precice }},\
+        PYTHON_BINDINGS_REF:${{ needs.gather-refs.outputs.ref-python-bindings }},\
+        CALCULIX_VERSION:2.20,\
+        CALCULIX_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-calculix-adapter }},\
+        FENICS_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-fenics-adapter }},\
+        OPENFOAM_EXECUTABLE:openfoam2312,\
+        OPENFOAM_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-openfoam-adapter }},\
+        SU2_VERSION:7.5.1,\
+        SU2_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-su2-adapter }},\
+        TUTORIALS_REF:${{ needs.gather-refs.outputs.ref-tutorials }}"
+      systests_branch: develop
+      loglevel: "INFO"

--- a/changelog-entries/631.md
+++ b/changelog-entries/631.md
@@ -1,0 +1,1 @@
+- Added a workflow to run the system tests nightly [#631](https://github.com/precice/tutorials/pull/631)


### PR DESCRIPTION
This adds a workflow to run the system tests with the latest state of each involved component. The workflow is triggered every night at 4am, or manually.

I add this here and not in the preCICE repository, as this repository is the consumer of all and defines the related infrastructure. We still need some way to notify the maintainers in case of failure (this is a bit complicated, let's do it in a separate PR).

While we already have a fully-customizable, manual workflow, this allows to just click a button and test the latest state of everything. As such, we can say it closes #552.

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
