### PR TITLE
Quickstart: Bump suggested preCICE version to v3.2.0

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -21,17 +21,15 @@ To get a feeling what preCICE does, watch a [short presentation](https://www.you
 1. Get and install preCICE. For Ubuntu 24.04 (Noble Numbat), this is pretty easy: [download](https://github.com/precice/precice/releases/latest) and install our binary package by clicking on it or using the following commands:
 
     ```bash
-    wget https://github.com/precice/precice/releases/download/v3.1.2/libprecice3_3.1.2_noble.deb
-    sudo apt install ./libprecice3_3.1.2_noble.deb
+    wget https://github.com/precice/precice/releases/download/v3.2.0/libprecice3_3.2.0_noble.deb
+    sudo apt install ./libprecice3_3.2.0_noble.deb
     ```
 
     | OS                            | Package |
     | ---                           | ---     |
-    | Ubuntu 20.04 Focal Fossa      | [`libprecice3_3.1.2_focal.deb`](https://github.com/precice/precice/releases/download/v3.1.2/libprecice3_3.1.2_focal.deb) |
-    | Ubuntu 22.04 Jammy Jellyfish  | [`libprecice3_3.1.2_jammy.deb`](https://github.com/precice/precice/releases/download/v3.1.2/libprecice3_3.1.2_jammy.deb) |
-    | Ubuntu 24.04 Noble Numbat  | [`libprecice3_3.1.2_noble.deb`](https://github.com/precice/precice/releases/download/v3.1.2/libprecice3_3.1.2_noble.deb) |
-    | Debian 11 "bullseye"          | [`libprecice3_3.1.2_bullseye.deb`](https://github.com/precice/precice/releases/download/v3.1.2/libprecice3_3.1.2_bullseye.deb) |
-    | Debian 12 "bookworm"          | [`libprecice3_3.1.2_bookworm.deb`](https://github.com/precice/precice/releases/download/v3.1.2/libprecice3_3.1.2_bookworm.deb) |
+    | Ubuntu 22.04 Jammy Jellyfish  | [`libprecice3_3.2.0_jammy.deb`](https://github.com/precice/precice/releases/download/v3.2.0/libprecice3_3.2.0_jammy.deb) |
+    | Ubuntu 24.04 Noble Numbat  | [`libprecice3_3.2.0_noble.deb`](https://github.com/precice/precice/releases/download/v3.2.0/libprecice3_3.2.0_noble.deb) |
+    | Debian 12 "bookworm"          | [`libprecice3_3.2.0_bookworm.deb`](https://github.com/precice/precice/releases/download/v3.2.0/libprecice3_3.2.0_bookworm.deb) |
     | Something else                | See an [overview of options](https://precice.org/installation-overview.html) |
 
     Facing any problems? [Ask for help](https://precice.org/community-channels.html).


### PR DESCRIPTION
In [Quickstart](https://precice.org/quickstart.html):

- Updates preCICE from v3.1.2 to v3.2.0
- Adjusts the list of available Debian packages, based on our [release artifacts](https://github.com/precice/precice/releases/tag/v3.2.0)

A repository-wide search for `3.1.2` does not show any other occurrences.
