### PR TITLE
Use configuration reader in dumux-adapter

### DIFF
--- a/changelog-entries/713.md
+++ b/changelog-entries/713.md
@@ -1,0 +1,1 @@
+- Ported the solvers using the DuMux adapter to configure the adapter via parameter file.

--- a/free-flow-over-porous-media/free-flow-dumux/params.input
+++ b/free-flow-over-porous-media/free-flow-dumux/params.input
@@ -35,3 +35,10 @@ AddVelocity = 1
 
 [Output]
 EnableCSVWriter = false
+
+[precice-adapter-config]
+participant_name = Free-Flow
+precice_config_file_path = ../precice-config.xml
+interfaces.1.mesh_name = Free-Flow-Mesh
+interfaces.1.read_data.1.name = Velocity
+interfaces.1.write_data.1.name = Pressure

--- a/free-flow-over-porous-media/free-flow-dumux/solver-dumux/main.cc
+++ b/free-flow-over-porous-media/free-flow-dumux/solver-dumux/main.cc
@@ -353,11 +353,10 @@ int main(int argc, char **argv)
   std::string preciceConfigFilename = "../precice-config.xml";
 
   auto &couplingParticipant = Dumux::Precice::CouplingAdapter::getInstance();
-  couplingParticipant.announceSolver("Free-Flow", preciceConfigFilename,
-                                     mpiHelper.rank(), mpiHelper.size());
+  couplingParticipant.announceConfig(mpiHelper.rank(), mpiHelper.size());
 
-  const std::string meshName("Free-Flow-Mesh"); // mesh name
-  const int         dim = couplingParticipant.getMeshDimensions(meshName);
+  const std::string meshName = couplingParticipant.getMeshNames()[0]; // mesh name
+  const int         dim      = couplingParticipant.getMeshDimensions(meshName);
   std::cout << dim << "  " << int(MassGridGeometry::GridView::dimension)
             << std::endl;
   if (dim != int(MassGridGeometry::GridView::dimension))
@@ -393,10 +392,8 @@ int main(int argc, char **argv)
   couplingParticipant.setMesh(meshName, coords);
   couplingParticipant.createIndexMapping(coupledScvfIndices);
 
-  const std::string dataNameV("Velocity");
-  const std::string dataNameP("Pressure");
-  couplingParticipant.announceQuantity(meshName, dataNameV);
-  couplingParticipant.announceQuantity(meshName, dataNameP);
+  const std::string dataNameV = couplingParticipant.getReadDataNamesOnMesh(meshName)[0];
+  const std::string dataNameP = couplingParticipant.getWriteDataNamesOnMesh(meshName)[0];
 
   // apply initial solution for instationary problems
   momentumProblem->applyInitialSolution(sol[momentumIdx]);

--- a/free-flow-over-porous-media/porous-media-dumux/params.input
+++ b/free-flow-over-porous-media/porous-media-dumux/params.input
@@ -16,3 +16,10 @@ AlphaBeaversJoseph = 1.0
 
 [Vtk]
 AddVelocity = 1
+
+[precice-adapter-config]
+participant_name = Porous-Media
+precice_config_file_path = ../precice-config.xml
+interfaces.1.mesh_name = Porous-Media-Mesh
+interfaces.1.read_data.1.name = Pressure
+interfaces.1.write_data.1.name = Velocity

--- a/free-flow-over-porous-media/porous-media-dumux/solver-dumux/main.cc
+++ b/free-flow-over-porous-media/porous-media-dumux/solver-dumux/main.cc
@@ -203,8 +203,8 @@ int main(int argc, char **argv)
   couplingParticipant.setMesh(meshName, coords);
   couplingParticipant.createIndexMapping(coupledScvfIndices);
 
-  const std::string dataNameV = couplingParticipant.getWriteDataNamesonMesh(meshName)[0];
-  const std::string dataNamePcouplingParticipant.getReadDataNamesonMesh(meshName)[0];
+  const std::string dataNameV = couplingParticipant.getWriteDataNamesOnMesh(meshName)[0];
+  const std::string dataNameP = couplingParticipant.getReadDataNamesOnMesh(meshName)[0];
 
   darcyProblem->applyInitialSolution(sol);
 

--- a/free-flow-over-porous-media/porous-media-dumux/solver-dumux/main.cc
+++ b/free-flow-over-porous-media/porous-media-dumux/solver-dumux/main.cc
@@ -166,11 +166,10 @@ int main(int argc, char **argv)
   std::string preciceConfigFilename = "../precice-config.xml";
 
   auto &couplingParticipant = Dumux::Precice::CouplingAdapter::getInstance();
-  couplingParticipant.announceSolver("Porous-Media", preciceConfigFilename,
-                                     mpiHelper.rank(), mpiHelper.size());
+  couplingParticipant.announceConfig(mpiHelper.rank(), mpiHelper.size());
 
-  const std::string meshName("Porous-Media-Mesh");
-  const int         dim = couplingParticipant.getMeshDimensions(meshName);
+  const std::string meshName = couplingParticipant.getMeshNames()[0];
+  const int         dim      = couplingParticipant.getMeshDimensions(meshName);
   std::cout << dim << "  " << int(DarcyGridGeometry::GridView::dimension)
             << std::endl;
   if (dim != int(DarcyGridGeometry::GridView::dimension))
@@ -204,10 +203,8 @@ int main(int argc, char **argv)
   couplingParticipant.setMesh(meshName, coords);
   couplingParticipant.createIndexMapping(coupledScvfIndices);
 
-  const std::string dataNameV("Velocity");
-  const std::string dataNameP("Pressure");
-  couplingParticipant.announceQuantity(meshName, dataNameP);
-  couplingParticipant.announceQuantity(meshName, dataNameV);
+  const std::string dataNameV = couplingParticipant.getWriteDataNamesonMesh(meshName)[0];
+  const std::string dataNamePcouplingParticipant.getReadDataNamesonMesh(meshName)[0];
 
   darcyProblem->applyInitialSolution(sol);
 

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -93,18 +93,15 @@ int main(int argc, char **argv)
   // - Name of solver
   // - What rank of how many ranks this instance is
   // Configure preCICE. For now the config file is hardcoded.
-  std::string       preciceConfigFilename = "../precice-config.xml";
-  const std::string meshName              = "Macro-Mesh";
-  if (argc > 2)
-    preciceConfigFilename = argv[argc - 1];
+  const std::string meshName;
 
   auto &couplingParticipant = Dumux::Precice::CouplingAdapter::getInstance();
 
   const auto runWithCoupling = getParam<bool>("Precice.RunWithCoupling");
 
   if (runWithCoupling) {
-    couplingParticipant.announceSolver("Macro", preciceConfigFilename,
-                                       mpiHelper.rank(), mpiHelper.size());
+    couplingParticipant.announceConfig(mpiHelper.rank(), mpiHelper.size());
+    meshName = couplingParticipant.getMeshNames[0];
     // verify that dimensions match
     const int preciceDim = couplingParticipant.getMeshDimensions(meshName);
     const int dim        = int(leafGridView.dimension);
@@ -151,20 +148,20 @@ int main(int argc, char **argv)
   }
 
   // initialize the coupling data
-  const std::string readDatak00            = "K00";
-  const std::string readDatak01            = "K01";
-  const std::string readDatak10            = "K10";
-  const std::string readDatak11            = "K11";
-  const std::string readDataPorosity       = "Porosity";
-  const std::string writeDataConcentration = "Concentration";
+  const std::string readDatak00;
+  const std::string readDatak01;
+  const std::string readDatak10;
+  const std::string readDatak11;
+  const std::string readDataPorosity;
+  const std::string writeDataConcentration;
 
   if (runWithCoupling) {
-    couplingParticipant.announceQuantity(meshName, readDatak00);
-    couplingParticipant.announceQuantity(meshName, readDatak01);
-    couplingParticipant.announceQuantity(meshName, readDatak10);
-    couplingParticipant.announceQuantity(meshName, readDatak11);
-    couplingParticipant.announceQuantity(meshName, readDataPorosity);
-    couplingParticipant.announceQuantity(meshName, writeDataConcentration);
+    readDatak00            = couplingParticipant.getReadDataNamesOnMesh(meshName)[0];
+    readDatak01            = couplingParticipant.getReadDataNamesOnMesh(meshName)[1];
+    readDatak10            = couplingParticipant.getReadDataNamesOnMesh(meshName)[2];
+    readDatak11            = couplingParticipant.getReadDataNamesOnMesh(meshName)[3];
+    readDataPorosity       = couplingParticipant.getReadDataNamesOnMesh(meshName)[4];
+    writeDataConcentration = couplingParticipant.getWriteDataNamesOnMesh(meshName)[0];
   }
 
   // the solution vector (initialized with zeros) NElements x 2(pressure,

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
 
   if (runWithCoupling) {
     couplingParticipant.announceConfig(mpiHelper.rank(), mpiHelper.size());
-    meshName = couplingParticipant.getMeshNames[0];
+    meshName = couplingParticipant.getMeshNames()[0];
     // verify that dimensions match
     const int preciceDim = couplingParticipant.getMeshDimensions(meshName);
     const int dim        = int(leafGridView.dimension);

--- a/two-scale-heat-conduction/macro-dumux/appl/main.cc
+++ b/two-scale-heat-conduction/macro-dumux/appl/main.cc
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
   // - Name of solver
   // - What rank of how many ranks this instance is
   // Configure preCICE. For now the config file is hardcoded.
-  const std::string meshName;
+  std::string meshName;
 
   auto &couplingParticipant = Dumux::Precice::CouplingAdapter::getInstance();
 
@@ -148,12 +148,12 @@ int main(int argc, char **argv)
   }
 
   // initialize the coupling data
-  const std::string readDatak00;
-  const std::string readDatak01;
-  const std::string readDatak10;
-  const std::string readDatak11;
-  const std::string readDataPorosity;
-  const std::string writeDataConcentration;
+  std::string readDatak00;
+  std::string readDatak01;
+  std::string readDatak10;
+  std::string readDatak11;
+  std::string readDataPorosity;
+  std::string writeDataConcentration;
 
   if (runWithCoupling) {
     readDatak00            = couplingParticipant.getReadDataNamesOnMesh(meshName)[0];

--- a/two-scale-heat-conduction/macro-dumux/params.input
+++ b/two-scale-heat-conduction/macro-dumux/params.input
@@ -43,3 +43,14 @@ Pressure = 0.0
 
 [Precice]
 RunWithCoupling = true
+
+[precice-adapter-config]
+participant_name = Macro
+precice_config_file_path = ../precice-config.xml
+interfaces.1.mesh_name = Macro-Mesh
+interfaces.1.read_data.1.name = K00
+interfaces.1.read_data.2.name = K01
+interfaces.1.read_data.3.name = K10
+interfaces.1.read_data.4.name = K11
+interfaces.1.read_data.5.name = Porosity
+interfaces.1.write_data.1.name = Concentration


### PR DESCRIPTION
With the changes in https://github.com/precice/dumux-adapter/pull/68, it's not allowed to hardcode dumux-adapter configuration and the config-reader should be used. This PR applies this change to the relevant tutorial solvers.

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
