### PR TITLE
Enforce recomputation of preconditioner to avoid regression

### DIFF
--- a/changelog-entries/634.md
+++ b/changelog-entries/634.md
@@ -1,0 +1,1 @@
+- Changed the IQN settings in the elastic-tube-1d and perpendicular flap tutorials to enforce recomputation of the preconditioner [#634](https://github.com/precice/tutorials/pull/634)

--- a/elastic-tube-1d/precice-config.xml
+++ b/elastic-tube-1d/precice-config.xml
@@ -63,6 +63,7 @@
     <acceleration:IQN-ILS>
       <data name="CrossSectionLength" mesh="Solid-Nodes-Mesh" />
       <initial-relaxation value="0.01" />
+      <preconditioner type="residual-sum" update-on-threshold="false" />
       <max-used-iterations value="50" />
       <time-windows-reused value="8" />
       <filter type="QR2" limit="1e-3" />

--- a/perpendicular-flap/precice-config.xml
+++ b/perpendicular-flap/precice-config.xml
@@ -56,7 +56,7 @@
     <acceleration:IQN-ILS>
       <data name="Displacement" mesh="Solid-Mesh" />
       <data name="Force" mesh="Solid-Mesh" />
-      <preconditioner type="residual-sum" />
+      <preconditioner type="residual-sum" update-on-threshold="false" />
       <filter type="QR2" limit="1e-2" />
       <initial-relaxation value="0.5" />
       <max-used-iterations value="100" />


### PR DESCRIPTION
This could avoid the regression originatting from https://github.com/precice/precice/pull/1493.
Makes sense to for the perpendicular flap, but I don't yet understand the 1D elastic tube, as there, a preconditioner should make no difference (one data field in acc only). 

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
