### PR TITLE
Add a cleanup workflow for the system tests runner

### DIFF
--- a/.github/workflows/system-tests-cleanup.yml
+++ b/.github/workflows/system-tests-cleanup.yml
@@ -10,6 +10,12 @@ jobs:
     name: Cleanup system tests runner
     runs-on: [self-hosted, linux, x64, precice-tests-vm]
     steps:
+      - name: Report disk usage before cleanup
+        run: |
+          df -h | grep /var
       - name: Run docker system prune
         run: |
           docker system prune --all --force
+      - name: Report disk usage after cleanup
+        run: |
+          df -h | grep /var

--- a/.github/workflows/system-tests-cleanup.yml
+++ b/.github/workflows/system-tests-cleanup.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Report disk usage before cleanup
         run: |
-          df -h | grep /var
+          df -h | grep -E '(Filesystem|/var)'
       - name: Run docker system prune
         run: |
           docker system prune --all --force
       - name: Report disk usage after cleanup
         run: |
-          df -h | grep /var
+          df -h | grep -E '(Filesystem|/var)'

--- a/.github/workflows/system-tests-cleanup.yml
+++ b/.github/workflows/system-tests-cleanup.yml
@@ -1,0 +1,15 @@
+name: System tests cleanup
+
+on:
+  schedule:
+    - cron: "0 3 1 * *"
+  workflow_dispatch:
+
+jobs:
+ cleanup-system-tests-runner:
+    name: Cleanup system tests runner
+    runs-on: [self-hosted, linux, x64, precice-tests-vm]
+    steps:
+      - name: Run docker system prune
+        run: |
+          docker system prune --all --force

--- a/changelog-entries/645.md
+++ b/changelog-entries/645.md
@@ -1,0 +1,1 @@
+- Added a workflow to cleanup the system tests runner [#645](https://github.com/precice/tutorials/pull/645)


### PR DESCRIPTION
We run the system tests on the same runner to take advantage of the intrinsic caching of Docker, but we also often get issues because of this, as we have no cleanup step. These issues are mainly:

- Running out of networks
- Running out of storage space

The manual solution so far is that I log into the runner and run a `docker system prune -a` every time this happens. This PR adds a workflow that performs this step, so that:

- Others can easily trigger it, without having to connect to the runner
- It runs periodically, unsupervised

After each run, the caching effects are gone, so jobs should take longer. I set it to run once per month (1st day of the month, at 3am, so that it is before any scheduled run of the system tests). We might need to make it more frequent, but this felt like an easy to remember frequency.

Related to https://github.com/precice/infrastructure/issues/11.
