### PR TITLE
Gate gather-refs on trigger-system-tests label in PR workflow

### DIFF
--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   gather-refs:
     name: Map Git branches to latest refs
+    if: github.event.label.name == 'trigger-system-tests'
     runs-on: ubuntu-latest
     outputs:
       ref-precice: ${{ steps.ref-precice.outputs.shorthash }}

--- a/changelog-entries/682.md
+++ b/changelog-entries/682.md
@@ -1,0 +1,1 @@
+- Gate the `gather-refs` job in the System tests (PR) workflow on the `trigger-system-tests` label, so the workflow skips entirely for PRs labeled with anything else (e.g. "bug", "GSoC"), reducing GitHub API usage. #682


### PR DESCRIPTION
Fix #682 (part 1)

The System tests (PR) workflow runs on any `pull_request: labeled` event. Previously, `gather-refs` ran for every label add (making 7 GitHub API calls), while `run-system-tests` only ran when the label was `trigger-system-tests`. This wasted API quota for labels like "bug" or "GSoC".

This PR gates the `gather-refs` job on the same condition as `run-system-tests`:
`if: github.event.label.name == 'trigger-system-tests'`

The workflow now skips entirely for non-trigger labels, reducing GitHub API usage.

Per maintainer feedback in #723, authentication (token/App ID) is deferred and can be added separately if rate limits persist.

Checklist:
- [x] I added a summary of any user-facing changes (compared to the last release) in `changelog-entries/682.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes when merging.