### PR TITLE
System tests: Rename inconsistent workflow variables

### DIFF
--- a/.github/workflows/generate_reference_results_manual.yml
+++ b/.github/workflows/generate_reference_results_manual.yml
@@ -10,8 +10,8 @@ on:
         description: 'Commit msg for commit that adds the reference results'
         default: "Adding reference results"
         type: string
-      loglevel:
-        description: 'loglevel used for the systemtests'
+      log_level:
+        description: 'Logging verbosity level used for the systemtests'
         default: 'INFO'
         required: true
         type: choice
@@ -28,4 +28,4 @@ jobs:
     with: 
       from_ref: ${{ inputs.from_ref }}
       commit_msg: ${{ inputs.commit_msg }}
-      loglevel: ${{ inputs.loglevel }}
+      log_level: ${{ inputs.log_level }}

--- a/.github/workflows/generate_reference_results_workflow.yml
+++ b/.github/workflows/generate_reference_results_workflow.yml
@@ -36,7 +36,7 @@ jobs:
         rm -rf ./*
         rm -rf ./.??*
         ls -la ./
-    - name: Check out Tutorials for systest
+    - name: Check out Tutorials for the system tests (tools/tests/)
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.from_ref }}

--- a/.github/workflows/generate_reference_results_workflow.yml
+++ b/.github/workflows/generate_reference_results_workflow.yml
@@ -10,8 +10,8 @@ on:
         description: 'Commit msg for commit that adds the reference results'
         default: "Adding reference results"
         type: string
-      loglevel:
-        description: 'loglevel used for the systemtests'
+      log_level:
+        description: 'Logging verbosity level used for the systemtests'
         default: 'INFO'
         required: true
         type: string
@@ -22,7 +22,7 @@ jobs:
     - name: Display a quick job summary
       run: |
         echo "Initiated by: ${{ github.actor }}"
-        echo "Running generate_reference_results.py --log-level ${{inputs.loglevel}}"
+        echo "Running generate_reference_results.py --log-level ${{inputs.log_level}}"
         echo "Using Ref: ${{ inputs.from_ref }}"
         echo "Commit message on success:  ${{ inputs.commit_msg }}"
     - name: Move LFS URL to local LFS server
@@ -56,7 +56,7 @@ jobs:
         test -f generate_reference_results.py && export GENERATE_REF_RESULTS=generate_reference_results.py
         test -f generate_reference_data.py && export GENERATE_REF_RESULTS=generate_reference_data.py
         echo "Selected $GENERATE_REF_RESULTS to run"
-        python $GENERATE_REF_RESULTS --log-level=${{inputs.loglevel}}
+        python $GENERATE_REF_RESULTS --log-level=${{inputs.log_level}}
         cd ../../
     - name: Create commit
       if: success()

--- a/.github/workflows/run_testsuite_manual.yml
+++ b/.github/workflows/run_testsuite_manual.yml
@@ -10,8 +10,8 @@ on:
         description: 'Build arguments, if not specified defaults will be taken'
         required: false
         type: string
-      systests_branch:
-        description: 'Branch to take the systest from'
+      system_tests_branch:
+        description: 'Branch to take the system tests from (tools/tests/)'
         default: 'develop'
         required: true
         type: string
@@ -40,6 +40,6 @@ jobs:
     with: 
       suites: ${{ inputs.suites }}
       build_args: ${{ inputs.build_args }}
-      systests_branch: ${{ inputs.systests_branch }}
+      system_tests_branch: ${{ inputs.system_tests_branch }}
       log_level: ${{ inputs.log_level }}
       upload_artifacts: ${{ inputs.upload_artifacts }}

--- a/.github/workflows/run_testsuite_manual.yml
+++ b/.github/workflows/run_testsuite_manual.yml
@@ -15,8 +15,8 @@ on:
         default: 'develop'
         required: true
         type: string
-      loglevel:
-        description: 'loglevel used for the systemtests'
+      log_level:
+        description: 'Logging verbosity level used for the systemtests'
         default: 'INFO'
         required: true
         type: choice
@@ -41,5 +41,5 @@ jobs:
       suites: ${{ inputs.suites }}
       build_args: ${{ inputs.build_args }}
       systests_branch: ${{ inputs.systests_branch }}
-      loglevel: ${{ inputs.loglevel }}
+      log_level: ${{ inputs.log_level }}
       upload_artifacts: ${{ inputs.upload_artifacts }}

--- a/.github/workflows/run_testsuite_workflow.yml
+++ b/.github/workflows/run_testsuite_workflow.yml
@@ -10,8 +10,8 @@ on:
         description: 'Build arguments'
         required: false
         type: string
-      systests_branch:
-        description: 'Branch to take the systest from'
+      system_tests_branch:
+        description: 'Branch to take the system tests from'
         default: 'develop'
         required: true
         type: string
@@ -32,7 +32,7 @@ jobs:
       run: |
         echo "Initiated by: ${{ github.actor }}"
         echo "Test suites: ${{ inputs.suites}}"
-        echo "System tests branch (tools/): ${{ inputs.systests_branch }}"
+        echo "System tests branch (tools/): ${{ inputs.system_tests_branch }}"
         echo "System tests log level: ${{ inputs.log_level }}"
         echo "Uploading the runs folder on success: ${{ inputs.upload_artifacts }}"
         echo "Running the following command inside tutorials/tools/:"
@@ -42,7 +42,7 @@ jobs:
         echo "Job inputs:"
         echo "- Initiated by: @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
         echo "- Test suites: \`${{ inputs.suites}}\`" >> $GITHUB_STEP_SUMMARY
-        echo "- System tests branch (\`tools/\`): [\`${{ inputs.systests_branch }}\`](https://github.com/precice/tutorials/tree/${{ inputs.systests_branch }})" >> $GITHUB_STEP_SUMMARY
+        echo "- System tests branch (\`tools/\`): [\`${{ inputs.system_tests_branch }}\`](https://github.com/precice/tutorials/tree/${{ inputs.system_tests_branch }})" >> $GITHUB_STEP_SUMMARY
         echo "- System tests log level: \`${{ inputs.log_level }}\`"
         echo "- Uploading the runs folder on success: \`${{ inputs.upload_artifacts }}\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -59,11 +59,11 @@ jobs:
         rm -rf ./*
         rm -rf ./.??*
         ls -la ./
-    - name: Check out Tutorials for systest
+    - name: Check out Tutorials for them system tests (tools/tests/)
       uses: actions/checkout@v4
       with:
         repository: precice/tutorials
-        ref: ${{ inputs.systests_branch }}
+        ref: ${{ inputs.system_tests_branch }}
         lfs: true
         fetch-depth: 0
     - name: Map remote branches to local ones

--- a/.github/workflows/run_testsuite_workflow.yml
+++ b/.github/workflows/run_testsuite_workflow.yml
@@ -15,8 +15,8 @@ on:
         default: 'develop'
         required: true
         type: string
-      loglevel:
-        description: 'loglevel used for the systemtests'
+      log_level:
+        description: 'Logging verbosity level used for the systemtests'
         default: 'INFO'
         required: false
         type: string
@@ -33,7 +33,7 @@ jobs:
         echo "Initiated by: ${{ github.actor }}"
         echo "Test suites: ${{ inputs.suites}}"
         echo "System tests branch (tools/): ${{ inputs.systests_branch }}"
-        echo "System tests log level: ${{ inputs.loglevel }}"
+        echo "System tests log level: ${{ inputs.log_level }}"
         echo "Uploading the runs folder on success: ${{ inputs.upload_artifacts }}"
         echo "Running the following command inside tutorials/tools/:"
         echo "python3 systemtests.py --build_args=${{inputs.build_args}} --suites=${{ inputs.suites}}"
@@ -43,7 +43,7 @@ jobs:
         echo "- Initiated by: @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
         echo "- Test suites: \`${{ inputs.suites}}\`" >> $GITHUB_STEP_SUMMARY
         echo "- System tests branch (\`tools/\`): [\`${{ inputs.systests_branch }}\`](https://github.com/precice/tutorials/tree/${{ inputs.systests_branch }})" >> $GITHUB_STEP_SUMMARY
-        echo "- System tests log level: \`${{ inputs.loglevel }}\`"
+        echo "- System tests log level: \`${{ inputs.log_level }}\`"
         echo "- Uploading the runs folder on success: \`${{ inputs.upload_artifacts }}\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "Running the following command inside \`tutorials/tools/\`:" >> $GITHUB_STEP_SUMMARY
@@ -75,7 +75,7 @@ jobs:
     - name: Run tests
       run: |
         cd tools/tests
-        python systemtests.py --build_args=${{ inputs.build_args}} --suites=${{ inputs.suites}} --log-level=${{ inputs.loglevel}}
+        python systemtests.py --build_args=${{ inputs.build_args}} --suites=${{ inputs.suites}} --log-level=${{ inputs.log_level}}
         cd ../../
     - name: Archive run files
       if: ${{  failure() || inputs.upload_artifacts == 'TRUE' }}

--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -142,4 +142,4 @@ jobs:
         SU2_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-su2-adapter }},\
         TUTORIALS_REF:${{ needs.gather-refs.outputs.ref-tutorials }}"
       systests_branch: develop
-      loglevel: "INFO"
+      log_level: "INFO"

--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -141,5 +141,5 @@ jobs:
         SU2_VERSION:7.5.1,\
         SU2_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-su2-adapter }},\
         TUTORIALS_REF:${{ needs.gather-refs.outputs.ref-tutorials }}"
-      systests_branch: develop
+      system_tests_branch: develop
       log_level: "INFO"

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -100,7 +100,7 @@ In this case, building and running seems to work out, but the tests fail because
 ## Understanding what went wrong
 
 The easiest way to debug a systemtest run is first to have a look at the output written into the action on GitHub.
-If this does not provide enough hints, the next step is to download the generated `system_tests_run_<jobid>_<attempt>` artifact. Note that by default this will only be generated if the systemtests fail.
+If this does not provide enough hints, the next step is to download the generated `system_tests_run_<run_id>_<run_attempt>` artifact. Note that by default this will only be generated if the systemtests fail.
 Inside the archive, a test-specific subfolder like `flow-over-heated-plate_fluid-openfoam-solid-fenics_2023-11-19-211723` contains two log files: a `stderr.log` and `stdout.log`. This can be a starting point for a further investigation.
 
 ## Adding new tests

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -61,7 +61,7 @@ gh workflow run run_testsuite_manual.yml -f suites=fenics_test --ref=develop
 Another example, to use the latest releases and enable debug information of the tests:
 
 ```shell
-gh workflow run run_testsuite_manual.yml -f suites=fenics_test -f build_args="PRECICE_REF:v3.1.1,PRECICE_PRESET:production-audit,OPENFOAM_ADAPTER_REF:v1.3.0,PYTHON_BINDINGS_REF:v3.1.0,FENICS_ADAPTER_REF:v2.1.0,SU2_VERSION:7.5.1,SU2_ADAPTER_REF:64d4aff,TUTORIALS_REF:340b447" -f loglevel=DEBUG --ref=develop
+gh workflow run run_testsuite_manual.yml -f suites=fenics_test -f build_args="PRECICE_REF:v3.1.1,PRECICE_PRESET:production-audit,OPENFOAM_ADAPTER_REF:v1.3.0,PYTHON_BINDINGS_REF:v3.1.0,FENICS_ADAPTER_REF:v2.1.0,SU2_VERSION:7.5.1,SU2_ADAPTER_REF:64d4aff,TUTORIALS_REF:340b447" -f log_level=DEBUG --ref=develop
 ```
 
 where the `*_REF` should be a specific [commit-ish](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefcommit-ishacommit-ishalsocommittish).
@@ -100,7 +100,7 @@ In this case, building and running seems to work out, but the tests fail because
 ## Understanding what went wrong
 
 The easiest way to debug a systemtest run is first to have a look at the output written into the action on GitHub.
-If this does not provide enough hints, the next step is to download the generated `runs` artifact. Note that by default this will only be generated if the systemtests fail.
+If this does not provide enough hints, the next step is to download the generated `system_tests_run_<jobid>_<attempt>` artifact. Note that by default this will only be generated if the systemtests fail.
 Inside the archive, a test-specific subfolder like `flow-over-heated-plate_fluid-openfoam-solid-fenics_2023-11-19-211723` contains two log files: a `stderr.log` and `stdout.log`. This can be a starting point for a further investigation.
 
 ## Adding new tests


### PR DESCRIPTION
Renames a couple of variables in the workflows that have inconsistent names:

- `loglevel` -> `log_level`
- `systests_branch` -> `system_tests_branch` (and with this, the term `systest` does not appear anywhere anymore)

Also updates the name of the build artifact in the documentation (from `runs` -> `system_tests_run_<run_id>_<run_attempt>`

This will require updates in other repositories that call this workflow. I will update them. (FYI @BenjaminRodenberg)