### PR TITLE
Quickstart: Bump preCICE to v3.3.0 and update list of packages

### DIFF
--- a/changelog-entries/691.md
+++ b/changelog-entries/691.md
@@ -1,0 +1,1 @@
+- Updated the recommended preCICE version in the Quickstart tutorial [#691](https://github.com/precice/tutorials/pull/691)

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -21,15 +21,16 @@ To get a feeling what preCICE does, watch a [short presentation](https://www.you
 1. Get and install preCICE. For Ubuntu 24.04 (Noble Numbat), this is pretty easy: [download](https://github.com/precice/precice/releases/latest) and install our binary package by clicking on it or using the following commands:
 
     ```bash
-    wget https://github.com/precice/precice/releases/download/v3.2.0/libprecice3_3.2.0_noble.deb
-    sudo apt install ./libprecice3_3.2.0_noble.deb
+    wget https://github.com/precice/precice/releases/download/v3.3.0/libprecice3_3.3.0_noble.deb
+    sudo apt install ./libprecice3_3.3.0_noble.deb
     ```
 
     | OS                            | Package |
     | ---                           | ---     |
-    | Ubuntu 22.04 Jammy Jellyfish  | [`libprecice3_3.2.0_jammy.deb`](https://github.com/precice/precice/releases/download/v3.2.0/libprecice3_3.2.0_jammy.deb) |
-    | Ubuntu 24.04 Noble Numbat  | [`libprecice3_3.2.0_noble.deb`](https://github.com/precice/precice/releases/download/v3.2.0/libprecice3_3.2.0_noble.deb) |
-    | Debian 12 "bookworm"          | [`libprecice3_3.2.0_bookworm.deb`](https://github.com/precice/precice/releases/download/v3.2.0/libprecice3_3.2.0_bookworm.deb) |
+    | Ubuntu 22.04 Jammy Jellyfish  | [`libprecice3_3.3.0_jammy.deb`](https://github.com/precice/precice/releases/download/v3.3.0/libprecice3_3.3.0_jammy.deb) |
+    | Ubuntu 24.04 Noble Numbat     | [`libprecice3_3.3.0_noble.deb`](https://github.com/precice/precice/releases/download/v3.3.0/libprecice3_3.3.0_noble.deb) |
+    | Ubuntu 25.10 Questing Quokka  | [`libprecice3_3.3.0_questing.deb`](https://github.com/precice/precice/releases/download/v3.3.0/libprecice3_3.3.0_questing.deb) |
+    | Debian 13 Trixie              | [`libprecice3_3.3.0_trixie.deb`](https://github.com/precice/precice/releases/download/v3.3.0/libprecice3_3.3.0_trixie.deb) |
     | Something else                | See an [overview of options](https://precice.org/installation-overview.html) |
 
     Facing any problems? [Ask for help](https://precice.org/community-channels.html).


### PR DESCRIPTION
Related to #690, but with smaller scope and quicker to merge: only updates the preCICE version and packages in the Quickstart README.