### PR TITLE
Fix autopep8-related syntax errors

### DIFF
--- a/partitioned-heat-conduction-overlap/solver-fenics/heat.py
+++ b/partitioned-heat-conduction-overlap/solver-fenics/heat.py
@@ -96,8 +96,8 @@ class OverlapDomain(SubDomain):
     def inside(self, x, on_boundary):
         tol = 1E-14
         if (x[0] <= x_coupling + hx * (overlap_cells * 0.5) + tol) and (x[0] >= x_coupling -
-                                                                        # Point lies inside of overlapping domain
                                                                         hx * (overlap_cells - 0.5) - tol):
+            # Point lies inside of overlapping domain
             return True
         else:
             return False

--- a/tools/tests/systemtests/Systemtest.py
+++ b/tools/tests/systemtests/Systemtest.py
@@ -83,14 +83,11 @@ def display_systemtestresults_as_table(results: List[SystemtestResult]):
 
     max_name_length = _get_length_of_name(results)
 
-    header = f"| {
-        'systemtest':<{
-            max_name_length +
-            2}} | {
-        'success':^7} | {
-                'building time [s]':^17} | {
-                    'solver time [s]':^15} | {
-                        'fieldcompare time [s]':^21} |"
+    header = f"| {'systemtest':<{max_name_length + 2}} "\
+             f"| {'success':^7} "\
+             f"| {'building time [s]':^17} "\
+             f"| {'solver time [s]':^15} "\
+             f"| {'fieldcompare time [s]':^21} |"
     separator_plaintext = "+-" + "-" * (max_name_length + 2) + \
         "-+---------+-------------------+-----------------+-----------------------+"
     separator_markdown = "| --- | --- | --- | --- | --- |"
@@ -105,15 +102,11 @@ def display_systemtestresults_as_table(results: List[SystemtestResult]):
             print(separator_markdown, file=f)
 
     for result in results:
-        row = f"| {
-            str(
-                result.systemtest):<{
-                max_name_length +
-                2}} | {
-            result.success:^7} | {
-                    result.build_time:^17.1f} | {
-                        result.solver_time:^15.1f} | {
-                            result.fieldcompare_time:^21.1f} |"
+        row = f"| {str(result.systemtest):<{max_name_length + 2}} "\
+              f"| {result.success:^7} "\
+              f"| {result.build_time:^17.1f} "\
+              f"| {result.solver_time:^15.1f} "\
+              f"| {result.fieldcompare_time:^21.1f} |"
         print(row)
         print(separator_plaintext)
         if "GITHUB_STEP_SUMMARY" in os.environ:


### PR DESCRIPTION
We are using the [autopep8](https://github.com/hhatto/autopep8) formatter via our pre-commit hooks. In the latest version (upgraded in https://github.com/precice/tutorials/commit/58b360ee64f6d634bc7b77b99201c5a5201bce30), autopep8 seems to break long f-strings, which broke our system tests (see all files formatted in https://github.com/precice/tutorials/commit/8270f1f90ea8013c583fc8ab6508196a50f4edaf).

While it is questionable whether we want to remain with autopep8 in the long run, we have to fix our system tests before we start merging and code with regressions.

This PR manually splits some long f-strings (in a way that is also more readable) and moves a comment that was in a weird position.

Note: The `trigger-system-tests` label triggers the tests with the scripts from `develop`. A job using the scripts from this branch: https://github.com/precice/tutorials/actions/runs/16930119218 (works past the affected code)