### PR TITLE
Fix libs declaration in perpendicular-flap/solid-openfoam

### DIFF
--- a/perpendicular-flap/solid-openfoam/system/controlDict
+++ b/perpendicular-flap/solid-openfoam/system/controlDict
@@ -7,8 +7,6 @@ FoamFile
     object      controlDict;
 }
 
-libs            ("libsolidDisplacementFoamForce.so");
-
 application     solidDisplacementFoam;
 
 startFrom       startTime;
@@ -37,7 +35,8 @@ timeFormat      general;
 
 timePrecision   6;
 
-libs ("libpreciceAdapterFunctionObject.so");
+libs ("libpreciceAdapterFunctionObject.so" "libsolidDisplacementFoamForce.so");
+
 functions
 {
     preCICE_Adapter


### PR DESCRIPTION
Fixes the library declarations in #655, broken since https://github.com/precice/tutorials/commit/dd1b840854bba6f8aad46bbe8902e6c42afd7596 (unreleased).

Checklist:

- I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`. -> Not needed, bug not in a release.
