### PR TITLE
Fix: Start counter from 1 instead of 0 in logs 

### DIFF
--- a/tools/tests/generate_reference_results.py
+++ b/tools/tests/generate_reference_results.py
@@ -119,7 +119,7 @@ def main():
 
     logging.info(f"About to run the following tests {systemtests_to_run}")
     for number, systemtest in enumerate(systemtests_to_run):
-        logging.info(f"Started running {systemtest},  {number}/{len(systemtests_to_run)}")
+        logging.info(f"Started running {systemtest},  {number+1}/{len(systemtests_to_run)}")
         t = time.perf_counter()
         result = systemtest.run_for_reference_results(run_directory)
         elapsed_time = time.perf_counter() - t

--- a/tools/tests/systemtests.py
+++ b/tools/tests/systemtests.py
@@ -70,7 +70,7 @@ def main():
 
     results = []
     for number, systemtest in enumerate(systemtests_to_run):
-        logging.info(f"Started running {systemtest},  {number}/{len(systemtests_to_run)}")
+        logging.info(f"Started running {systemtest},  {number+1}/{len(systemtests_to_run)}")
         t = time.perf_counter()
         result = systemtest.run(run_directory)
         elapsed_time = time.perf_counter() - t


### PR DESCRIPTION
### Summary

Previously, the counter in log messages started from 0, which could be confusing to users expecting 1-based indexing.

### Before:
INFO: Started running Flow over heated plate,  0/2  
INFO: Started running Perpendicular flap,  1/2

### After:
INFO: Started running Flow over heated plate,  1/2  
INFO: Started running Perpendicular flap,  2/2

### Changes Made
- Modified `tools/tests/generate_reference_results.py` to change the counter from `number` to `number + 1` in the log line.

