### PR TITLE
Switch to adapter-based checkpointing in the two-scale heat conduction tutorial

### DIFF
--- a/changelog-entries/676.md
+++ b/changelog-entries/676.md
@@ -1,0 +1,1 @@
+- Switched to adapter-based checkpointing in the macro-dumux participant of the two-scale heat conduction tutorial [#676](https://github.com/precice/tutorials/pull/676)

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -222,6 +222,11 @@ int main(int argc, char **argv)
   // output every vtkOutputInterval time step
   const int vtkOutputInterval = getParam<int>("TimeLoop.OutputInterval");
 
+  // initialize preCICE
+  if (runWithCoupling) {
+    couplingParticipant.initialize();
+  }
+
   // time loop parameters
   const auto tEnd      = getParam<Scalar>("TimeLoop.TEnd");
   double     preciceDt = couplingParticipant.getMaxTimeStepSize();
@@ -239,10 +244,9 @@ int main(int argc, char **argv)
   auto timeLoop = std::make_shared<TimeLoop<Scalar>>(0.0, dt, tEnd);
   timeLoop->setMaxTimeStepSize(getParam<Scalar>("TimeLoop.MaxDt"));
 
-  // initialize preCICE and the adapter checkpointing
+  // initialize adapter checkpointing
   if (runWithCoupling) {
-    couplingParticipant.initialize();
-    couplingParticipant.initializeCheckpoint(x, *gridVariables, timeLoop);
+    couplingParticipant.initializeCheckpoint(x, *gridVariables, *timeLoop);
   }
 
   // the assembler with time loop for instationary problem

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -173,8 +173,6 @@ int main(int argc, char **argv)
   problem->applyInitialSolution(x);
   auto xOld = x;
 
-  int timeStepCheckpoint = 0;
-
   // initialize the coupling data
   std::vector<double> temperatures;
   for (int solIdx = 0; solIdx < numberOfElements; ++solIdx) {
@@ -224,12 +222,6 @@ int main(int argc, char **argv)
   // output every vtkOutputInterval time step
   const int vtkOutputInterval = getParam<int>("TimeLoop.OutputInterval");
 
-  // initialize preCICE and the adapter checkpointing
-  if (runWithCoupling) {
-    couplingParticipant.initialize();
-    couplingParticipant.initializeCheckpoint(x, *gridVariables);
-  }
-
   // time loop parameters
   const auto tEnd      = getParam<Scalar>("TimeLoop.TEnd");
   double     preciceDt = couplingParticipant.getMaxTimeStepSize();
@@ -246,6 +238,12 @@ int main(int argc, char **argv)
   // instantiate time loop
   auto timeLoop = std::make_shared<TimeLoop<Scalar>>(0.0, dt, tEnd);
   timeLoop->setMaxTimeStepSize(getParam<Scalar>("TimeLoop.MaxDt"));
+
+  // initialize preCICE and the adapter checkpointing
+  if (runWithCoupling) {
+    couplingParticipant.initialize();
+    couplingParticipant.initializeCheckpoint(x, *gridVariables, timeLoop);
+  }
 
   // the assembler with time loop for instationary problem
   using Assembler = FVAssembler<TypeTag, DiffMethod::numeric>;
@@ -273,9 +271,7 @@ int main(int argc, char **argv)
         break;
 
       // write checkpoint
-      if (couplingParticipant.writeCheckpointIfRequired()) {
-        timeStepCheckpoint = timeLoop->timeStepIndex();
-      }
+      couplingParticipant.writeCheckpointIfRequired();
 
       preciceDt = couplingParticipant.getMaxTimeStepSize();
       solverDt  = std::min(nonLinearSolver.suggestTimeStepSize(timeLoop->timeStepSize()),
@@ -357,9 +353,8 @@ int main(int argc, char **argv)
 
       // reset to checkpoint if not converged
       if (couplingParticipant.readCheckpointIfRequired()) {
-        // TODO: previousTimeStep might be more appropriate, last one could be small
-        timeLoop->setTimeStepSize(dt);
         gridVariables->advanceTimeStep();
+        xOld = x;
         continue;
       }
     }

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -173,8 +173,7 @@ int main(int argc, char **argv)
   problem->applyInitialSolution(x);
   auto xOld = x;
 
-  double timeCheckpoint     = 0.0;
-  int    timeStepCheckpoint = 0;
+  int timeStepCheckpoint = 0;
 
   // initialize the coupling data
   std::vector<double> temperatures;
@@ -275,7 +274,6 @@ int main(int argc, char **argv)
 
       // write checkpoint
       if (couplingParticipant.writeCheckpointIfRequired()) {
-        timeCheckpoint     = timeLoop->time();
         timeStepCheckpoint = timeLoop->timeStepIndex();
       }
 
@@ -359,11 +357,8 @@ int main(int argc, char **argv)
 
       // reset to checkpoint if not converged
       if (couplingParticipant.readCheckpointIfRequired()) {
-        timeLoop->setTime(timeCheckpoint, timeStepCheckpoint);
-
         // TODO: previousTimeStep might be more appropriate, last one could be small
         timeLoop->setTimeStepSize(dt);
-        gridVariables->update(x);
         gridVariables->advanceTimeStep();
         continue;
       }

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -173,7 +173,6 @@ int main(int argc, char **argv)
   problem->applyInitialSolution(x);
   auto xOld = x;
 
-  auto   xCheckpoint        = x;
   double timeCheckpoint     = 0.0;
   int    timeStepCheckpoint = 0;
 
@@ -226,8 +225,11 @@ int main(int argc, char **argv)
   // output every vtkOutputInterval time step
   const int vtkOutputInterval = getParam<int>("TimeLoop.OutputInterval");
 
-  // initialize preCICE
-  couplingParticipant.initialize();
+  // initialize preCICE and the adapter checkpointing
+  if (runWithCoupling) {
+    couplingParticipant.initialize();
+    couplingParticipant.initializeCheckpoint(x, *gridVariables);
+  }
 
   // time loop parameters
   const auto tEnd      = getParam<Scalar>("TimeLoop.TEnd");
@@ -272,8 +274,7 @@ int main(int argc, char **argv)
         break;
 
       // write checkpoint
-      if (couplingParticipant.requiresToWriteCheckpoint()) {
-        xCheckpoint        = x;
+      if (couplingParticipant.writeCheckpointIfRequired()) {
         timeCheckpoint     = timeLoop->time();
         timeStepCheckpoint = timeLoop->timeStepIndex();
       }
@@ -357,9 +358,7 @@ int main(int argc, char **argv)
       couplingParticipant.advance(dt);
 
       // reset to checkpoint if not converged
-      if (couplingParticipant.requiresToReadCheckpoint()) {
-        x    = xCheckpoint;
-        xOld = x;
+      if (couplingParticipant.readCheckpointIfRequired()) {
         timeLoop->setTime(timeCheckpoint, timeStepCheckpoint);
 
         // TODO: previousTimeStep might be more appropriate, last one could be small


### PR DESCRIPTION
In the macro-dumux participant of the two-scale heat conduction tutorial, the checkpointing is currently done manually. https://github.com/precice/dumux-adapter/pull/58 introduces checkpointing functionality in the DuMuX adapter. This PR changes macro-dumux to use this functionality.

**Note**: Not to be merged before https://github.com/precice/dumux-adapter/pull/58. This PR is for testing purposes.

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
