### PR TITLE
Fix system test counter to start from 1 instead of 0

### DIFF
--- a/tools/tests/build_docker_images.py
+++ b/tools/tests/build_docker_images.py
@@ -69,7 +69,7 @@ def main():
     logging.info(f"About to build the images for the following systemtests:\n {systemtests_to_run}")
 
     results = []
-    for number, systemtest in enumerate(systemtests_to_run):
+    for number, systemtest in enumerate(systemtests_to_run, start=1):
         logging.info(f"Started building {systemtest},  {number}/{len(systemtests_to_run)}")
         t = time.perf_counter()
         result = systemtest.run_only_build(run_directory)

--- a/tools/tests/generate_reference_results.py
+++ b/tools/tests/generate_reference_results.py
@@ -118,7 +118,7 @@ def main():
     current_time_string = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
 
     logging.info(f"About to run the following tests {systemtests_to_run}")
-    for number, systemtest in enumerate(systemtests_to_run):
+    for number, systemtest in enumerate(systemtests_to_run, start=1):
         logging.info(f"Started running {systemtest},  {number}/{len(systemtests_to_run)}")
         t = time.perf_counter()
         result = systemtest.run_for_reference_results(run_directory)

--- a/tools/tests/systemtests.py
+++ b/tools/tests/systemtests.py
@@ -69,7 +69,7 @@ def main():
     logging.info(f"About to run the following systemtest in the directory {run_directory}:\n {systemtests_to_run}")
 
     results = []
-    for number, systemtest in enumerate(systemtests_to_run):
+    for number, systemtest in enumerate(systemtests_to_run, start=1):
         logging.info(f"Started running {systemtest},  {number}/{len(systemtests_to_run)}")
         t = time.perf_counter()
         result = systemtest.run(run_directory)


### PR DESCRIPTION
## Summary

This PR fixes the system test progress counter starting from 0 instead of 1.

Previously, the counter output appeared as:

0/N  
1/N  

which could be confusing when interpreting test progress.  
The counter now correctly starts from 1, producing:

1/N  
2/N  

## Changes Made

- Updated the counter initialization logic in the system test runner.
- Adjusted the progress display to reflect 1-based indexing.
- Ensured the total test count remains unchanged.

## Verification

- Ran the system test workflow locally.
- Confirmed progress output now starts from 1.
- No impact on test execution or results.

## Related Issue

Closes #644