### PR TITLE
Fix symlinks of two clean-tutorial.sh scripts

### DIFF
--- a/channel-transport-reaction/clean-tutorial.sh
+++ b/channel-transport-reaction/clean-tutorial.sh
@@ -1,11 +1,1 @@
-#!/bin/sh
-set -e -u
-
-# shellcheck disable=SC1091
-. ../tools/cleaning-tools.sh
-
-clean_tutorial .
-clean_precice_logs .
-rm -fv ./*.log
-rm -fv ./*.vtu
-
+../tools/clean-tutorial-base.sh

--- a/flow-around-controlled-moving-cylinder/clean-tutorial.sh
+++ b/flow-around-controlled-moving-cylinder/clean-tutorial.sh
@@ -1,8 +1,1 @@
-#!/bin/sh
-set -e -u
-
-# shellcheck disable=SC1091
-. ../tools/cleaning-tools.sh
-
-clean_tutorial .
-clean_precice_logs .
+../tools/clean-tutorial-base.sh


### PR DESCRIPTION
The `flow-around-controlled-moving-cylinder` and `channel-transport-reaction` cases were copying the `clean-tutorial-base.sh` script instead of just linking to it, without any clear reason (the file was essentially the same).

This PR replaces the files with symlinks, as expected.

Interestingly, GitHub thinks that this is a conflict. :thinking: 