### PR TITLE
Fix precommit hooks

### DIFF
--- a/tools/check-image-names.py
+++ b/tools/check-image-names.py
@@ -2,9 +2,30 @@
 
 import sys
 import os
+import subprocess
+
+
+def is_tracked(path: str) -> bool:
+    """
+    Return True if the given path is tracked by git, False otherwise.
+
+    This guards the hook against local, untracked files that pre-commit
+    might pick up when running outside of the normal commit workflow.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", path],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
 
 problems = False
 for file in sys.argv[1:]:
+    # Skip files that are not tracked by git
+    if not is_tracked(file):
+        continue
+
     parts = file.split(os.sep)
     # Ignore non-interesting files
     if len(parts) != 3 or parts[1] != "images":

--- a/tools/check-size.sh
+++ b/tools/check-size.sh
@@ -18,6 +18,8 @@ echo "Limit for gifs: ${MAXIMUMGIFSIZE} kb"
 for tutorial in $tutorials; do
   images=$(find ./"${tutorial}"/images -type f 2> /dev/null | sed "s/^.\///")
   for img in $images; do
+    # Only check files that are tracked by git
+    git ls-files --error-unmatch "$img" >/dev/null 2>&1 || continue
     actualsize=$(du -k "$img" | cut -f 1)
     # Check gifs
     if [[ "${img}" == *.gif || "${img}" == *.webp || "${img}" == *.webm ]]; then

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -11,6 +11,9 @@ for tutorial in $tutorials; do
   # Check permalinks
   docs=$(find "./$tutorial" -maxdepth 1 -type f -name "*.md" -print0 | xargs -0 grep -l "permalink:" | sed "s/^.\///")
   for doc in $docs; do
+    # Only check files that are tracked by git
+    git ls-files --error-unmatch "$doc" >/dev/null 2>&1 || continue
+
     link=$(grep "permalink:" "$doc" | sed "s/permalink: \+//")
     prefix="tutorials-$tutorial"
 
@@ -28,6 +31,8 @@ for tutorial in $tutorials; do
   images=$(find "./$tutorial/images" -type f 2> /dev/null | sed "s/^.\///")
   prefix="tutorials-$tutorial-"
   for img in $images; do
+    # Only check files that are tracked by git
+    git ls-files --error-unmatch "$img" >/dev/null 2>&1 || continue
     if ! [[ $img =~ ^$tutorial/images/$prefix ]]; then
       echo "$img: error: wrong filename"
       echo "$img: note: expected prefix \"$prefix\""
@@ -42,6 +47,8 @@ done
 # Check quickstart
 docs=$(find ./quickstart -maxdepth 1 -type f -name "*.md" -print0 | xargs -0 grep -l "permalink:" | sed "s/^.\///")
 for doc in $docs; do
+  # Only check files that are tracked by git
+  git ls-files --error-unmatch "$doc" >/dev/null 2>&1 || continue
   link=$(grep "permalink:" "$doc" | sed "s/permalink: \+//")
   prefix="quickstart"
 
@@ -59,6 +66,8 @@ done
 images=$(find ./quickstart/images -type f 2> /dev/null | sed "s/^.\///")
 prefix="quickstart-"
 for img in $images; do
+  # Only check files that are tracked by git
+  git ls-files --error-unmatch "$img" >/dev/null 2>&1 || continue
   if ! [[ $img =~ ^quickstart/images/$prefix ]]; then
     echo "$img: error: wrong filename"
     echo "$img: note: expected prefix \"$prefix\""


### PR DESCRIPTION
this PR addresses #707 and adjusts how our validation scripts behave during pre-commit checks.

# Summary

at the moment, scripts like `check-image-names.py`, `check.sh`, and `check-size.sh` also pick up untracked local files. This can cause pre-commit to fail even when those files aren’t part of the repository.

With this change, the scripts now only operate on files that are actually tracked by Git. Untracked local files are ignored.

Changes

* `check-image-names.py` now determines tracked files using `git ls-files` and skips anything untracked.
* `check.sh` and `check-size.sh` have been updated to validate only Git-tracked files.

This keeps the naming and size checks strict for repository content, while avoiding unnecessary failures caused by local development files.

## Impact

* pre-commit no longer fails because of untracked local files.
* Naming and size rules are still enforced for all tracked content.
* The workflow becomes less frustrating for contributors without reducing repository standards.

## Checklist

* [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
* [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
