### PR TITLE
Improve compilation script for cases with DuMux

### DIFF
--- a/changelog-entries/701.md
+++ b/changelog-entries/701.md
@@ -1,0 +1,1 @@
+- Changed the compilation script for the tutorials with DuMux solvers to allow the cases to be compiled from scratch into a DUNE module.

--- a/free-flow-over-porous-media/compile-dumux-cases.sh
+++ b/free-flow-over-porous-media/compile-dumux-cases.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -e -u
 
-# To compile free-flow-dumux and porous-media-dumux from zero or recompile them after changes
+# To compile free-flow-dumux and porous-media-dumux from scratch or recompile them after changes
 ./dune-common/bin/dunecontrol --opts=./dumux/cmake.opts --only=free_flow_dumux all
 ./dune-common/bin/dunecontrol --opts=./dumux/cmake.opts --only=porous_media_dumux all
 

--- a/free-flow-over-porous-media/compile-dumux-cases.sh
+++ b/free-flow-over-porous-media/compile-dumux-cases.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env sh
 set -e -u
 
-(
-cd free-flow-dumux/build-cmake/solver-dumux
-make free_flow_dumux
-)
+# To compile free-flow-dumux and porous-media-dumux from zero or recompile them after changes
+./dune-common/bin/dunecontrol --opts=./dumux/cmake.opts --only=free_flow_dumux all
+./dune-common/bin/dunecontrol --opts=./dumux/cmake.opts --only=porous_media_dumux all
 
-(
-cd porous-media-dumux/build-cmake/solver-dumux
-make porous_media_dumux
-)
+# Alternatively, you can manually recompile free-flow-dumux and porous-media-dumux when the `build-cmake` folder is present by uncommenting the following lines:
+# (
+# cd free-flow-dumux/build-cmake/solver-dumux
+# make free_flow_dumux
+# )
+
+# (
+# cd porous-media-dumux/build-cmake/solver-dumux
+# make porous_media_dumux
+# )
 
 # Move free-flow-dumux and porous-media-dumux executables to the participant folder level
 mv free-flow-dumux/build-cmake/solver-dumux/free_flow_dumux free-flow-dumux/

--- a/two-scale-heat-conduction/compile-dumux-cases.sh
+++ b/two-scale-heat-conduction/compile-dumux-cases.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -e -u
 
-# To compile macro-dumux and micro-dumux from zero or recompile them after changes
+# To compile macro-dumux and micro-dumux from scratch or recompile them after changes
 ./dune-common/bin/dunecontrol --opts=./dumux/cmake.opts --only=macro_dumux all
 ./dune-common/bin/dunecontrol --opts=./dumux/cmake.opts --only=micro_sim all
 

--- a/two-scale-heat-conduction/compile-dumux-cases.sh
+++ b/two-scale-heat-conduction/compile-dumux-cases.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env sh
 set -e -u
 
-cd macro-dumux/build-cmake/appl
-make macro_dumux
-cd ../../../micro-dumux/build-cmake/appl
-make
-cd ../../../
+# To compile macro-dumux and micro-dumux from zero or recompile them after changes
+./dune-common/bin/dunecontrol --opts=./dumux/cmake.opts --only=macro_dumux all
+./dune-common/bin/dunecontrol --opts=./dumux/cmake.opts --only=micro_sim all
+
+# Alternatively, you can manually recompile macro-dumux and micro-dumux when the `build-cmake` folder is present by uncommenting the following lines:
+# (
+# cd macro-dumux/build-cmake/appl
+# make macro_dumux
+# )
+# (
+# cd micro-dumux/build-cmake/appl
+# make micro_sim
+# )
 
 # Move macro-dumux and micro-dumux executables to the participant folder level
 mv macro-dumux/build-cmake/appl/macro_dumux macro-dumux/
-mv micro-dumux/build-cmake/appl/micro_sim.cpython-310-x86_64-linux-gnu.so micro-dumux/
+mv micro-dumux/build-cmake/appl/micro_sim.cpython-*.so micro-dumux/


### PR DESCRIPTION
With current `compile-dumux-cases` script, it can't compile when the case folders are newly cloned and contains no `build-cmake` folder. In the new ones, two options are offered: compile from zero or only recompile.

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
