### PR TITLE
Fix subcycling / checkpointing for two-scale-heat-conduction participant macro-dumux

### DIFF
--- a/changelog-entries/666.md
+++ b/changelog-entries/666.md
@@ -1,0 +1,1 @@
+- Fix subcycling and checkpointing in macro-dumux of tw0-scale-heat-conduction [#666](https://github.com/precice/tutorials/pull/666)

--- a/changelog-entries/666.md
+++ b/changelog-entries/666.md
@@ -1,1 +1,1 @@
-- Fix subcycling and checkpointing in macro-dumux of tw0-scale-heat-conduction [#666](https://github.com/precice/tutorials/pull/666)
+- Fix subcycling and checkpointing in macro-dumux of two-scale-heat-conduction [#666](https://github.com/precice/tutorials/pull/666)

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -276,6 +276,11 @@ int main(int argc, char **argv)
         timeStepCheckpoint = timeLoop->timeStepIndex();
       }
 
+      preciceDt = couplingParticipant.getMaxTimeStepSize();
+      solverDt  = std::min(nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()), timeLoop->maxTimeStepSize());
+      dt        = std::min(preciceDt, solverDt);
+      timeLoop->setTimeStepSize(dt);
+
       // read porosity and conductivity data from other solver
       couplingParticipant.readQuantityFromOtherSolver(meshName, readDatak00,
                                                       dt);
@@ -289,7 +294,13 @@ int main(int argc, char **argv)
                                                       readDataPorosity, dt);
       // store coupling data in problem
       problem->spatialParams().updateCouplingData();
+    } else {
+      dt = std::min(
+          nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()),
+          getParam<Scalar>("TimeLoop.MaxDt"));
+      timeLoop->setTimeStepSize(dt);
     }
+
     std::cout << "Solver starts" << std::endl;
 
     std::cout << "Using dt: " << dt << std::endl;
@@ -317,16 +328,6 @@ int main(int argc, char **argv)
                   << preciceDt << " and DuMuX dt =" << solverDt << std::endl;
       }
     }
-
-    if (getParam<bool>("Precice.RunWithCoupling") == true) {
-      preciceDt = couplingParticipant.getMaxTimeStepSize();
-      solverDt  = std::min(nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()), timeLoop->maxTimeStepSize());
-      dt        = std::min(preciceDt, solverDt);
-
-    } else
-      dt = std::min(
-          nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()),
-          getParam<Scalar>("TimeLoop.MaxDt"));
 
     if (getParam<bool>("Precice.RunWithCoupling") == true) {
       if (couplingParticipant.requiresToReadCheckpoint()) {

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -306,7 +306,12 @@ int main(int argc, char **argv)
     std::cout << "Using dt: " << dt << std::endl;
     // linearize & solve
     nonLinearSolver.solve(x, *timeLoop);
+    // save actual time-step size
     dt = timeLoop->timeStepSize();
+    // DuMux advance + report
+    gridVariables->advanceTimeStep();
+    timeLoop->advanceTimeStep();
+    timeLoop->reportTimeStep();
 
     for (int solIdx = 0; solIdx < numberOfElements; ++solIdx)
       temperatures[solIdx] = x[solIdx][problem->returnTemperatureIdx()];
@@ -320,21 +325,19 @@ int main(int argc, char **argv)
 
     // advance precice
     if (getParam<bool>("Precice.RunWithCoupling") == true) {
-      couplingParticipant.advance(timeLoop->timeStepSize());
 
       if ((!fabs(preciceDt - dt)) < 1e-14) {
-        std::cout << "dt from preCICE is different than dt from DuMuX. "
-                     "preCICE dt = "
-                  << preciceDt << " and DuMuX dt =" << solverDt << std::endl;
+        std::cout << "dt from preCICE is different than dt from DuMuX."
+                  << " preCICE dt = " << preciceDt
+                  << " and DuMuX dt =" << solverDt
+                  << " resulted in dt = " << dt
+                  << std::endl;
       }
+      couplingParticipant.advance(dt);
     }
 
     if (getParam<bool>("Precice.RunWithCoupling") == true) {
       if (couplingParticipant.requiresToReadCheckpoint()) {
-        // make the new solution the old solution
-        gridVariables->advanceTimeStep();
-        timeLoop->advanceTimeStep();
-        timeLoop->reportTimeStep();
         x    = xCheckpoint;
         xOld = x;
         timeLoop->setTime(timeCheckpoint, timeStepCheckpoint);
@@ -350,20 +353,9 @@ int main(int argc, char **argv)
           vtkWriter.write(timeLoop->time());
           n = 0;
         }
-        gridVariables->advanceTimeStep();
-        // advance the time loop to the next step
-        timeLoop->advanceTimeStep();
-        // report statistics of this time step
-        timeLoop->reportTimeStep();
       }
     } else {
       xOld = x;
-      gridVariables->advanceTimeStep();
-      // advance the time loop to the next step
-      timeLoop->advanceTimeStep();
-      // report statistics of this time step
-      timeLoop->reportTimeStep();
-
       // output every outputinterval steps
       n += 1;
       if (n == vtkOutputInterval) {

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -171,6 +171,10 @@ int main(int argc, char **argv)
   problem->applyInitialSolution(x);
   auto xOld = x;
 
+  auto   xCheckpoint        = x;
+  double timeCheckpoint     = 0.0;
+  int    timeStepCheckpoint = 0;
+
   // initialize the coupling data
   std::vector<double> temperatures;
   for (int solIdx = 0; solIdx < numberOfElements; ++solIdx) {
@@ -267,7 +271,9 @@ int main(int argc, char **argv)
 
       // write checkpoint
       if (couplingParticipant.requiresToWriteCheckpoint()) {
-        xOld = x;
+        xCheckpoint        = x;
+        timeCheckpoint     = timeLoop->time();
+        timeStepCheckpoint = timeLoop->timeStepIndex();
       }
 
       // read porosity and conductivity data from other solver
@@ -322,11 +328,18 @@ int main(int argc, char **argv)
     if (getParam<bool>("Precice.RunWithCoupling") == true) {
       if (couplingParticipant.requiresToReadCheckpoint()) {
         // make the new solution the old solution
-        x = xOld;
+        gridVariables->advanceTimeStep();
+        timeLoop->advanceTimeStep();
+        timeLoop->reportTimeStep();
+        x    = xCheckpoint;
+        xOld = x;
+        timeLoop->setTime(timeCheckpoint, timeStepCheckpoint);
+        timeLoop->setTimeStepSize(dt);
         gridVariables->update(x);
         gridVariables->advanceTimeStep();
-      } else // coupling successful
+      } else // coupling successful OR not at time window!!
       {
+        xOld = x;
         n += 1;
         if (n == vtkOutputInterval) {
           problem->updateVtkOutput(x);

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -292,8 +292,10 @@ int main(int argc, char **argv)
     }
     std::cout << "Solver starts" << std::endl;
 
+    std::cout << "Using dt: " << dt << std::endl;
     // linearize & solve
     nonLinearSolver.solve(x, *timeLoop);
+    dt = timeLoop->timeStepSize();
 
     for (int solIdx = 0; solIdx < numberOfElements; ++solIdx)
       temperatures[solIdx] = x[solIdx][problem->returnTemperatureIdx()];
@@ -309,21 +311,22 @@ int main(int argc, char **argv)
     if (getParam<bool>("Precice.RunWithCoupling") == true) {
       couplingParticipant.advance(timeLoop->timeStepSize());
 
-      preciceDt = couplingParticipant.getMaxTimeStepSize();
-      solverDt  = std::min(nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()), timeLoop->maxTimeStepSize());
-      dt        = std::min(preciceDt, solverDt);
-
       if ((!fabs(preciceDt - dt)) < 1e-14) {
         std::cout << "dt from preCICE is different than dt from DuMuX. "
                      "preCICE dt = "
                   << preciceDt << " and DuMuX dt =" << solverDt << std::endl;
       }
+    }
+
+    if (getParam<bool>("Precice.RunWithCoupling") == true) {
+      preciceDt = couplingParticipant.getMaxTimeStepSize();
+      solverDt  = std::min(nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()), timeLoop->maxTimeStepSize());
+      dt        = std::min(preciceDt, solverDt);
+
     } else
       dt = std::min(
           nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()),
           getParam<Scalar>("TimeLoop.MaxDt"));
-
-    std::cout << "Using dt: " << dt << std::endl;
 
     if (getParam<bool>("Precice.RunWithCoupling") == true) {
       if (couplingParticipant.requiresToReadCheckpoint()) {

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -100,7 +100,8 @@ int main(int argc, char **argv)
 
   auto &couplingParticipant = Dumux::Precice::CouplingAdapter::getInstance();
 
-  if (getParam<bool>("Precice.RunWithCoupling") == true) {
+  const auto runWithCoupling = getParam<bool>("Precice.RunWithCoupling");
+  if (runWithCoupling) {
     couplingParticipant.announceSolver("macro-heat", preciceConfigFilename,
                                        mpiHelper.rank(), mpiHelper.size());
     // verify that dimensions match
@@ -138,7 +139,7 @@ int main(int argc, char **argv)
   // initialize preCICE
   auto numberOfElements =
       coords.size() / couplingParticipant.getMeshDimensions(meshName);
-  if (getParam<bool>("Precice.RunWithCoupling") == true) {
+  if (runWithCoupling) {
     couplingParticipant.setMesh(meshName, coords);
 
     // couples between dumux element indices and preciceIndices;
@@ -154,7 +155,7 @@ int main(int argc, char **argv)
   const std::string writeDataConcentration = "concentration";
   // const std::string writeDataTemperature = "temperature";
 
-  if (getParam<bool>("Precice.RunWithCoupling") == true) {
+  if (runWithCoupling) {
     couplingParticipant.announceQuantity(meshName, readDatak00);
     couplingParticipant.announceQuantity(meshName, readDatak01);
     couplingParticipant.announceQuantity(meshName, readDatak10);
@@ -181,7 +182,7 @@ int main(int argc, char **argv)
     temperatures.push_back(x[solIdx][problem->returnTemperatureIdx()]);
   };
 
-  if (getParam<bool>("Precice.RunWithCoupling") == true) {
+  if (runWithCoupling) {
     couplingParticipant.writeQuantityVector(meshName, writeDataConcentration,
                                             temperatures);
     if (couplingParticipant
@@ -233,7 +234,7 @@ int main(int argc, char **argv)
   double     solverDt;
   double     dt;
 
-  if (getParam<bool>("Precice.RunWithCoupling") == true) {
+  if (runWithCoupling) {
     solverDt = getParam<Scalar>("TimeLoop.InitialDt");
     dt       = std::min(preciceDt, solverDt);
   } else {
@@ -265,7 +266,7 @@ int main(int argc, char **argv)
   std::cout << "Time Loop starts" << std::endl;
   timeLoop->start();
   do {
-    if (getParam<bool>("Precice.RunWithCoupling") == true) {
+    if (runWithCoupling) {
       if (couplingParticipant.isCouplingOngoing() == false)
         break;
 
@@ -277,11 +278,13 @@ int main(int argc, char **argv)
       }
 
       preciceDt = couplingParticipant.getMaxTimeStepSize();
-      solverDt  = std::min(nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()), timeLoop->maxTimeStepSize());
+      solverDt  = std::min(nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()),
+                           timeLoop->maxTimeStepSize());
       dt        = std::min(preciceDt, solverDt);
-      timeLoop->setTimeStepSize(dt);
 
       // read porosity and conductivity data from other solver
+      // TODO: data needs to be updated if Newton solver adapts time-step size
+      // and coupling data is interpolated in time
       couplingParticipant.readQuantityFromOtherSolver(meshName, readDatak00,
                                                       dt);
       couplingParticipant.readQuantityFromOtherSolver(meshName, readDatak01,
@@ -292,80 +295,71 @@ int main(int argc, char **argv)
                                                       dt);
       couplingParticipant.readQuantityFromOtherSolver(meshName,
                                                       readDataPorosity, dt);
-      // store coupling data in problem
+      // store coupling data in spatial params, exchange with MPI
       problem->spatialParams().updateCouplingData();
     } else {
       dt = std::min(
           nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()),
-          getParam<Scalar>("TimeLoop.MaxDt"));
-      timeLoop->setTimeStepSize(dt);
+          timeLoop->maxTimeStepSize());
     }
+    // set new dt as suggested by the newton solver or by preCICE
+    timeLoop->setTimeStepSize(dt);
 
-    std::cout << "Solver starts" << std::endl;
+    std::cout << "Solver starts with Target dt: " << dt << std::endl;
 
-    std::cout << "Using dt: " << dt << std::endl;
     // linearize & solve
     nonLinearSolver.solve(x, *timeLoop);
     // save actual time-step size
     dt = timeLoop->timeStepSize();
+
     // DuMux advance + report
     gridVariables->advanceTimeStep();
     timeLoop->advanceTimeStep();
     timeLoop->reportTimeStep();
+    xOld = x;
 
-    for (int solIdx = 0; solIdx < numberOfElements; ++solIdx)
-      temperatures[solIdx] = x[solIdx][problem->returnTemperatureIdx()];
+    // Vtk output
+    // TODO: output interval doesn't work easily with subcycling
+    n += 1;
+    if (n == vtkOutputInterval) {
+      problem->updateVtkOutput(x);
+      vtkWriter.write(timeLoop->time());
+      n = 0;
+    }
 
-    if (getParam<bool>("Precice.RunWithCoupling") == true) {
+    if (runWithCoupling) {
+      // write coupling data to preCICE
+      for (int solIdx = 0; solIdx < numberOfElements; ++solIdx)
+        temperatures[solIdx] = x[solIdx][problem->returnTemperatureIdx()];
+
       couplingParticipant.writeQuantityVector(meshName,
                                               writeDataConcentration, temperatures);
       couplingParticipant.writeQuantityToOtherSolver(meshName,
                                                      writeDataConcentration);
-    }
 
-    // advance precice
-    if (getParam<bool>("Precice.RunWithCoupling") == true) {
-
+      // advance precice
       if ((!fabs(preciceDt - dt)) < 1e-14) {
         std::cout << "dt from preCICE is different than dt from DuMuX."
                   << " preCICE dt = " << preciceDt
-                  << " and DuMuX dt =" << solverDt
+                  << " and DuMuX dt = " << solverDt
                   << " resulted in dt = " << dt
                   << std::endl;
       }
+      std::flush(std::cout);
       couplingParticipant.advance(dt);
-    }
 
-    if (getParam<bool>("Precice.RunWithCoupling") == true) {
+      // reset to checkpoint if not converged
       if (couplingParticipant.requiresToReadCheckpoint()) {
         x    = xCheckpoint;
         xOld = x;
         timeLoop->setTime(timeCheckpoint, timeStepCheckpoint);
+        // TODO: previousTimeStep might be more appropriate, last one could be small
         timeLoop->setTimeStepSize(dt);
         gridVariables->update(x);
         gridVariables->advanceTimeStep();
-      } else // coupling successful OR not at time window!!
-      {
-        xOld = x;
-        n += 1;
-        if (n == vtkOutputInterval) {
-          problem->updateVtkOutput(x);
-          vtkWriter.write(timeLoop->time());
-          n = 0;
-        }
-      }
-    } else {
-      xOld = x;
-      // output every outputinterval steps
-      n += 1;
-      if (n == vtkOutputInterval) {
-        problem->updateVtkOutput(x);
-        vtkWriter.write(timeLoop->time());
-        n = 0;
+        continue;
       }
     }
-    // set new dt as suggested by the newton solver or by preCICE
-    timeLoop->setTimeStepSize(dt);
 
     std::cout << "Time: " << timeLoop->time() << std::endl;
 
@@ -376,7 +370,7 @@ int main(int argc, char **argv)
   ////////////////////////////////////////////////////////////
   // finalize, print dumux message to say goodbye
   ////////////////////////////////////////////////////////////
-  if (getParam<bool>("Precice.RunWithCoupling") == true) {
+  if (runWithCoupling) {
     couplingParticipant.finalize();
   }
   // print dumux end message

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -101,6 +101,7 @@ int main(int argc, char **argv)
   auto &couplingParticipant = Dumux::Precice::CouplingAdapter::getInstance();
 
   const auto runWithCoupling = getParam<bool>("Precice.RunWithCoupling");
+
   if (runWithCoupling) {
     couplingParticipant.announceSolver("macro-heat", preciceConfigFilename,
                                        mpiHelper.rank(), mpiHelper.size());
@@ -133,10 +134,10 @@ int main(int argc, char **argv)
       std::cout << " ;" << std::endl;
     }
   }
+
   std::cout << "Number of Coupled Cells:" << coupledElementIdxs.size()
             << std::endl;
 
-  // initialize preCICE
   auto numberOfElements =
       coords.size() / couplingParticipant.getMeshDimensions(meshName);
   if (runWithCoupling) {
@@ -208,7 +209,7 @@ int main(int argc, char **argv)
   auto gridVariables  = std::make_shared<GridVariables>(problem, gridGeometry);
   gridVariables->init(x);
 
-  // intialize the vtk output module
+  // initialize the vtk output module
   using IOFields = GetPropType<TypeTag, Properties::IOFields>;
   VtkOutputModule<GridVariables, SolutionVector> vtkWriter(*gridVariables, x,
                                                            problem->name());
@@ -225,7 +226,7 @@ int main(int argc, char **argv)
   // output every vtkOutputInterval time step
   const int vtkOutputInterval = getParam<int>("TimeLoop.OutputInterval");
 
-  // initialize
+  // initialize preCICE
   couplingParticipant.initialize();
 
   // time loop parameters
@@ -302,14 +303,15 @@ int main(int argc, char **argv)
           nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()),
           timeLoop->maxTimeStepSize());
     }
-    // set new dt as suggested by the newton solver or by preCICE
+    // set new dt as suggested by the Newton solver or by preCICE
     timeLoop->setTimeStepSize(dt);
 
-    std::cout << "Solver starts with Target dt: " << dt << std::endl;
+    std::cout << "Solver starts with target dt: " << dt << std::endl;
 
     // linearize & solve
     nonLinearSolver.solve(x, *timeLoop);
-    // save actual time-step size
+
+    // save dt value that was actually used by the non-linear solver
     dt = timeLoop->timeStepSize();
 
     // DuMux advance + report
@@ -319,7 +321,7 @@ int main(int argc, char **argv)
     xOld = x;
 
     // Vtk output
-    // TODO: output interval doesn't work easily with subcycling
+    // TODO: output interval does not work seamlessly when subcycling
     n += 1;
     if (n == vtkOutputInterval) {
       problem->updateVtkOutput(x);
@@ -343,7 +345,7 @@ int main(int argc, char **argv)
       couplingParticipant.writeQuantityToOtherSolver(meshName,
                                                      writeDataConcentration);
 
-      // advance precice
+      // advance preCICE
       if ((!fabs(preciceDt - dt)) < 1e-14) {
         std::cout << "dt from preCICE is different than dt from DuMuX."
                   << " preCICE dt = " << preciceDt
@@ -359,6 +361,7 @@ int main(int argc, char **argv)
         x    = xCheckpoint;
         xOld = x;
         timeLoop->setTime(timeCheckpoint, timeStepCheckpoint);
+
         // TODO: previousTimeStep might be more appropriate, last one could be small
         timeLoop->setTimeStepSize(dt);
         gridVariables->update(x);

--- a/two-scale-heat-conduction/macro-dumux/params.input
+++ b/two-scale-heat-conduction/macro-dumux/params.input
@@ -14,9 +14,9 @@ UpperRight = 1 0.5
 Cells = 8 4
 
 [TimeLoop]
-TEnd = 0.25 
+TEnd = 0.025
 OutputInterval = 1 # output after every n timesteps 
-MaxDt = 0.01 
+MaxDt = 0.004
 InitialDt = 0.01
 
 [Problem]

--- a/two-scale-heat-conduction/precice-config.xml
+++ b/two-scale-heat-conduction/precice-config.xml
@@ -63,7 +63,7 @@
 
   <coupling-scheme:serial-implicit>
     <participants first="macro-heat" second="Micro-Manager" />
-    <max-time value="0.02" />
+    <max-time value="0.025" />
     <time-window-size value="1.0e-2" />
     <max-iterations value="30" />
     <exchange data="k_00" mesh="macro-mesh" from="Micro-Manager" to="macro-heat" />


### PR DESCRIPTION
<!-- Please submit your Pull Request to the `develop` branch.

It may help to have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

Checkpointing was mixed up with normal DuMux time-step advances, breaking the macro-dumux participant in the case of subcycling. Fixed checkpointing and subcycling and cleaned up the time loop.

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
