### PR TITLE
Changing wording of Calculix case in perpendicular-flap

### DIFF
--- a/perpendicular-flap/README.md
+++ b/perpendicular-flap/README.md
@@ -89,7 +89,7 @@ You should get results similar to this one:
 
 Reasons for the differences:
 
-* The CalculiX adapter only supports linear finite elements (deal.II uses 4th order, FEniCS 2nd order).
+* The CalculiX mesh uses the linear element [C3D8I](https://web.mit.edu/calculix_v2.7/CalculiX/ccx_2.7/doc/ccx/node28.html), as opposed to FEniCS using a quadratic element, and deal.II using a 4th order element.
 * SU2 models a compressible fluid, OpenFOAM and Nutils an incompressible one.  
 
 ### Looking closer


### PR DESCRIPTION
The reason why the result for the perpendicular-flap tutorial using CalculiX as a solid solver is different than when FEniCS or deal.II is used, is misleading. It was pointed out by a user in [this post](https://precice.discourse.group/t/recommended-solid-solver-with-3d-functionality/1094/5?u=ishaandesai). This PR changes the comment to clarify the disparity.

Checklist:

- [ ] ~~I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.~~
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
