### PR TITLE
Fix negotiation of dt value in two-scale-heat-conduction/macro-dumux

### DIFF
--- a/changelog-entries/664.md
+++ b/changelog-entries/664.md
@@ -1,0 +1,1 @@
+- Fix negotiation of dt value in two-scale-heat-conduction/macro-dumux [#664](https://github.com/precice/tutorials/pull/664)

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -223,14 +223,18 @@ int main(int argc, char **argv)
   // initialize
   couplingParticipant.initialize();
 
-  // get some time loop parameters
+  // time loop parameters
   const auto tEnd      = getParam<Scalar>("TimeLoop.TEnd");
   double     preciceDt = couplingParticipant.getMaxTimeStepSize();
+  double     solverDt;
   double     dt;
-  if (getParam<bool>("Precice.RunWithCoupling") == true)
-    dt = preciceDt;
-  else
+
+  if (getParam<bool>("Precice.RunWithCoupling") == true) {
+    solverDt = getParam<Scalar>("TimeLoop.InitialDt");
+    dt       = std::min(preciceDt, solverDt);
+  } else {
     dt = getParam<Scalar>("TimeLoop.InitialDt");
+  }
 
   // instantiate time loop
   auto timeLoop = std::make_shared<TimeLoop<Scalar>>(0.0, dt, tEnd);
@@ -265,6 +269,10 @@ int main(int argc, char **argv)
         xOld = x;
       }
 
+      preciceDt = couplingParticipant.getMaxTimeStepSize();
+      solverDt  = std::min(nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()), getParam<Scalar>("TimeLoop.MaxDt"));
+      dt        = std::min(preciceDt, solverDt);
+
       // read porosity and conductivity data from other solver
       couplingParticipant.readQuantityFromOtherSolver(meshName, readDatak00,
                                                       dt);
@@ -297,22 +305,17 @@ int main(int argc, char **argv)
     // advance precice
     if (getParam<bool>("Precice.RunWithCoupling") == true) {
       couplingParticipant.advance(dt);
-      preciceDt = couplingParticipant.getMaxTimeStepSize();
-      dt        = std::min(preciceDt, std::min(nonLinearSolver.suggestTimeStepSize(
-                                                   timeLoop->timeStepSize()),
-                                               getParam<Scalar>("TimeLoop.MaxDt")));
-      if (preciceDt != dt) {
-        std::cout << "preciceDt too large. We currently assume fixed timestep "
-                     "size but timesteps no longer correspond: preciceDt = "
-                  << preciceDt << " and dt =" << dt << std::endl;
-        // exit(1);
+      if ((!fabs(preciceDt - dt)) < 1e-14) {
+        std::cout << "dt from preCICE is different than dt from DuMuX. "
+                     "preCICE dt = "
+                  << preciceDt << " and DuMuX dt =" << solverDt << std::endl;
       }
     } else
       dt = std::min(
           nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()),
           getParam<Scalar>("TimeLoop.MaxDt"));
 
-    std::cout << "dt: " << dt << std::endl;
+    std::cout << "Using dt: " << dt << std::endl;
 
     if (getParam<bool>("Precice.RunWithCoupling") == true) {
       if (couplingParticipant.requiresToReadCheckpoint()) {
@@ -350,7 +353,7 @@ int main(int argc, char **argv)
         n = 0;
       }
     }
-    // set new dt as suggested by the newton solver or by precice
+    // set new dt as suggested by the newton solver or by preCICE
     timeLoop->setTimeStepSize(dt);
 
     std::cout << "Time: " << timeLoop->time() << std::endl;

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -238,6 +238,7 @@ int main(int argc, char **argv)
 
   // instantiate time loop
   auto timeLoop = std::make_shared<TimeLoop<Scalar>>(0.0, dt, tEnd);
+  timeLoop->setMaxTimeStepSize(getParam<Scalar>("TimeLoop.MaxDt"));
 
   // the assembler with time loop for instationary problem
   using Assembler = FVAssembler<TypeTag, DiffMethod::numeric>;
@@ -268,10 +269,6 @@ int main(int argc, char **argv)
       if (couplingParticipant.requiresToWriteCheckpoint()) {
         xOld = x;
       }
-
-      preciceDt = couplingParticipant.getMaxTimeStepSize();
-      solverDt  = std::min(nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()), getParam<Scalar>("TimeLoop.MaxDt"));
-      dt        = std::min(preciceDt, solverDt);
 
       // read porosity and conductivity data from other solver
       couplingParticipant.readQuantityFromOtherSolver(meshName, readDatak00,
@@ -304,7 +301,12 @@ int main(int argc, char **argv)
 
     // advance precice
     if (getParam<bool>("Precice.RunWithCoupling") == true) {
-      couplingParticipant.advance(dt);
+      couplingParticipant.advance(timeLoop->timeStepSize());
+
+      preciceDt = couplingParticipant.getMaxTimeStepSize();
+      solverDt  = std::min(nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()), timeLoop->maxTimeStepSize());
+      dt        = std::min(preciceDt, solverDt);
+
       if ((!fabs(preciceDt - dt)) < 1e-14) {
         std::cout << "dt from preCICE is different than dt from DuMuX. "
                      "preCICE dt = "


### PR DESCRIPTION
The negotiation of the time step value from the time step recommended by preCICE and the time step recommended by DuMuX is correctly handled. The incorrect implementation was noticed when the case was scaled up, leading to DuMuX suggesting a time step value lesser than the one recommended by preCICE.

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
