### PR TITLE
OpenFOAM: Strictly require the preciceAdapterFunctionObject

### DIFF
--- a/breaking-dam-2d/fluid-openfoam/system/controlDict
+++ b/breaking-dam-2d/fluid-openfoam/system/controlDict
@@ -43,12 +43,12 @@ maxCo           2;
 maxAlphaCo      1;
 maxDeltaT       1;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/breaking-dam-2d/fluid-openfoam/system/controlDict
+++ b/breaking-dam-2d/fluid-openfoam/system/controlDict
@@ -49,5 +49,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/changelog-entries/642.md
+++ b/changelog-entries/642.md
@@ -1,0 +1,1 @@
+- Added the errors strict` option to cases using the OpenFOAM adapter (assumes OpenFOAM v2012 or later) [#642](https://github.com/precice/tutorials/pull/642).

--- a/channel-transport/fluid-openfoam/system/controlDict
+++ b/channel-transport/fluid-openfoam/system/controlDict
@@ -40,5 +40,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/channel-transport/fluid-openfoam/system/controlDict
+++ b/channel-transport/fluid-openfoam/system/controlDict
@@ -34,12 +34,12 @@ timeFormat      general;
 
 timePrecision   6;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/elastic-tube-3d/fluid-openfoam/system/controlDict
+++ b/elastic-tube-3d/fluid-openfoam/system/controlDict
@@ -39,12 +39,12 @@ runTimeModifiable false;
 
 adjustTimeStep no;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/elastic-tube-3d/fluid-openfoam/system/controlDict
+++ b/elastic-tube-3d/fluid-openfoam/system/controlDict
@@ -45,5 +45,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/flow-around-controlled-moving-cylinder/fluid-openfoam/system/controlDict
+++ b/flow-around-controlled-moving-cylinder/fluid-openfoam/system/controlDict
@@ -41,13 +41,13 @@ adjustTimeStep  no;
 
 maxCo           0.75;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
    #includeFunc forces
    preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/flow-around-controlled-moving-cylinder/fluid-openfoam/system/controlDict
+++ b/flow-around-controlled-moving-cylinder/fluid-openfoam/system/controlDict
@@ -48,5 +48,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/controlDict
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/controlDict
@@ -42,5 +42,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/controlDict
+++ b/flow-over-heated-plate-nearest-projection/fluid-openfoam/system/controlDict
@@ -36,12 +36,12 @@ timePrecision   6;
 
 runTimeModifiable false;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/flow-over-heated-plate-nearest-projection/solid-openfoam/system/controlDict
+++ b/flow-over-heated-plate-nearest-projection/solid-openfoam/system/controlDict
@@ -44,6 +44,7 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }
 

--- a/flow-over-heated-plate-partitioned-flow/fluid1-openfoam/system/controlDict
+++ b/flow-over-heated-plate-partitioned-flow/fluid1-openfoam/system/controlDict
@@ -43,5 +43,6 @@ functions
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/flow-over-heated-plate-partitioned-flow/fluid2-openfoam/system/controlDict
+++ b/flow-over-heated-plate-partitioned-flow/fluid2-openfoam/system/controlDict
@@ -43,5 +43,6 @@ functions
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/flow-over-heated-plate-partitioned-flow/solid-openfoam/system/controlDict
+++ b/flow-over-heated-plate-partitioned-flow/solid-openfoam/system/controlDict
@@ -44,5 +44,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/flow-over-heated-plate-steady-state/fluid-openfoam/system/controlDict
+++ b/flow-over-heated-plate-steady-state/fluid-openfoam/system/controlDict
@@ -40,5 +40,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/flow-over-heated-plate-steady-state/fluid-openfoam/system/controlDict
+++ b/flow-over-heated-plate-steady-state/fluid-openfoam/system/controlDict
@@ -34,12 +34,12 @@ timePrecision   6;
 
 runTimeModifiable false;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/flow-over-heated-plate-two-meshes/fluid-openfoam/system/controlDict
+++ b/flow-over-heated-plate-two-meshes/fluid-openfoam/system/controlDict
@@ -42,5 +42,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/flow-over-heated-plate-two-meshes/fluid-openfoam/system/controlDict
+++ b/flow-over-heated-plate-two-meshes/fluid-openfoam/system/controlDict
@@ -36,12 +36,12 @@ timePrecision   6;
 
 runTimeModifiable false;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/flow-over-heated-plate/fluid-openfoam/system/controlDict
+++ b/flow-over-heated-plate/fluid-openfoam/system/controlDict
@@ -42,5 +42,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/flow-over-heated-plate/solid-openfoam/system/controlDict
+++ b/flow-over-heated-plate/solid-openfoam/system/controlDict
@@ -51,6 +51,7 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }
 

--- a/heat-exchanger-simplified/fluid-bottom-openfoam/system/controlDict
+++ b/heat-exchanger-simplified/fluid-bottom-openfoam/system/controlDict
@@ -42,5 +42,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/heat-exchanger-simplified/fluid-bottom-openfoam/system/controlDict
+++ b/heat-exchanger-simplified/fluid-bottom-openfoam/system/controlDict
@@ -36,12 +36,12 @@ timePrecision   6;
 
 runTimeModifiable false;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/heat-exchanger-simplified/fluid-top-openfoam/system/controlDict
+++ b/heat-exchanger-simplified/fluid-top-openfoam/system/controlDict
@@ -42,5 +42,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/heat-exchanger-simplified/fluid-top-openfoam/system/controlDict
+++ b/heat-exchanger-simplified/fluid-top-openfoam/system/controlDict
@@ -36,12 +36,12 @@ timePrecision   6;
 
 runTimeModifiable false;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/heat-exchanger/fluid-inner-openfoam/system/controlDict
+++ b/heat-exchanger/fluid-inner-openfoam/system/controlDict
@@ -35,12 +35,12 @@ endTime             500;
 
 writeControl        timeStep;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/heat-exchanger/fluid-inner-openfoam/system/controlDict
+++ b/heat-exchanger/fluid-inner-openfoam/system/controlDict
@@ -41,5 +41,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/heat-exchanger/fluid-outer-openfoam/system/controlDict
+++ b/heat-exchanger/fluid-outer-openfoam/system/controlDict
@@ -35,12 +35,12 @@ endTime 500;
 
 writeControl timeStep;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/heat-exchanger/fluid-outer-openfoam/system/controlDict
+++ b/heat-exchanger/fluid-outer-openfoam/system/controlDict
@@ -41,5 +41,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/multiple-perpendicular-flaps/fluid-openfoam/system/controlDict
+++ b/multiple-perpendicular-flaps/fluid-openfoam/system/controlDict
@@ -35,12 +35,12 @@ timeFormat      general;
 
 timePrecision   6;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/multiple-perpendicular-flaps/fluid-openfoam/system/controlDict
+++ b/multiple-perpendicular-flaps/fluid-openfoam/system/controlDict
@@ -41,5 +41,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-backwards-facing-step/fluid1-openfoam/system/controlDict
+++ b/partitioned-backwards-facing-step/fluid1-openfoam/system/controlDict
@@ -38,11 +38,11 @@ runTimeModifiable false;
 
 
 libs ("libpreciceAdapterFunctionObject.so");
-        errors strict; // Available since OpenFOAM v2012
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-backwards-facing-step/fluid1-openfoam/system/controlDict
+++ b/partitioned-backwards-facing-step/fluid1-openfoam/system/controlDict
@@ -38,6 +38,7 @@ runTimeModifiable false;
 
 
 libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
 functions
 {
     preCICE_Adapter

--- a/partitioned-backwards-facing-step/fluid2-openfoam/system/controlDict
+++ b/partitioned-backwards-facing-step/fluid2-openfoam/system/controlDict
@@ -43,5 +43,6 @@ functions
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-heat-conduction/dirichlet-openfoam/system/controlDict
+++ b/partitioned-heat-conduction/dirichlet-openfoam/system/controlDict
@@ -47,5 +47,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-heat-conduction/dirichlet-openfoam/system/controlDict
+++ b/partitioned-heat-conduction/dirichlet-openfoam/system/controlDict
@@ -41,12 +41,12 @@ timePrecision   6;
 
 runTimeModifiable false;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-heat-conduction/neumann-openfoam/system/controlDict
+++ b/partitioned-heat-conduction/neumann-openfoam/system/controlDict
@@ -47,5 +47,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-heat-conduction/neumann-openfoam/system/controlDict
+++ b/partitioned-heat-conduction/neumann-openfoam/system/controlDict
@@ -41,12 +41,12 @@ timePrecision   6;
 
 runTimeModifiable false;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-pipe-two-phase/fluid1-openfoam/system/controlDict
+++ b/partitioned-pipe-two-phase/fluid1-openfoam/system/controlDict
@@ -51,5 +51,6 @@ functions
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-pipe-two-phase/fluid2-openfoam/system/controlDict
+++ b/partitioned-pipe-two-phase/fluid2-openfoam/system/controlDict
@@ -51,5 +51,6 @@ functions
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-pipe/fluid1-openfoam-pimplefoam/system/controlDict
+++ b/partitioned-pipe/fluid1-openfoam-pimplefoam/system/controlDict
@@ -40,5 +40,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-pipe/fluid1-openfoam-pimplefoam/system/controlDict
+++ b/partitioned-pipe/fluid1-openfoam-pimplefoam/system/controlDict
@@ -34,12 +34,12 @@ timeFormat      general;
 
 timePrecision   6;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/system/controlDict
+++ b/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/system/controlDict
@@ -40,5 +40,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/system/controlDict
+++ b/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/system/controlDict
@@ -34,12 +34,12 @@ timeFormat      general;
 
 timePrecision   6;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-pipe/fluid2-openfoam-pimplefoam/system/controlDict
+++ b/partitioned-pipe/fluid2-openfoam-pimplefoam/system/controlDict
@@ -35,12 +35,12 @@ timeFormat      general;
 
 timePrecision   6;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-pipe/fluid2-openfoam-pimplefoam/system/controlDict
+++ b/partitioned-pipe/fluid2-openfoam-pimplefoam/system/controlDict
@@ -41,5 +41,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/system/controlDict
+++ b/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/system/controlDict
@@ -40,5 +40,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/system/controlDict
+++ b/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/system/controlDict
@@ -34,12 +34,12 @@ timeFormat      general;
 
 timePrecision   6;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/perpendicular-flap/fluid-openfoam/system/controlDict
+++ b/perpendicular-flap/fluid-openfoam/system/controlDict
@@ -35,12 +35,12 @@ timeFormat      general;
 
 timePrecision   6;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/perpendicular-flap/fluid-openfoam/system/controlDict
+++ b/perpendicular-flap/fluid-openfoam/system/controlDict
@@ -41,5 +41,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/perpendicular-flap/solid-openfoam/system/controlDict
+++ b/perpendicular-flap/solid-openfoam/system/controlDict
@@ -43,6 +43,7 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }
 

--- a/perpendicular-flap/solid-openfoam/system/controlDict
+++ b/perpendicular-flap/solid-openfoam/system/controlDict
@@ -37,12 +37,12 @@ timeFormat      general;
 
 timePrecision   6;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/perpendicular-flap/solid-solids4foam/system/controlDict
+++ b/perpendicular-flap/solid-solids4foam/system/controlDict
@@ -35,12 +35,12 @@ timeFormat      general;
 
 timePrecision   6;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/perpendicular-flap/solid-solids4foam/system/controlDict
+++ b/perpendicular-flap/solid-solids4foam/system/controlDict
@@ -41,6 +41,7 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }
 

--- a/quickstart/fluid-openfoam/system/controlDict
+++ b/quickstart/fluid-openfoam/system/controlDict
@@ -53,5 +53,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/quickstart/fluid-openfoam/system/controlDict
+++ b/quickstart/fluid-openfoam/system/controlDict
@@ -36,6 +36,7 @@ timeFormat          general;
 
 timePrecision       8;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     forces
@@ -52,7 +53,6 @@ functions
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/turek-hron-fsi3/fluid-openfoam/system/controlDict
+++ b/turek-hron-fsi3/fluid-openfoam/system/controlDict
@@ -52,5 +52,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/turek-hron-fsi3/fluid-openfoam/system/controlDict
+++ b/turek-hron-fsi3/fluid-openfoam/system/controlDict
@@ -35,6 +35,7 @@ timeFormat          general;
 
 timePrecision       8;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     forces
@@ -51,7 +52,6 @@ functions
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/volume-coupled-flow/fluid-openfoam/system/controlDict
+++ b/volume-coupled-flow/fluid-openfoam/system/controlDict
@@ -42,5 +42,6 @@ functions
     {
         type preciceAdapterFunctionObject;
         libs ("libpreciceAdapterFunctionObject.so");
+        errors strict; // Available since OpenFOAM v2012
     }
 }

--- a/volume-coupled-flow/fluid-openfoam/system/controlDict
+++ b/volume-coupled-flow/fluid-openfoam/system/controlDict
@@ -36,12 +36,12 @@ timePrecision   6;
 
 runTimeModifiable false;
 
+libs ("libpreciceAdapterFunctionObject.so");
 functions
 {
     preCICE_Adapter
     {
         type preciceAdapterFunctionObject;
-        libs ("libpreciceAdapterFunctionObject.so");
         errors strict; // Available since OpenFOAM v2012
     }
 }


### PR DESCRIPTION
Asks OpenFOAM to abort in case an error is raised inside the adapter, or in case the adapter cannot be loaded (most common source of confusion). Previously, the simulation would continue without the adapter/coupling. Now:

```
Starting time loop

forces forces:
    rho: rhoInf
    Freestream density (rhoInf) set to 10
    Not including porosity effects

--> FOAM Warning : 
    From void* Foam::dlLibraryTable::openLibrary(const Foam::fileName&, bool)
    in file db/dynamicLibrary/dlLibraryTable/dlLibraryTable.C at line 188
    Could not load "libpreciceAdapterFunctionObject.so"
libpreciceAdapterFunctionObject.so: cannot open shared object file: No such file or directory


--> FOAM FATAL ERROR: (openfoam-2412)
Unknown function type preciceAdapterFunctionObject

Valid function types :

15
(
...
)



    From static Foam::autoPtr<Foam::functionObject> Foam::functionObject::New(const Foam::word&, const Foam::Time&, const Foam::dictionary&)
    in file db/functionObjects/functionObject/functionObject.C at line 129.

FOAM exiting
```

**Future reader:** In case you get this error, check for issues with the OpenFOAM adapter / preCICE / dependencies installation. Search or ask in the [forum](https://precice.discourse.group/).

Option [available since v2012](https://www.openfoam.com/news/main-news/openfoam-v20-12/post-processing#post-processing-function-object-error-handling), already long enough. Related discussion in the [OpenFOAM GitLab](https://develop.openfoam.com/Development/openfoam/-/issues/1779#note_57407).

I have added a comment, so that users of other versions can get a hint to remove it.

Pending PR to the adapter, to update the documentation and any error-handling workarounds.

Thanks to @fsimonis for asking again for a solution to this.

@vidulejs: Do you see any reason not to merge this?

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
