### PR TITLE
[two-scale-heat-conduction] Fix parallel macro: Write data only for interior elements

### DIFF
--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -295,7 +295,7 @@ int main(int argc, char **argv)
       fvGeometry.bindElement(element);
       for (const auto &scv : scvs(fvGeometry)) {
         temperatures[solIdx++] =
-                 x[scv.elementIndex()][problem->returnTemperatureIdx()];
+            x[scv.elementIndex()][problem->returnTemperatureIdx()];
       }
     }
 

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -289,8 +289,15 @@ int main(int argc, char **argv)
     // linearize & solve
     nonLinearSolver.solve(x, *timeLoop);
 
-    for (int solIdx = 0; solIdx < numberOfElements; ++solIdx)
-      temperatures[solIdx] = x[solIdx][problem->returnTemperatureIdx()];
+    int solIdx = 0;
+    for (const auto &element : elements(leafGridView, Dune::Partitions::interior)) {
+      auto fvGeometry = localView(*gridGeometry);
+      fvGeometry.bindElement(element);
+      for (const auto &scv : scvs(fvGeometry)) {
+        temperatures[solIdx++] =
+                 x[scv.elementIndex()][problem->returnTemperatureIdx()];
+      }
+    }
 
     if (getParam<bool>("Precice.RunWithCoupling") == true) {
       couplingParticipant.writeQuantityVector(meshName,


### PR DESCRIPTION
<!-- Please submit your Pull Request to the `develop` branch.

It may help to have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

Coupling data was still written from the solution vector, not limited to interior elements / coupling points.

Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
