### PR TITLE
Add flow-over-heated-plate-two-meshes test case

### DIFF
--- a/changelog-entries/708.md
+++ b/changelog-entries/708.md
@@ -1,0 +1,1 @@
+- Added the flow-over-heated-plate-two-meshes case to the system tests [#708](https://github.com/precice/tutorials/pull/708)

--- a/flow-over-heated-plate-two-meshes/metadata.yaml
+++ b/flow-over-heated-plate-two-meshes/metadata.yaml
@@ -1,0 +1,20 @@
+name: Flow over heated plate with two meshes
+path: flow-over-heated-plate-two-meshes # relative to git repo 
+url: https://precice.org/tutorials-flow-over-heated-plate-two-meshes.html
+
+participants:
+  - Fluid 
+  - Solid 
+
+cases:
+  fluid-openfoam:
+    participant: Fluid
+    directory: ./fluid-openfoam
+    run: ./run.sh 
+    component: openfoam-adapter
+  
+  solid-calculix:
+    participant: Solid
+    directory: ./solid-calculix
+    run: ./run.sh 
+    component: calculix-adapter 

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -30,6 +30,11 @@ test_suites:
           - fluid-openfoam
           - solid-openfoam
         reference_result: ./flow-over-heated-plate-nearest-projection/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+      - path: flow-over-heated-plate-two-meshes
+        case_combination:
+          - fluid-openfoam
+          - solid-calculix
+        reference_result: ./flow-over-heated-plate-two-meshes/reference-results/fluid-openfoam_solid-openfoam.tar.gz
   openfoam_adapter_release:
     tutorials:
       - path: flow-over-heated-plate
@@ -37,6 +42,26 @@ test_suites:
           - fluid-openfoam
           - solid-openfoam
         reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+      - path: perpendicular-flap
+        case_combination:
+          - fluid-openfoam
+          - solid-calculix
+        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-calculix.tar.gz
+      - path: perpendicular-flap
+        case_combination:
+          - fluid-openfoam
+          - solid-openfoam
+        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+      - path: flow-over-heated-plate-nearest-projection
+        case_combination:
+          - fluid-openfoam
+          - solid-openfoam
+        reference_result: ./flow-over-heated-plate-nearest-projection/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+      - path: flow-over-heated-plate-two-meshes
+        case_combination:
+          - fluid-openfoam
+          - solid-calculix
+        reference_result: ./flow-over-heated-plate-two-meshes/reference-results/fluid-openfoam_solid-openfoam.tar.gz
   fenics_test:
     tutorials:
       - path: flow-over-heated-plate
@@ -63,6 +88,11 @@ test_suites:
           - fluid-openfoam
           - solid-calculix
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-calculix.tar.gz
+      - path: flow-over-heated-plate-two-meshes
+        case_combination:
+          - fluid-openfoam
+          - solid-calculix
+        reference_result: ./flow-over-heated-plate-two-meshes/reference-results/fluid-openfoam_solid-openfoam.tar.gz
   dumux_test:
     tutorials:
       - path: two-scale-heat-conduction
@@ -176,6 +206,11 @@ test_suites:
           - fluid-openfoam
           - solid-openfoam
         reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+      - path: flow-over-heated-plate-two-meshes
+        case_combination:
+          - fluid-openfoam
+          - solid-calculix
+        reference_result: ./flow-over-heated-plate-two-meshes/reference-results/fluid-openfoam_solid-openfoam.tar.gz
       - path: perpendicular-flap
         case_combination:
           - fluid-openfoam

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -1,4 +1,13 @@
 test_suites:
+  flow-over-heated-plate-two-meshes:
+    tutorials:
+      - &flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
+        path: flow-over-heated-plate-two-meshes
+        case_combination:
+          - fluid-openfoam
+          - solid-calculix
+        reference_result: ./flow-over-heated-plate-two-meshes/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+
   quickstart_test:
     tutorials:
       - &quickstart
@@ -30,11 +39,7 @@ test_suites:
           - fluid-openfoam
           - solid-openfoam
         reference_result: ./flow-over-heated-plate-nearest-projection/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - path: flow-over-heated-plate-two-meshes
-        case_combination:
-          - fluid-openfoam
-          - solid-calculix
-        reference_result: ./flow-over-heated-plate-two-meshes/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+      - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
   openfoam_adapter_release:
     tutorials:
       - path: flow-over-heated-plate
@@ -57,11 +62,7 @@ test_suites:
           - fluid-openfoam
           - solid-openfoam
         reference_result: ./flow-over-heated-plate-nearest-projection/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - path: flow-over-heated-plate-two-meshes
-        case_combination:
-          - fluid-openfoam
-          - solid-calculix
-        reference_result: ./flow-over-heated-plate-two-meshes/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+      - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
   fenics_test:
     tutorials:
       - path: flow-over-heated-plate
@@ -88,11 +89,7 @@ test_suites:
           - fluid-openfoam
           - solid-calculix
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-calculix.tar.gz
-      - path: flow-over-heated-plate-two-meshes
-        case_combination:
-          - fluid-openfoam
-          - solid-calculix
-        reference_result: ./flow-over-heated-plate-two-meshes/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+      - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
   dumux_test:
     tutorials:
       - path: two-scale-heat-conduction
@@ -206,11 +203,7 @@ test_suites:
           - fluid-openfoam
           - solid-openfoam
         reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - path: flow-over-heated-plate-two-meshes
-        case_combination:
-          - fluid-openfoam
-          - solid-calculix
-        reference_result: ./flow-over-heated-plate-two-meshes/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+      - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
       - path: perpendicular-flap
         case_combination:
           - fluid-openfoam


### PR DESCRIPTION
Our [flow-over-heated-plate-two-meshes tutorial](https://precice.org/tutorials-flow-over-heated-plate-two-meshes.html) has been broken since a few months. This PR adds it to the system tests (follow-up of https://github.com/precice/calculix-adapter/pull/148). It serves as a test case for the CalculiX adapter with one data field/direction exchanged per mesh.

@Fujikawas @IshaanDesai since you are currently working on #696, you might be interested in reviewing this PR.

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] Triggered the generation of reference results: https://github.com/precice/tutorials/actions/runs/21760188808
- [x] Waiting for the system tests to add reference results.
