### PR TITLE
Fix: Start counter from 1 instead of 0 in logs

### DIFF
--- a/tools/tests/build_docker_images.py
+++ b/tools/tests/build_docker_images.py
@@ -70,7 +70,7 @@ def main():
 
     results = []
     for number, systemtest in enumerate(systemtests_to_run):
-        logging.info(f"Started building {systemtest},  {number}/{len(systemtests_to_run)}")
+        logging.info(f"Started building {systemtest},  {number+1}/{len(systemtests_to_run)}")
         t = time.perf_counter()
         result = systemtest.run_only_build(run_directory)
         elapsed_time = time.perf_counter() - t

--- a/tools/tests/systemtests.py
+++ b/tools/tests/systemtests.py
@@ -70,7 +70,7 @@ def main():
 
     results = []
     for number, systemtest in enumerate(systemtests_to_run):
-        logging.info(f"Started running {systemtest},  {number}/{len(systemtests_to_run)}")
+        logging.info(f"Started running {systemtest},  {number+1}/{len(systemtests_to_run)}")
         t = time.perf_counter()
         result = systemtest.run(run_directory)
         elapsed_time = time.perf_counter() - t


### PR DESCRIPTION
### Summary

Previously, the counter in log messages started from 0, which could be confusing to users expecting 1-based indexing.


### Changes Made
- Modified `tools/tests/build_docker_images.py` to change the counter from `number` to `number + 1` in the log line.

