### PR TITLE
Exports: Migrate from vtk to vtu

### DIFF
--- a/flow-over-heated-plate-nearest-projection/README.md
+++ b/flow-over-heated-plate-nearest-projection/README.md
@@ -75,7 +75,7 @@ From the preCICE point of view, the simulation here is in 3D, as opposed to the 
 ## Post-processing
 
 Have a look at the [flow-over heated-plate](https://precice.org/tutorials-flow-over-heated-plate.html) tutorial for the general aspects of post-processing.
-Since we now defined mesh connectivity on our interface, we can export the coupling interface with the tag `<export:vtk directory="precice-exports" />` in our `precice-config.xml`.
+Since we now defined mesh connectivity on our interface, we can export the coupling interface with the tag `<export:vtu directory="precice-exports" />` in our `precice-config.xml`.
 Visualizing these files (e.g. using ParaView) will show a triangular mesh, even though you use hexahedral meshes. This has nothing to do with your mesh and is just caused by the way the connectivity is defined in preCICE. As described above, the function `setMeshTriangles` is used to define the connectivity. Hence, every interface cell/face is represented by two triangles. The following image should give you an impression of a possible triangulated coupling mesh, which consists purely of hexahedral cells:
 
 ![triangulated](https://user-images.githubusercontent.com/33414590/55974257-96b07d80-5c87-11e9-9965-972b922c483d.png)

--- a/flow-over-heated-plate-nearest-projection/precice-config.xml
+++ b/flow-over-heated-plate-nearest-projection/precice-config.xml
@@ -47,7 +47,7 @@
     <provide-mesh name="Solid-Mesh-Centers" />
     <read-data name="Temperature" mesh="Solid-Mesh-Centers" />
     <write-data name="Heat-Flux" mesh="Solid-Mesh-Nodes" />
-    <!-- <export:vtk directory="precice-exports" /> -->
+    <!-- <export:vtu directory="precice-exports" /> -->
     <mapping:nearest-projection
       direction="read"
       from="Fluid-Mesh-Nodes"

--- a/flow-over-heated-plate/README.md
+++ b/flow-over-heated-plate/README.md
@@ -86,7 +86,7 @@ First generate the output for each run by adding export to the participant `Soli
 
 ```xml
 <participant name="Solid">
-  <export:vtk directory="precice-exports" />
+  <export:vtu directory="precice-exports" />
   <receive-mesh name="Fluid-Mesh" from="Fluid" />
   <provide-mesh name="Solid-Mesh" />
   ...

--- a/flow-over-heated-plate/precice-config.xml
+++ b/flow-over-heated-plate/precice-config.xml
@@ -35,7 +35,7 @@
   </participant>
 
   <participant name="Solid">
-    <export:vtk directory="precice-exports" />
+    <export:vtu directory="precice-exports" />
     <receive-mesh name="Fluid-Mesh" from="Fluid" />
     <provide-mesh name="Solid-Mesh" />
     <mapping:nearest-neighbor

--- a/quickstart/precice-config.xml
+++ b/quickstart/precice-config.xml
@@ -40,7 +40,7 @@
     <read-data name="Force" mesh="Solid-Mesh" />
     <write-data name="Displacement" mesh="Solid-Mesh" />
     <watch-point mesh="Solid-Mesh" name="Flap-Tip" coordinate="0.25;0.0" />
-    <export:vtk directory="precice-exports" />
+    <export:vtu directory="precice-exports" />
   </participant>
 
   <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />


### PR DESCRIPTION
Prevents the following error when running in parallel:

```
---[precice] ERROR:  You attempted to use the legacy VTK exporter with the parallel participant Solid, which isn't supported.Migrate to another exporter, such as the VTU exporter by specifying "<export:vtu ... />"  instead of "<export:vtk ... />".
```

Not sure if we can already change this in the system tests Docker Compose file as well. It currently just works.