### PR TITLE
Enable running the system tests in forks

### DIFF
--- a/.github/workflows/run_testsuite_workflow.yml
+++ b/.github/workflows/run_testsuite_workflow.yml
@@ -59,7 +59,7 @@ jobs:
         rm -rf ./*
         rm -rf ./.??*
         ls -la ./
-    - name: Check out Tutorials for them system tests (tools/tests/)
+    - name: Check out Tutorials for the system tests (tools/tests/)
       uses: actions/checkout@v4
       with:
         repository: precice/tutorials

--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -109,6 +109,7 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### Tutorials" >> $GITHUB_STEP_SUMMARY
           echo "Reference (pull request): \`${{ github.event.pull_request.head.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Pull request number: [${{ github.event.number }}](https://github.com/precice/tutorials/pull/${{ github.event.number }})" >> $GITHUB_STEP_SUMMARY
 
   run-system-tests:
     name: Trigger system tests
@@ -127,6 +128,7 @@ jobs:
         OPENFOAM_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-openfoam-adapter }},\
         SU2_VERSION:7.5.1,\
         SU2_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-su2-adapter }},\
+        TUTORIALS_PR:${{ github.event.number }},\
         TUTORIALS_REF:${{ github.event.pull_request.head.sha }}"
-      system_tests_branch: develop
-      log_level: "INFO"
+      system_tests_branch: test-forks
+      log_level: "DEBUG"

--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -130,5 +130,5 @@ jobs:
         SU2_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-su2-adapter }},\
         TUTORIALS_PR:${{ github.event.number }},\
         TUTORIALS_REF:${{ github.event.pull_request.head.sha }}"
-      system_tests_branch: test-forks
-      log_level: "DEBUG"
+      system_tests_branch: develop
+      log_level: "INFO"

--- a/changelog-entries/638.md
+++ b/changelog-entries/638.md
@@ -1,0 +1,1 @@
+- Added support for running the system tests in forks [#638](https://github.com/precice/tutorials/pull/638)

--- a/tools/tests/components.yaml
+++ b/tools/tests/components.yaml
@@ -2,15 +2,15 @@ bare: # A default component used when the solver does not have any dependencies 
   repository: https://github.com/precice/precice
   template: component-templates/bare.yaml
   build_arguments: # these things mean something to the docker-service
+    PLATFORM:
+      description: Dockerfile platform used
+      default: "ubuntu_2404"
     PRECICE_REF:
       description: Version of preCICE to use
       default: "main"
     PRECICE_PRESET:
       description: CMake preset of preCICE
       default: "production-audit"
-    PLATFORM:
-      description: Dockerfile platform used
-      default: "ubuntu_2404"
     TUTORIALS_REF:
       description: Tutorial git reference to use
       default: "master"
@@ -19,35 +19,35 @@ python-bindings:
   repository: https://github.com/precice/python-bindings
   template: component-templates/python-bindings.yaml
   build_arguments:
+    PLATFORM:
+      description: Dockerfile platform used
+      default: "ubuntu_2404"
     PRECICE_REF:
       description: Version of preCICE to use
       default: "main"
     PRECICE_PRESET:
       description: CMake preset of preCICE
       default: "production-audit"
-    PLATFORM:
-      description: Dockerfile platform used
-      default: "ubuntu_2404"
     TUTORIALS_REF:
       description: Tutorial git reference to use
       default: "master"
     PYTHON_BINDINGS_REF:
-      semnantic: Git ref of the pythonbindings to use
+      semnantic: Git ref of the Python bindings to use
       default: "master"
 
 openfoam-adapter:
   repository: https://github.com/precice/openfoam-adapter
   template: component-templates/openfoam-adapter.yaml
   build_arguments:
+    PLATFORM:
+      description: Dockerfile platform used
+      default: "ubuntu_2404"
     PRECICE_REF:
       description: Version of preCICE to use
       default: "main"
     PRECICE_PRESET:
       description: CMake preset of preCICE
       default: "production-audit"
-    PLATFORM:
-      description: Dockerfile platform used
-      default: "ubuntu_2404"
     TUTORIALS_REF:
       description: Tutorial git reference to use
       default: "master"
@@ -56,28 +56,27 @@ openfoam-adapter:
       description: exectuable of openfoam to use
       default: "openfoam2306"
     OPENFOAM_ADAPTER_REF:
-      description: Reference/tag of the actual OpenFOAM adapter
+      description: Reference/tag of the OpenFOAM adapter to use
       default: "master"
 
-    
 fenics-adapter:
   repository: https://github.com/precice/fenics-adapter
   template: component-templates/fenics-adapter.yaml
   build_arguments:
+    PLATFORM:
+      description: Dockerfile platform used
+      default: "ubuntu_2404"
     PRECICE_REF:
       description: Version of preCICE to use
       default: "main"
     PRECICE_PRESET:
       description: CMake preset of preCICE
       default: "production-audit"
-    PLATFORM:
-      description: Dockerfile platform used
-      default: "ubuntu_2404"
     TUTORIALS_REF:
       description: Tutorial git reference to use
       default: "master"
     PYTHON_BINDINGS_REF:
-      semnantic: Git ref of the pythonbindings to use
+      semnantic: Git ref of the Python bindings to use
       default: "master"
     FENICS_ADAPTER_REF:
       semnantic: Git ref of the fenics adapter to use
@@ -87,35 +86,35 @@ nutils-adapter:
   repository: https://github.com/precice/nutils-adapter
   template: component-templates/nutils-adapter.yaml
   build_arguments:
+    PLATFORM:
+      description: Dockerfile platform used
+      default: "ubuntu_2404"
     PRECICE_REF:
       description: Version of preCICE to use
       default: "main"
     PRECICE_PRESET:
       description: CMake preset of preCICE
       default: "production-audit"
-    PLATFORM:
-      description: Dockerfile platform used
-      default: "ubuntu_2404"
     TUTORIALS_REF:
       description: Tutorial git reference to use
       default: "master"
     PYTHON_BINDINGS_REF:
-      semnantic: Git ref of the pythonbindings to use
-
+      semnantic: Git ref of the Python bindings to use
+      default: "master"
 
 calculix-adapter:
   repository: https://github.com/precice/calculix-adapter
   template: component-templates/calculix-adapter.yaml
   build_arguments:
+    PLATFORM:
+      description: Dockerfile platform used
+      default: "ubuntu_2404"
     PRECICE_REF:
       description: Version of preCICE to use
       default: "main"
     PRECICE_PRESET:
       description: CMake preset of preCICE
       default: "production-audit"
-    PLATFORM:
-      description: Dockerfile platform used
-      default: "ubuntu_2404"
     TUTORIALS_REF:
       description: Tutorial git reference to use
       default: "master"
@@ -130,15 +129,15 @@ su2-adapter:
   repository: https://github.com/precice/su2-adapter
   template: component-templates/su2-adapter.yaml
   build_arguments:
+    PLATFORM:
+      description: Dockerfile platform used
+      default: "ubuntu_2404"
     PRECICE_REF:
       description: Version of preCICE to use
       default: "main"
     PRECICE_PRESET:
       description: CMake preset of preCICE
       default: "production-audit"
-    PLATFORM:
-      description: Dockerfile platform used
-      default: "ubuntu_2404"
     TUTORIALS_REF:
       description: Tutorial git reference to use
       default: "master"

--- a/tools/tests/dockerfiles/ubuntu_2204/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2204/Dockerfile
@@ -47,12 +47,14 @@ RUN python3 -m pip install --user --upgrade pip
 
 FROM precice_dependecies AS precice
 # Install & build precice into /home/precice/precice
+ARG PRECICE_PR
 ARG PRECICE_REF
 ARG PRECICE_PRESET
 USER precice
 WORKDIR /home/precice
 RUN git clone https://github.com/precice/precice.git precice && \
     cd precice && \
+    if [ -n "${PRECICE_PR}" ]; then git fetch origin pull/${PRECICE_PR}/head; fi && \
     git checkout ${PRECICE_REF} && \
     mkdir build && cd build &&\
     cmake .. --preset=${PRECICE_PRESET} -DCMAKE_INSTALL_PREFIX=/home/precice/.local/ -DPRECICE_PETScMapping=OFF -DBUILD_TESTING=OFF && \
@@ -67,12 +69,14 @@ RUN apt-get update &&\
     ln -s $(which ${OPENFOAM_EXECUTABLE} ) /usr/bin/openfoam
 USER precice
 COPY --from=precice /home/precice/.local/ /home/precice/.local/
+ARG OPENFOAM_ADAPTER_PR
 ARG OPENFOAM_ADAPTER_REF
 # Build the OpenFOAM adapter 
 USER precice
 WORKDIR /home/precice
 RUN git clone https://github.com/precice/openfoam-adapter.git &&\
     cd openfoam-adapter && \
+    if [ -n "${OPENFOAM_ADAPTER_PR}" ]; then git fetch origin pull/${OPENFOAM_ADAPTER_PR}/head; fi && \
     git checkout ${OPENFOAM_ADAPTER_REF} && \
     /usr/bin/${OPENFOAM_EXECUTABLE} ./Allwmake -j $(nproc)
 
@@ -119,10 +123,12 @@ RUN wget http://www.dhondt.de/ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
     tar xvjf ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
     rm -fv ccx_${CALCULIX_VERSION}.src.tar.bz2
 
+ARG CALCULIX_ADAPTER_PR
 ARG CALCULIX_ADAPTER_REF
 WORKDIR /home/precice
 RUN git clone https://github.com/precice/calculix-adapter.git && \
     cd calculix-adapter && \
+    if [ -n "${CALCULIX_ADAPTER_PR}" ]; then git fetch origin pull/${CALCULIX_ADAPTER_PR}/head; fi && \
     git checkout ${CALCULIX_ADAPTER_REF} &&\
     make CXX_VERSION=${CALCULIX_VERSION} ADDITIONAL_FFLAGS="-fallow-argument-mismatch" -j $(nproc) && \
     ln -s /home/precice/calculix-adapter/bin/ccx_preCICE /home/precice/.local/bin/ccx_preCICE
@@ -141,6 +147,7 @@ RUN wget https://github.com/su2code/SU2/archive/refs/tags/v${SU2_VERSION}.tar.gz
     tar xvzf v${SU2_VERSION}.tar.gz && \
     rm -fv v${SU2_VERSION}.tar.gz
 RUN pip3 install --user mpi4py
+ARG SU2_ADAPTER_PR
 ARG SU2_ADAPTER_REF
 WORKDIR /home/precice
 ENV SU2_RUN="/home/precice/SU2_RUN" 
@@ -149,6 +156,7 @@ ENV PATH="/home/precice/su2-adapter/run:$SU2_RUN:$PATH"
 ENV PYTHONPATH="$SU2_RUN:$PYTHONPATH"
 RUN git clone https://github.com/precice/su2-adapter.git && \
     cd su2-adapter &&\
+    if [ -n "${SU2_ADAPTER_PR}" ]; then git fetch origin pull/${SU2_ADAPTER_PR}/head; fi && \
     git checkout ${SU2_ADAPTER_REF} &&\
     ./su2AdapterInstall
 RUN cd "${SU2_HOME}" &&\

--- a/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -45,12 +45,14 @@ USER precice
 
 FROM precice_dependecies AS precice
 # Install & build precice into /home/precice/precice
+ARG PRECICE_PR
 ARG PRECICE_REF
 ARG PRECICE_PRESET
 USER precice
 WORKDIR /home/precice
 RUN git clone https://github.com/precice/precice.git precice && \
     cd precice && \
+    if [ -n "${PRECICE_PR}" ]; then git fetch origin pull/${PRECICE_PR}/head; fi && \
     git checkout ${PRECICE_REF} && \
     mkdir build && cd build &&\
     cmake .. --preset=${PRECICE_PRESET} -DCMAKE_INSTALL_PREFIX=/home/precice/.local/ -DPRECICE_PETScMapping=OFF -DBUILD_TESTING=OFF && \
@@ -65,12 +67,14 @@ RUN apt-get update &&\
     ln -s $(which ${OPENFOAM_EXECUTABLE} ) /usr/bin/openfoam
 USER precice
 COPY --from=precice /home/precice/.local/ /home/precice/.local/
+ARG OPENFOAM_ADAPTER_PR
 ARG OPENFOAM_ADAPTER_REF
 # Build the OpenFOAM adapter 
 USER precice
 WORKDIR /home/precice
 RUN git clone https://github.com/precice/openfoam-adapter.git &&\
     cd openfoam-adapter && \
+    if [ -n "${OPENFOAM_ADAPTER_PR}" ]; then git fetch origin pull/${OPENFOAM_ADAPTER_PR}/head; fi && \
     git checkout ${OPENFOAM_ADAPTER_REF} && \
     /usr/bin/${OPENFOAM_EXECUTABLE} ./Allwmake -j $(nproc)
 
@@ -123,10 +127,12 @@ RUN wget http://www.dhondt.de/ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
     tar xvjf ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
     rm -fv ccx_${CALCULIX_VERSION}.src.tar.bz2
 
+ARG CALCULIX_ADAPTER_PR
 ARG CALCULIX_ADAPTER_REF
 WORKDIR /home/precice
 RUN git clone https://github.com/precice/calculix-adapter.git && \
     cd calculix-adapter && \
+    if [ -n "${CALCULIX_ADAPTER_PR}" ]; then git fetch origin pull/${CALCULIX_ADAPTER_PR}/head; fi && \
     git checkout ${CALCULIX_ADAPTER_REF} &&\
     make CXX_VERSION=${CALCULIX_VERSION} ADDITIONAL_FFLAGS="-fallow-argument-mismatch" -j $(nproc) && \
     ln -s /home/precice/calculix-adapter/bin/ccx_preCICE /home/precice/.local/bin/ccx_preCICE
@@ -147,6 +153,7 @@ RUN wget https://github.com/su2code/SU2/archive/refs/tags/v${SU2_VERSION}.tar.gz
     rm -fv v${SU2_VERSION}.tar.gz
 RUN python3 -m venv /home/precice/venv && \
     . /home/precice/venv/bin/activate
+ARG SU2_ADAPTER_PR
 ARG SU2_ADAPTER_REF
 WORKDIR /home/precice
 ENV SU2_RUN="/home/precice/SU2_RUN" 
@@ -155,6 +162,7 @@ ENV PATH="/home/precice/su2-adapter/run:$SU2_RUN:$PATH"
 ENV PYTHONPATH="$SU2_RUN:$PYTHONPATH"
 RUN git clone https://github.com/precice/su2-adapter.git && \
     cd su2-adapter &&\
+    if [ -n "${SU2_ADAPTER_PR}" ]; then git fetch origin pull/${SU2_ADAPTER_PR}/head; fi && \
     git checkout ${SU2_ADAPTER_REF} &&\
     ./su2AdapterInstall
 RUN cd "${SU2_HOME}" &&\


### PR DESCRIPTION
Forwards the PR number to the `systemtests.py`, which then forwards it to the `Dockerfile`, allowing a `git fetch origin pull/<pr>/head`.

In the `Systemtest.py` class, I had to remove a strict check (that every argument without a default value is provided), to keep the implementation relatively straight-forward.

Closes #580.

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
