### PR TITLE
Read initial pressure from end of time window

### DIFF
--- a/elastic-tube-1d/solid-python/SolidSolver.py
+++ b/elastic-tube-1d/solid-python/SolidSolver.py
@@ -65,7 +65,8 @@ print("Solid: init precice...")
 interface.initialize()
 
 # Calculate initial crossSection and local pressure from initial received pressure
-pressure = interface.read_data(meshName, pressureName, vertexIDs, 0)
+precice_dt = interface.get_max_time_step_size()
+pressure = interface.read_data(meshName, pressureName, vertexIDs, precice_dt)
 
 crossSection0 = crossSection0(pressure.shape[0] - 1)
 pressure0 = p0 * np.ones_like(pressure)


### PR DESCRIPTION
Potential fix for systemtests regression

Compare run: https://github.com/precice/tutorials/actions/runs/14035646677

<!-- Please submit your Pull Request to the `develop` branch.

It may help to have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
