### PR TITLE
Make the get-latest-components workflow conditional.

### DIFF
--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -25,6 +25,7 @@ jobs:
           owner: precice
           repo: precice
           branch: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-python-bindings
         name: Get Python bindings ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -32,6 +33,7 @@ jobs:
           owner: precice
           repo: python-bindings
           branch: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-calculix-adapter
         name: Get CalculiX adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -39,6 +41,7 @@ jobs:
           owner: precice
           repo: calculix-adapter
           branch: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-fenics-adapter
         name: Get FEniCS adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -46,6 +49,7 @@ jobs:
           owner: precice
           repo: fenics-adapter
           branch: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-openfoam-adapter
         name: Get OpenFOAM adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -53,6 +57,7 @@ jobs:
           owner: precice
           repo: openfoam-adapter
           branch: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-su2-adapter
         name: Get SU2 adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -60,6 +65,7 @@ jobs:
           owner: precice
           repo: su2-adapter
           branch: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-tutorials
         name: Get tutorials ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -67,6 +73,7 @@ jobs:
           owner: precice
           repo: tutorials
           branch: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
       - id: report-refs
         name: Report Git refs
         run: |

--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -25,7 +25,6 @@ jobs:
           owner: precice
           repo: precice
           branch: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-python-bindings
         name: Get Python bindings ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -33,7 +32,6 @@ jobs:
           owner: precice
           repo: python-bindings
           branch: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-calculix-adapter
         name: Get CalculiX adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -41,7 +39,6 @@ jobs:
           owner: precice
           repo: calculix-adapter
           branch: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-fenics-adapter
         name: Get FEniCS adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -49,7 +46,6 @@ jobs:
           owner: precice
           repo: fenics-adapter
           branch: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-openfoam-adapter
         name: Get OpenFOAM adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -57,7 +53,6 @@ jobs:
           owner: precice
           repo: openfoam-adapter
           branch: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-su2-adapter
         name: Get SU2 adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -65,7 +60,6 @@ jobs:
           owner: precice
           repo: su2-adapter
           branch: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-tutorials
         name: Get tutorials ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -73,7 +67,6 @@ jobs:
           owner: precice
           repo: tutorials
           branch: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
       - id: report-refs
         name: Report Git refs
         run: |

--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   gather-refs:
     name: Map Git branches to latest refs
+    if: ${{ github.event.label.name == 'trigger-system-tests' }}
     runs-on: ubuntu-latest
     outputs:
       ref-precice: ${{ steps.ref-precice.outputs.shorthash }}
@@ -23,6 +24,7 @@ jobs:
           owner: precice
           repo: precice
           branch: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-python-bindings
         name: Get Python bindings ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -30,6 +32,7 @@ jobs:
           owner: precice
           repo: python-bindings
           branch: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-calculix-adapter
         name: Get CalculiX adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -37,6 +40,7 @@ jobs:
           owner: precice
           repo: calculix-adapter
           branch: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-fenics-adapter
         name: Get FEniCS adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -44,6 +48,7 @@ jobs:
           owner: precice
           repo: fenics-adapter
           branch: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-openfoam-adapter
         name: Get OpenFOAM adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -51,6 +56,7 @@ jobs:
           owner: precice
           repo: openfoam-adapter
           branch: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-su2-adapter
         name: Get SU2 adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -58,6 +64,7 @@ jobs:
           owner: precice
           repo: su2-adapter
           branch: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
       - id: report-refs
         name: Report Git refs
         run: |

--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -24,7 +24,6 @@ jobs:
           owner: precice
           repo: precice
           branch: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-python-bindings
         name: Get Python bindings ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -32,7 +31,6 @@ jobs:
           owner: precice
           repo: python-bindings
           branch: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-calculix-adapter
         name: Get CalculiX adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -40,7 +38,6 @@ jobs:
           owner: precice
           repo: calculix-adapter
           branch: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-fenics-adapter
         name: Get FEniCS adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -48,7 +45,6 @@ jobs:
           owner: precice
           repo: fenics-adapter
           branch: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-openfoam-adapter
         name: Get OpenFOAM adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -56,7 +52,6 @@ jobs:
           owner: precice
           repo: openfoam-adapter
           branch: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
       - id: ref-su2-adapter
         name: Get SU2 adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -64,7 +59,6 @@ jobs:
           owner: precice
           repo: su2-adapter
           branch: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
       - id: report-refs
         name: Report Git refs
         run: |


### PR DESCRIPTION
Fix #682  - Part 1
1. **Gate the gather-refs job in system-tests-pr.yml** with the trigger-system-tests label check so the workflow skips entirely for unlabeled PRs
   - Added conditional: `if: ${{ github.event.label.name == 'trigger-system-tests' }}`
   - This prevents unnecessary API calls when the workflow isn't explicitly triggered

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR. 