### PR TITLE
Add a pull request label trigger for the system tests

### DIFF
--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -1,0 +1,132 @@
+name: System tests (PR)
+
+on:
+  pull_request:
+    types: [labeled]
+    
+jobs:
+  gather-refs:
+    name: Map Git branches to latest refs
+    runs-on: ubuntu-latest
+    outputs:
+      ref-precice: ${{ steps.ref-precice.outputs.shorthash }}
+      ref-python-bindings: ${{ steps.ref-python-bindings.outputs.shorthash }}
+      ref-calculix-adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}
+      ref-fenics-adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}
+      ref-openfoam-adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }}
+      ref-su2-adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}
+    steps:
+      - id: ref-precice
+        name: Get preCICE ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: precice
+          branch: develop
+      - id: ref-python-bindings
+        name: Get Python bindings ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: python-bindings
+          branch: develop
+      - id: ref-calculix-adapter
+        name: Get CalculiX adapter ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: calculix-adapter
+          branch: develop
+      - id: ref-fenics-adapter
+        name: Get FEniCS adapter ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: fenics-adapter
+          branch: develop
+      - id: ref-openfoam-adapter
+        name: Get OpenFOAM adapter ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: openfoam-adapter
+          branch: develop
+      - id: ref-su2-adapter
+        name: Get SU2 adapter ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: su2-adapter
+          branch: develop
+      - id: report-refs
+        name: Report Git refs
+        run: |
+          printf 'preCICE: ${{ steps.ref-precice.outputs.shorthash }}\n ${{ steps.ref-precice.outputs.description }}\n----------\n'
+          printf 'Python bindings: ${{ steps.ref-python-bindings.outputs.shorthash }}\n ${{ steps.ref-python-bindings.outputs.description }}\n----------\n'
+          printf 'CalculiX adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}\n ${{ steps.ref-calculix-adapter.outputs.description }}\n----------\n'
+          printf 'FEniCS adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}\n ${{ steps.ref-fenics-adapter.outputs.description }}\n----------\n'
+          printf 'OpenFOAM adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }} ${{ steps.ref-openfoam-adapter.outputs.description }}\n----------\n'
+          printf 'SU2 adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}\n ${{ steps.ref-su2-adapter.outputs.description }}\n----------\n'
+      - id: summary
+        name: Prepare Markdown summary
+        run: |
+          echo "## Git references of latest (develop) components" >> $GITHUB_STEP_SUMMARY
+          echo "### preCICE" >> $GITHUB_STEP_SUMMARY
+          echo "Reference: [\`${{ steps.ref-precice.outputs.shorthash }}\`](https://github.com/precice/precice/commit/${{ steps.ref-precice.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          echo "Description:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.ref-precice.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "### Python bindings" >> $GITHUB_STEP_SUMMARY
+          echo "Reference: [\`${{ steps.ref-python-bindings.outputs.shorthash }}\`](https://github.com/precice/python-bindings/commit/${{ steps.ref-python-bindings.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          echo "Description:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.ref-python-bindings.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "### CalculiX adapter" >> $GITHUB_STEP_SUMMARY
+          echo "Reference: [\`${{ steps.ref-calculix-adapter.outputs.shorthash }}\`](https://github.com/precice/calculix-adapter/commit/${{ steps.ref-calculix-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          echo "Description:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.ref-calculix-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "### FEniCS adapter" >> $GITHUB_STEP_SUMMARY
+          echo "Reference: [\`${{ steps.ref-fenics-adapter.outputs.shorthash }}\`](https://github.com/precice/fenics-adapter/commit/${{ steps.ref-fenics-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          echo "Description:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.ref-fenics-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "### OpenFOAM adapter" >> $GITHUB_STEP_SUMMARY
+          echo "Reference: [\`${{ steps.ref-openfoam-adapter.outputs.shorthash }}\`](https://github.com/precice/openfoam-adapter/commit/${{ steps.ref-openfoam-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          echo "Description:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.ref-openfoam-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "### SU2 adapter" >> $GITHUB_STEP_SUMMARY
+          echo "Reference: [\`${{ steps.ref-su2-adapter.outputs.shorthash }}\`](https://github.com/precice/su2-adapter/commit/${{ steps.ref-su2-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          echo "Description:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.ref-su2-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "### Tutorials" >> $GITHUB_STEP_SUMMARY
+          echo "Reference (pull request): \`${{ github.event.pull_request.head.sha }}\`" >> $GITHUB_STEP_SUMMARY
+
+  run-system-tests:
+    name: Trigger system tests
+    if: ${{ github.event.label.name == 'trigger-system-tests' }}
+    needs: gather-refs
+    uses: precice/tutorials/.github/workflows/run_testsuite_workflow.yml@develop
+    with:
+      suites: release_test
+      build_args: "PLATFORM:ubuntu_2404,\
+        PRECICE_REF:${{ needs.gather-refs.outputs.ref-precice }},\
+        PYTHON_BINDINGS_REF:${{ needs.gather-refs.outputs.ref-python-bindings }},\
+        CALCULIX_VERSION:2.20,\
+        CALCULIX_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-calculix-adapter }},\
+        FENICS_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-fenics-adapter }},\
+        OPENFOAM_EXECUTABLE:openfoam2312,\
+        OPENFOAM_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-openfoam-adapter }},\
+        SU2_VERSION:7.5.1,\
+        SU2_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-su2-adapter }},\
+        TUTORIALS_REF:${{ github.event.pull_request.head.sha }}"
+      system_tests_branch: develop
+      log_level: "INFO"


### PR DESCRIPTION
Adds a pull request label trigger, similarly to the workflow currently in `precice/precice` and `precice/openfoam-adapter`.

Trigger it by adding (or removing and re-adding) the `trigger-system-tests` label.

We start accumulating quite some duplication, but de-duplicating would be a larger project, which I don't want to start before we have converged on some baseline.

Closes #581.

Edit: The trigger works, I cancelled the run before in completes, because only the triggering was relevant.