### PR TITLE
Add implementation to enable parallel execution of macro-dumux

### DIFF
--- a/changelog-entries/663.md
+++ b/changelog-entries/663.md
@@ -1,0 +1,1 @@
+- Enable parallel execution of the participant macro-dumux in the two-scale heat conduction tutorial [#663](https://github.com/precice/tutorials/pull/663)

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -278,6 +278,8 @@ int main(int argc, char **argv)
                                                       dt);
       couplingParticipant.readQuantityFromOtherSolver(meshName,
                                                       readDataPorosity, dt);
+      // store coupling data in problem
+      problem->spatialParams().updateCouplingData();
     }
     std::cout << "Solver starts" << std::endl;
 

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -24,6 +24,7 @@
 #include <dune/common/timer.hh>
 #include <dune/grid/io/file/vtk.hh>
 #include <dune/istl/io.hh>
+#include <dune/grid/common/gridenums.hh>
 
 #include "properties.hh"
 
@@ -114,6 +115,8 @@ int main(int argc, char **argv)
   // get mesh coordinates
   std::vector<double> coords;
   std::vector<int>    coupledElementIdxs;
+  std::vector<double> overlapCoords;
+  std::vector<int>    overlapElementIdxs;
 
   // coordinate loop (created vectors are 1D)
   // these positions of cell centers are later communicated to precice
@@ -122,15 +125,23 @@ int main(int argc, char **argv)
     auto fvGeometry = localView(*gridGeometry);
     fvGeometry.bindElement(element);
     for (const auto &scv : scvs(fvGeometry)) {
-      coupledElementIdxs.push_back(scv.elementIndex());
+      if (element.partitionType() != Dune::OverlapEntity)
+        coupledElementIdxs.push_back(scv.elementIndex());
+      else
+        overlapElementIdxs.push_back(scv.elementIndex());
       const auto &pos = scv.center();
       for (const auto p : pos) {
-        coords.push_back(p);
+        if (element.partitionType() != Dune::OverlapEntity)
+          coords.push_back(p);
+        else
+          overlapCoords.push_back(p);
         std::cout << p << "  ";
       }
       std::cout << " ;" << std::endl;
     }
   }
+  coupledElementIdxs.insert(coupledElementIdxs.end(), overlapElementIdxs.begin(),
+          overlapElementIdxs.end());
   std::cout << "Number of Coupled Cells:" << coupledElementIdxs.size()
             << std::endl;
 
@@ -138,7 +149,7 @@ int main(int argc, char **argv)
   auto numberOfElements =
       coords.size() / couplingParticipant.getMeshDimensions(meshName);
   if (getParam<bool>("Precice.RunWithCoupling") == true) {
-    couplingParticipant.setMesh(meshName, coords);
+    couplingParticipant.setMesh(meshName, coords, overlapCoords);
 
     // couples between dumux element indices and preciceIndices;
     couplingParticipant.createIndexMapping(coupledElementIdxs);

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -115,33 +115,25 @@ int main(int argc, char **argv)
   // get mesh coordinates
   std::vector<double> coords;
   std::vector<int>    coupledElementIdxs;
-  std::vector<double> overlapCoords;
-  std::vector<int>    overlapElementIdxs;
 
   // coordinate loop (created vectors are 1D)
   // these positions of cell centers are later communicated to precice
   std::cout << "Coordinates: " << std::endl;
   for (const auto &element : elements(leafGridView)) {
+    if (element.partitionType() == Dune::OverlapEntity)
+      continue;
     auto fvGeometry = localView(*gridGeometry);
     fvGeometry.bindElement(element);
     for (const auto &scv : scvs(fvGeometry)) {
-      if (element.partitionType() != Dune::OverlapEntity)
-        coupledElementIdxs.push_back(scv.elementIndex());
-      else
-        overlapElementIdxs.push_back(scv.elementIndex());
+      coupledElementIdxs.push_back(scv.elementIndex());
       const auto &pos = scv.center();
       for (const auto p : pos) {
-        if (element.partitionType() != Dune::OverlapEntity)
-          coords.push_back(p);
-        else
-          overlapCoords.push_back(p);
+        coords.push_back(p);
         std::cout << p << "  ";
       }
       std::cout << " ;" << std::endl;
     }
   }
-  coupledElementIdxs.insert(coupledElementIdxs.end(), overlapElementIdxs.begin(),
-                            overlapElementIdxs.end());
   std::cout << "Number of Coupled Cells:" << coupledElementIdxs.size()
             << std::endl;
 
@@ -149,7 +141,7 @@ int main(int argc, char **argv)
   auto numberOfElements =
       coords.size() / couplingParticipant.getMeshDimensions(meshName);
   if (getParam<bool>("Precice.RunWithCoupling") == true) {
-    couplingParticipant.setMesh(meshName, coords, overlapCoords);
+    couplingParticipant.setMesh(meshName, coords);
 
     // couples between dumux element indices and preciceIndices;
     couplingParticipant.createIndexMapping(coupledElementIdxs);

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -22,9 +22,9 @@
 
 #include <dune/common/parallel/mpihelper.hh>
 #include <dune/common/timer.hh>
+#include <dune/grid/common/gridenums.hh>
 #include <dune/grid/io/file/vtk.hh>
 #include <dune/istl/io.hh>
-#include <dune/grid/common/gridenums.hh>
 
 #include "properties.hh"
 
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
     }
   }
   coupledElementIdxs.insert(coupledElementIdxs.end(), overlapElementIdxs.begin(),
-          overlapElementIdxs.end());
+                            overlapElementIdxs.end());
   std::cout << "Number of Coupled Cells:" << coupledElementIdxs.size()
             << std::endl;
 

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -22,7 +22,7 @@
 
 #include <dune/common/parallel/mpihelper.hh>
 #include <dune/common/timer.hh>
-#include <dune/grid/common/gridenums.hh>
+#include <dune/grid/common/partitionset.hh>
 #include <dune/grid/io/file/vtk.hh>
 #include <dune/istl/io.hh>
 
@@ -119,9 +119,7 @@ int main(int argc, char **argv)
   // coordinate loop (created vectors are 1D)
   // these positions of cell centers are later communicated to precice
   std::cout << "Coordinates: " << std::endl;
-  for (const auto &element : elements(leafGridView)) {
-    if (element.partitionType() == Dune::OverlapEntity)
-      continue;
+  for (const auto &element : elements(leafGridView, Dune::Partitions::interior)) {
     auto fvGeometry = localView(*gridGeometry);
     fvGeometry.bindElement(element);
     for (const auto &scv : scvs(fvGeometry)) {

--- a/two-scale-heat-conduction/macro-dumux/appl/problem.hh
+++ b/two-scale-heat-conduction/macro-dumux/appl/problem.hh
@@ -249,6 +249,7 @@ public:
     }
   }
 
+
 private:
   Dumux::Precice::CouplingAdapter &couplingParticipant_;
 

--- a/two-scale-heat-conduction/macro-dumux/appl/problem.hh
+++ b/two-scale-heat-conduction/macro-dumux/appl/problem.hh
@@ -249,7 +249,6 @@ public:
     }
   }
 
-
 private:
   Dumux::Precice::CouplingAdapter &couplingParticipant_;
 

--- a/two-scale-heat-conduction/macro-dumux/appl/spatialparams.hh
+++ b/two-scale-heat-conduction/macro-dumux/appl/spatialparams.hh
@@ -18,6 +18,9 @@
 #ifndef DUMUX_TEST_1PNI_SPATIAL_PARAMS_HH
 #define DUMUX_TEST_1PNI_SPATIAL_PARAMS_HH
 
+#include <dune/grid/common/gridenums.hh>
+
+#include <dumux/parallel/vectorcommdatahandle.hh>
 #include <dumux/porousmediumflow/fvspatialparams1p.hh>
 #include <dumux/porousmediumflow/properties.hh>
 
@@ -48,8 +51,11 @@ public:
   using PermeabilityType = Scalar;
 
   OnePNISpatialParams(std::shared_ptr<const GridGeometry> gridGeometry)
-      : ParentType(gridGeometry),
-        couplingParticipant_(Dumux::Precice::CouplingAdapter::getInstance()) {}
+      : ParentType(gridGeometry)
+      , couplingParticipant_(Dumux::Precice::CouplingAdapter::getInstance())
+      , couplingData_(gridGeometry->numDofs())
+      , couplingDataHandle_(this->gridGeometry().elementMapper(), couplingData_)
+  {}
 
   /*!
    * \brief Defines the intrinsic permeability \f$\mathrm{[m^2]}\f$.
@@ -71,8 +77,7 @@ public:
                   const ElementSolution &elemSol) const
   {
     if (getParam<bool>("Precice.RunWithCoupling") == true)
-      return couplingParticipant_.getScalarQuantityOnFace(
-          "macro-mesh", "porosity", scv.elementIndex());
+      return couplingData_[scv.elementIndex()][0];
     else
       return getParam<Scalar>("Problem.DefaultPorosity");
   }
@@ -87,14 +92,10 @@ public:
     DimWorldMatrix K;
 
     if (getParam<bool>("Precice.RunWithCoupling") == true) {
-      K[0][0] = couplingParticipant_.getScalarQuantityOnFace(
-          "macro-mesh", "k_00", scv.elementIndex());
-      K[0][1] = couplingParticipant_.getScalarQuantityOnFace(
-          "macro-mesh", "k_01", scv.elementIndex());
-      K[1][0] = couplingParticipant_.getScalarQuantityOnFace(
-          "macro-mesh", "k_10", scv.elementIndex());
-      K[1][1] = couplingParticipant_.getScalarQuantityOnFace(
-          "macro-mesh", "k_11", scv.elementIndex());
+      K[0][0] = couplingData_[scv.elementIndex()][1];
+      K[0][1] = couplingData_[scv.elementIndex()][2];
+      K[1][0] = couplingData_[scv.elementIndex()][3];
+      K[1][1] = couplingData_[scv.elementIndex()][4];
     } else {
       K[0][0] = getParam<Scalar>("Component.SolidThermalConductivity");
       K[0][1] = 0.0;
@@ -104,8 +105,42 @@ public:
     return K;
   }
 
+  void updateCouplingData()
+  {
+    for (const auto &element : elements(this->gridGeometry().gridView())) {
+      if (element.partitionType() == Dune::OverlapEntity)
+        continue;
+      auto fvGeometry = localView(this->gridGeometry());
+      fvGeometry.bindElement(element);
+      for (const auto &scv : scvs(fvGeometry)) {
+        const auto elementIdx = scv.elementIndex();
+        couplingData_[elementIdx][0] =
+            couplingParticipant_.getScalarQuantityOnFace("macro-mesh", "porosity", elementIdx);
+        couplingData_[elementIdx][1] =
+            couplingParticipant_.getScalarQuantityOnFace("macro-mesh", "k_00", elementIdx);
+        couplingData_[elementIdx][2] =
+            couplingParticipant_.getScalarQuantityOnFace("macro-mesh", "k_01", elementIdx);
+        couplingData_[elementIdx][3] =
+            couplingParticipant_.getScalarQuantityOnFace("macro-mesh", "k_10", elementIdx);
+        couplingData_[elementIdx][4] =
+            couplingParticipant_.getScalarQuantityOnFace("macro-mesh", "k_11", elementIdx);
+      }
+    }
+    // exchange coupling data with other ranks
+    if (this->gridGeometry().gridView().comm().size() > 1) {
+      this->gridGeometry().gridView().communicate(couplingDataHandle_,
+                                                  Dune::InteriorBorder_All_Interface, Dune::ForwardCommunication);
+    }
+  }
+
 private:
-  Dumux::Precice::CouplingAdapter &couplingParticipant_;
+  Dumux::Precice::CouplingAdapter                &couplingParticipant_;
+  Dune::BlockVector<Dune::FieldVector<double, 5>> couplingData_;
+  Dumux::VectorCommDataHandleEqual<
+      typename GridGeometry::ElementMapper,
+      Dune::BlockVector<Dune::FieldVector<double, 5>>,
+      /* Entity codimension = */ 0>
+      couplingDataHandle_;
 };
 
 } // end namespace Dumux

--- a/two-scale-heat-conduction/macro-dumux/appl/spatialparams.hh
+++ b/two-scale-heat-conduction/macro-dumux/appl/spatialparams.hh
@@ -51,11 +51,9 @@ public:
   using PermeabilityType = Scalar;
 
   OnePNISpatialParams(std::shared_ptr<const GridGeometry> gridGeometry)
-      : ParentType(gridGeometry)
-      , couplingParticipant_(Dumux::Precice::CouplingAdapter::getInstance())
-      , couplingData_(gridGeometry->numDofs())
-      , couplingDataHandle_(this->gridGeometry().elementMapper(), couplingData_)
-  {}
+      : ParentType(gridGeometry), couplingParticipant_(Dumux::Precice::CouplingAdapter::getInstance()), couplingData_(gridGeometry->numDofs()), couplingDataHandle_(this->gridGeometry().elementMapper(), couplingData_)
+  {
+  }
 
   /*!
    * \brief Defines the intrinsic permeability \f$\mathrm{[m^2]}\f$.

--- a/two-scale-heat-conduction/macro-dumux/appl/spatialparams.hh
+++ b/two-scale-heat-conduction/macro-dumux/appl/spatialparams.hh
@@ -122,7 +122,7 @@ public:
             couplingParticipant_.getScalarQuantityOnFace("macro-mesh", "k_11", elementIdx);
       }
     }
-    // exchange coupling data with other ranks
+    // Trigger exchange of coupling data between neighboring ranks, if the domain is partitioned
     if (this->gridGeometry().gridView().comm().size() > 1) {
       this->gridGeometry().gridView().communicate(couplingDataHandle_,
                                                   Dune::InteriorBorder_All_Interface, Dune::ForwardCommunication);

--- a/two-scale-heat-conduction/macro-dumux/appl/spatialparams.hh
+++ b/two-scale-heat-conduction/macro-dumux/appl/spatialparams.hh
@@ -18,7 +18,7 @@
 #ifndef DUMUX_TEST_1PNI_SPATIAL_PARAMS_HH
 #define DUMUX_TEST_1PNI_SPATIAL_PARAMS_HH
 
-#include <dune/grid/common/gridenums.hh>
+#include <dune/grid/common/partitionset.hh>
 
 #include <dumux/parallel/vectorcommdatahandle.hh>
 #include <dumux/porousmediumflow/fvspatialparams1p.hh>
@@ -105,9 +105,7 @@ public:
 
   void updateCouplingData()
   {
-    for (const auto &element : elements(this->gridGeometry().gridView())) {
-      if (element.partitionType() == Dune::OverlapEntity)
-        continue;
+    for (const auto &element : elements(this->gridGeometry().gridView(), Dune::Partitions::interior)) {
       auto fvGeometry = localView(this->gridGeometry());
       fvGeometry.bindElement(element);
       for (const auto &scv : scvs(fvGeometry)) {


### PR DESCRIPTION
Handle parallel execution of the participant macro-dumux in the two-scale heat conduction tutorial. Currently the communication of coupling data between ranks is handled in the application. In the future, it would be better to handle this in the DuMuX-preCICE adapter.

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
