### PR TITLE
System tests: Escape strings in commit info

### DIFF
--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -80,49 +80,49 @@ jobs:
       - id: summary
         name: Prepare Markdown summary
         run: |
-          echo "## Git references of latest (develop) components" >> $GITHUB_STEP_SUMMARY
-          echo "### preCICE" >> $GITHUB_STEP_SUMMARY
-          echo "Reference: [\`${{ steps.ref-precice.outputs.shorthash }}\`](https://github.com/precice/precice/commit/${{ steps.ref-precice.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
-          echo "Description:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.ref-precice.outputs.description }}' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "### Python bindings" >> $GITHUB_STEP_SUMMARY
-          echo "Reference: [\`${{ steps.ref-python-bindings.outputs.shorthash }}\`](https://github.com/precice/python-bindings/commit/${{ steps.ref-python-bindings.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
-          echo "Description:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.ref-python-bindings.outputs.description }}' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "### CalculiX adapter" >> $GITHUB_STEP_SUMMARY
-          echo "Reference: [\`${{ steps.ref-calculix-adapter.outputs.shorthash }}\`](https://github.com/precice/calculix-adapter/commit/${{ steps.ref-calculix-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
-          echo "Description:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.ref-calculix-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "### FEniCS adapter" >> $GITHUB_STEP_SUMMARY
-          echo "Reference: [\`${{ steps.ref-fenics-adapter.outputs.shorthash }}\`](https://github.com/precice/fenics-adapter/commit/${{ steps.ref-fenics-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
-          echo "Description:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.ref-fenics-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "### OpenFOAM adapter" >> $GITHUB_STEP_SUMMARY
-          echo "Reference: [\`${{ steps.ref-openfoam-adapter.outputs.shorthash }}\`](https://github.com/precice/openfoam-adapter/commit/${{ steps.ref-openfoam-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
-          echo "Description:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.ref-openfoam-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "### SU2 adapter" >> $GITHUB_STEP_SUMMARY
-          echo "Reference: [\`${{ steps.ref-su2-adapter.outputs.shorthash }}\`](https://github.com/precice/su2-adapter/commit/${{ steps.ref-su2-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
-          echo "Description:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.ref-su2-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "### Tutorials" >> $GITHUB_STEP_SUMMARY
-          echo "Reference: [\`${{ steps.ref-tutorials.outputs.shorthash }}\`](https://github.com/precice/tutorials/commit/${{ steps.ref-tutorials.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
-          echo "Description:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.ref-tutorials.outputs.description }}'' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "## Git references of latest (develop) components" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### preCICE" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference: [\`${{ steps.ref-precice.outputs.shorthash }}\`](https://github.com/precice/precice/commit/${{ steps.ref-precice.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' '${{ steps.ref-precice.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### Python bindings" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference: [\`${{ steps.ref-python-bindings.outputs.shorthash }}\`](https://github.com/precice/python-bindings/commit/${{ steps.ref-python-bindings.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' '${{ steps.ref-python-bindings.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### CalculiX adapter" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference: [\`${{ steps.ref-calculix-adapter.outputs.shorthash }}\`](https://github.com/precice/calculix-adapter/commit/${{ steps.ref-calculix-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' '${{ steps.ref-calculix-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### FEniCS adapter" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference: [\`${{ steps.ref-fenics-adapter.outputs.shorthash }}\`](https://github.com/precice/fenics-adapter/commit/${{ steps.ref-fenics-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' '${{ steps.ref-fenics-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### OpenFOAM adapter" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference: [\`${{ steps.ref-openfoam-adapter.outputs.shorthash }}\`](https://github.com/precice/openfoam-adapter/commit/${{ steps.ref-openfoam-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' '${{ steps.ref-openfoam-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### SU2 adapter" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference: [\`${{ steps.ref-su2-adapter.outputs.shorthash }}\`](https://github.com/precice/su2-adapter/commit/${{ steps.ref-su2-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' '${{ steps.ref-su2-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### Tutorials" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference: [\`${{ steps.ref-tutorials.outputs.shorthash }}\`](https://github.com/precice/tutorials/commit/${{ steps.ref-tutorials.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' '${{ steps.ref-tutorials.outputs.description }}'' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
   run-system-tests:
     name: Trigger system tests

--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -85,43 +85,43 @@ jobs:
           printf '%q\n' "Reference: [\`${{ steps.ref-precice.outputs.shorthash }}\`](https://github.com/precice/precice/commit/${{ steps.ref-precice.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf '%q\n' '${{ steps.ref-precice.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "${{ steps.ref-precice.outputs.description }}" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### Python bindings" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-python-bindings.outputs.shorthash }}\`](https://github.com/precice/python-bindings/commit/${{ steps.ref-python-bindings.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf '%q\n' '${{ steps.ref-python-bindings.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "${{ steps.ref-python-bindings.outputs.description }}" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### CalculiX adapter" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-calculix-adapter.outputs.shorthash }}\`](https://github.com/precice/calculix-adapter/commit/${{ steps.ref-calculix-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf '%q\n' '${{ steps.ref-calculix-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "${{ steps.ref-calculix-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### FEniCS adapter" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-fenics-adapter.outputs.shorthash }}\`](https://github.com/precice/fenics-adapter/commit/${{ steps.ref-fenics-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf '%q\n' '${{ steps.ref-fenics-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "${{ steps.ref-fenics-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### OpenFOAM adapter" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-openfoam-adapter.outputs.shorthash }}\`](https://github.com/precice/openfoam-adapter/commit/${{ steps.ref-openfoam-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf '%q\n' '${{ steps.ref-openfoam-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "${{ steps.ref-openfoam-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### SU2 adapter" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-su2-adapter.outputs.shorthash }}\`](https://github.com/precice/su2-adapter/commit/${{ steps.ref-su2-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf '%q\n' '${{ steps.ref-su2-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "${{ steps.ref-su2-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### Tutorials" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-tutorials.outputs.shorthash }}\`](https://github.com/precice/tutorials/commit/${{ steps.ref-tutorials.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf '%q\n' '${{ steps.ref-tutorials.outputs.description }}'' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "${{ steps.ref-tutorials.outputs.description }}"' >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
   run-system-tests:

--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -70,13 +70,13 @@ jobs:
       - id: report-refs
         name: Report Git refs
         run: |
-          printf 'preCICE: ${{ steps.ref-precice.outputs.shorthash }}\n ${{ steps.ref-precice.outputs.description }}\n----------\n'
-          printf 'Python bindings: ${{ steps.ref-python-bindings.outputs.shorthash }}\n ${{ steps.ref-python-bindings.outputs.description }}\n----------\n'
-          printf 'CalculiX adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}\n ${{ steps.ref-calculix-adapter.outputs.description }}\n----------\n'
-          printf 'FEniCS adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}\n ${{ steps.ref-fenics-adapter.outputs.description }}\n----------\n'
-          printf 'OpenFOAM adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }} ${{ steps.ref-openfoam-adapter.outputs.description }}\n----------\n'
-          printf 'SU2 adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}\n ${{ steps.ref-su2-adapter.outputs.description }}\n----------\n'
-          printf 'Tutorials: ${{ steps.ref-tutorials.outputs.shorthash }} ${{ steps.ref-tutorials.outputs.description }}\n----------\n'
+          printf '%q\n' "preCICE: ${{ steps.ref-precice.outputs.shorthash }}\n ${{ steps.ref-precice.outputs.description }}\n----------\n"
+          printf '%q\n' "Python bindings: ${{ steps.ref-python-bindings.outputs.shorthash }}\n ${{ steps.ref-python-bindings.outputs.description }}\n----------\n"
+          printf '%q\n' "CalculiX adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}\n ${{ steps.ref-calculix-adapter.outputs.description }}\n----------\n"
+          printf '%q\n' "FEniCS adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}\n ${{ steps.ref-fenics-adapter.outputs.description }}\n----------\n"
+          printf '%q\n' "OpenFOAM adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }} ${{ steps.ref-openfoam-adapter.outputs.description }}\n----------\n"
+          printf '%q\n' "SU2 adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}\n ${{ steps.ref-su2-adapter.outputs.description }}\n----------\n"
+          printf '%q\n' "Tutorials: ${{ steps.ref-tutorials.outputs.shorthash }} ${{ steps.ref-tutorials.outputs.description }}\n----------\n"
       - id: summary
         name: Prepare Markdown summary
         run: |

--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -85,43 +85,43 @@ jobs:
           echo "Reference: [\`${{ steps.ref-precice.outputs.shorthash }}\`](https://github.com/precice/precice/commit/${{ steps.ref-precice.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-precice.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.ref-precice.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### Python bindings" >> $GITHUB_STEP_SUMMARY
           echo "Reference: [\`${{ steps.ref-python-bindings.outputs.shorthash }}\`](https://github.com/precice/python-bindings/commit/${{ steps.ref-python-bindings.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-python-bindings.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.ref-python-bindings.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### CalculiX adapter" >> $GITHUB_STEP_SUMMARY
           echo "Reference: [\`${{ steps.ref-calculix-adapter.outputs.shorthash }}\`](https://github.com/precice/calculix-adapter/commit/${{ steps.ref-calculix-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-calculix-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.ref-calculix-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### FEniCS adapter" >> $GITHUB_STEP_SUMMARY
           echo "Reference: [\`${{ steps.ref-fenics-adapter.outputs.shorthash }}\`](https://github.com/precice/fenics-adapter/commit/${{ steps.ref-fenics-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-fenics-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.ref-fenics-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### OpenFOAM adapter" >> $GITHUB_STEP_SUMMARY
           echo "Reference: [\`${{ steps.ref-openfoam-adapter.outputs.shorthash }}\`](https://github.com/precice/openfoam-adapter/commit/${{ steps.ref-openfoam-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-openfoam-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.ref-openfoam-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### SU2 adapter" >> $GITHUB_STEP_SUMMARY
           echo "Reference: [\`${{ steps.ref-su2-adapter.outputs.shorthash }}\`](https://github.com/precice/su2-adapter/commit/${{ steps.ref-su2-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-su2-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.ref-su2-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### Tutorials" >> $GITHUB_STEP_SUMMARY
           echo "Reference: [\`${{ steps.ref-tutorials.outputs.shorthash }}\`](https://github.com/precice/tutorials/commit/${{ steps.ref-tutorials.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-tutorials.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.ref-tutorials.outputs.description }}'' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
   run-system-tests:

--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -70,46 +70,46 @@ jobs:
       - id: summary
         name: Prepare Markdown summary
         run: |
-          echo "## Git references of latest (develop) components" >> $GITHUB_STEP_SUMMARY
-          echo "### preCICE" >> $GITHUB_STEP_SUMMARY
-          echo "Reference: [\`${{ steps.ref-precice.outputs.shorthash }}\`](https://github.com/precice/precice/commit/${{ steps.ref-precice.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
-          echo "Description:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.ref-precice.outputs.description }}' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "### Python bindings" >> $GITHUB_STEP_SUMMARY
-          echo "Reference: [\`${{ steps.ref-python-bindings.outputs.shorthash }}\`](https://github.com/precice/python-bindings/commit/${{ steps.ref-python-bindings.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
-          echo "Description:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.ref-python-bindings.outputs.description }}' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "### CalculiX adapter" >> $GITHUB_STEP_SUMMARY
-          echo "Reference: [\`${{ steps.ref-calculix-adapter.outputs.shorthash }}\`](https://github.com/precice/calculix-adapter/commit/${{ steps.ref-calculix-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
-          echo "Description:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.ref-calculix-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "### FEniCS adapter" >> $GITHUB_STEP_SUMMARY
-          echo "Reference: [\`${{ steps.ref-fenics-adapter.outputs.shorthash }}\`](https://github.com/precice/fenics-adapter/commit/${{ steps.ref-fenics-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
-          echo "Description:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.ref-fenics-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "### OpenFOAM adapter" >> $GITHUB_STEP_SUMMARY
-          echo "Reference: [\`${{ steps.ref-openfoam-adapter.outputs.shorthash }}\`](https://github.com/precice/openfoam-adapter/commit/${{ steps.ref-openfoam-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
-          echo "Description:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.ref-openfoam-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "### SU2 adapter" >> $GITHUB_STEP_SUMMARY
-          echo "Reference: [\`${{ steps.ref-su2-adapter.outputs.shorthash }}\`](https://github.com/precice/su2-adapter/commit/${{ steps.ref-su2-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
-          echo "Description:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.ref-su2-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "### Tutorials" >> $GITHUB_STEP_SUMMARY
-          echo "Reference (pull request): \`${{ github.event.pull_request.head.sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "Pull request number: [${{ github.event.number }}](https://github.com/precice/tutorials/pull/${{ github.event.number }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "## Git references of latest (develop) components" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### preCICE" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference: [\`${{ steps.ref-precice.outputs.shorthash }}\`](https://github.com/precice/precice/commit/${{ steps.ref-precice.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf "%q" '${{ steps.ref-precice.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### Python bindings" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference: [\`${{ steps.ref-python-bindings.outputs.shorthash }}\`](https://github.com/precice/python-bindings/commit/${{ steps.ref-python-bindings.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf "%q" '${{ steps.ref-python-bindings.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### CalculiX adapter" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference: [\`${{ steps.ref-calculix-adapter.outputs.shorthash }}\`](https://github.com/precice/calculix-adapter/commit/${{ steps.ref-calculix-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf "%q" '${{ steps.ref-calculix-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### FEniCS adapter" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference: [\`${{ steps.ref-fenics-adapter.outputs.shorthash }}\`](https://github.com/precice/fenics-adapter/commit/${{ steps.ref-fenics-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf "%q" '${{ steps.ref-fenics-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### OpenFOAM adapter" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference: [\`${{ steps.ref-openfoam-adapter.outputs.shorthash }}\`](https://github.com/precice/openfoam-adapter/commit/${{ steps.ref-openfoam-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf "%q" '${{ steps.ref-openfoam-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### SU2 adapter" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference: [\`${{ steps.ref-su2-adapter.outputs.shorthash }}\`](https://github.com/precice/su2-adapter/commit/${{ steps.ref-su2-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf "%q" '${{ steps.ref-su2-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "### Tutorials" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Reference (pull request): \`${{ github.event.pull_request.head.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "Pull request number: [${{ github.event.number }}](https://github.com/precice/tutorials/pull/${{ github.event.number }})" >> $GITHUB_STEP_SUMMARY
 
   run-system-tests:
     name: Trigger system tests

--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -61,12 +61,12 @@ jobs:
       - id: report-refs
         name: Report Git refs
         run: |
-          printf 'preCICE: ${{ steps.ref-precice.outputs.shorthash }}\n ${{ steps.ref-precice.outputs.description }}\n----------\n'
-          printf 'Python bindings: ${{ steps.ref-python-bindings.outputs.shorthash }}\n ${{ steps.ref-python-bindings.outputs.description }}\n----------\n'
-          printf 'CalculiX adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}\n ${{ steps.ref-calculix-adapter.outputs.description }}\n----------\n'
-          printf 'FEniCS adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}\n ${{ steps.ref-fenics-adapter.outputs.description }}\n----------\n'
-          printf 'OpenFOAM adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }} ${{ steps.ref-openfoam-adapter.outputs.description }}\n----------\n'
-          printf 'SU2 adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}\n ${{ steps.ref-su2-adapter.outputs.description }}\n----------\n'
+          printf '%q\n' "preCICE: ${{ steps.ref-precice.outputs.shorthash }}\n ${{ steps.ref-precice.outputs.description }}\n----------\n"
+          printf '%q\n' "Python bindings: ${{ steps.ref-python-bindings.outputs.shorthash }}\n ${{ steps.ref-python-bindings.outputs.description }}\n----------\n"
+          printf '%q\n' "CalculiX adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}\n ${{ steps.ref-calculix-adapter.outputs.description }}\n----------\n"
+          printf '%q\n' "FEniCS adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}\n ${{ steps.ref-fenics-adapter.outputs.description }}\n----------\n"
+          printf '%q\n' "OpenFOAM adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }} ${{ steps.ref-openfoam-adapter.outputs.description }}\n----------\n"
+          printf '%q\n' "SU2 adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}\n ${{ steps.ref-su2-adapter.outputs.description }}\n----------\n"
       - id: summary
         name: Prepare Markdown summary
         run: |

--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -75,37 +75,37 @@ jobs:
           printf '%q\n' "Reference: [\`${{ steps.ref-precice.outputs.shorthash }}\`](https://github.com/precice/precice/commit/${{ steps.ref-precice.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf '%q\n' '${{ steps.ref-precice.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "${{ steps.ref-precice.outputs.description }}" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### Python bindings" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-python-bindings.outputs.shorthash }}\`](https://github.com/precice/python-bindings/commit/${{ steps.ref-python-bindings.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf '%q\n' '${{ steps.ref-python-bindings.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "${{ steps.ref-python-bindings.outputs.description }}" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### CalculiX adapter" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-calculix-adapter.outputs.shorthash }}\`](https://github.com/precice/calculix-adapter/commit/${{ steps.ref-calculix-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf '%q\n' '${{ steps.ref-calculix-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "${{ steps.ref-calculix-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### FEniCS adapter" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-fenics-adapter.outputs.shorthash }}\`](https://github.com/precice/fenics-adapter/commit/${{ steps.ref-fenics-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf '%q\n' '${{ steps.ref-fenics-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "${{ steps.ref-fenics-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### OpenFOAM adapter" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-openfoam-adapter.outputs.shorthash }}\`](https://github.com/precice/openfoam-adapter/commit/${{ steps.ref-openfoam-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf '%q\n' '${{ steps.ref-openfoam-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "${{ steps.ref-openfoam-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### SU2 adapter" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-su2-adapter.outputs.shorthash }}\`](https://github.com/precice/su2-adapter/commit/${{ steps.ref-su2-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf '%q\n' '${{ steps.ref-su2-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' "${{ steps.ref-su2-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### Tutorials" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference (pull request): \`${{ github.event.pull_request.head.sha }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -75,37 +75,37 @@ jobs:
           printf '%q\n' "Reference: [\`${{ steps.ref-precice.outputs.shorthash }}\`](https://github.com/precice/precice/commit/${{ steps.ref-precice.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf "%q" '${{ steps.ref-precice.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' '${{ steps.ref-precice.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### Python bindings" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-python-bindings.outputs.shorthash }}\`](https://github.com/precice/python-bindings/commit/${{ steps.ref-python-bindings.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf "%q" '${{ steps.ref-python-bindings.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' '${{ steps.ref-python-bindings.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### CalculiX adapter" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-calculix-adapter.outputs.shorthash }}\`](https://github.com/precice/calculix-adapter/commit/${{ steps.ref-calculix-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf "%q" '${{ steps.ref-calculix-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' '${{ steps.ref-calculix-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### FEniCS adapter" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-fenics-adapter.outputs.shorthash }}\`](https://github.com/precice/fenics-adapter/commit/${{ steps.ref-fenics-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf "%q" '${{ steps.ref-fenics-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' '${{ steps.ref-fenics-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### OpenFOAM adapter" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-openfoam-adapter.outputs.shorthash }}\`](https://github.com/precice/openfoam-adapter/commit/${{ steps.ref-openfoam-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf "%q" '${{ steps.ref-openfoam-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' '${{ steps.ref-openfoam-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### SU2 adapter" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference: [\`${{ steps.ref-su2-adapter.outputs.shorthash }}\`](https://github.com/precice/su2-adapter/commit/${{ steps.ref-su2-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Description:" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          printf "%q" '${{ steps.ref-su2-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
+          printf '%q\n' '${{ steps.ref-su2-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "\`\`\`" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "### Tutorials" >> $GITHUB_STEP_SUMMARY
           printf '%q\n' "Reference (pull request): \`${{ github.event.pull_request.head.sha }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -75,37 +75,37 @@ jobs:
           echo "Reference: [\`${{ steps.ref-precice.outputs.shorthash }}\`](https://github.com/precice/precice/commit/${{ steps.ref-precice.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-precice.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.ref-precice.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### Python bindings" >> $GITHUB_STEP_SUMMARY
           echo "Reference: [\`${{ steps.ref-python-bindings.outputs.shorthash }}\`](https://github.com/precice/python-bindings/commit/${{ steps.ref-python-bindings.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-python-bindings.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.ref-python-bindings.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### CalculiX adapter" >> $GITHUB_STEP_SUMMARY
           echo "Reference: [\`${{ steps.ref-calculix-adapter.outputs.shorthash }}\`](https://github.com/precice/calculix-adapter/commit/${{ steps.ref-calculix-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-calculix-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.ref-calculix-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### FEniCS adapter" >> $GITHUB_STEP_SUMMARY
           echo "Reference: [\`${{ steps.ref-fenics-adapter.outputs.shorthash }}\`](https://github.com/precice/fenics-adapter/commit/${{ steps.ref-fenics-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-fenics-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.ref-fenics-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### OpenFOAM adapter" >> $GITHUB_STEP_SUMMARY
           echo "Reference: [\`${{ steps.ref-openfoam-adapter.outputs.shorthash }}\`](https://github.com/precice/openfoam-adapter/commit/${{ steps.ref-openfoam-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-openfoam-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.ref-openfoam-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### SU2 adapter" >> $GITHUB_STEP_SUMMARY
           echo "Reference: [\`${{ steps.ref-su2-adapter.outputs.shorthash }}\`](https://github.com/precice/su2-adapter/commit/${{ steps.ref-su2-adapter.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
           echo "Description:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ref-su2-adapter.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.ref-su2-adapter.outputs.description }}' >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### Tutorials" >> $GITHUB_STEP_SUMMARY
           echo "Reference (pull request): \`${{ github.event.pull_request.head.sha }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
~~Replaces double quotes with single quotes in the Markdown summary tables, as suggested in #674.~~

The main table (with `printf '...'`) is still failing with the `'` in `Eigen's` in https://github.com/precice/precice/commit/40a98c3f0cf5543eae2352d0dd09b9424c486462

Error: https://github.com/precice/tutorials/actions/runs/20990221387/job/60333606849?pr=694


Tried with `printf '%q\n' "message"`, but then this does not handle backticks, and it messes up with the Markdown rendering. It looks like we cannot easily handle both backticks and single quotes.