### PR TITLE
Fix macOS compatibility in tools/log.sh

### DIFF
--- a/tools/log.sh
+++ b/tools/log.sh
@@ -5,14 +5,18 @@ CASENAME="$(pwd | xargs basename)"
 LOGFILE="$CASENAME.log"
 export LOGFILE
 
-STARTDATE="$(date --rfc-email)"
+rfc_email_date() {
+    date --rfc-email 2>/dev/null || date -u '+%a, %d %b %Y %H:%M:%S %z'
+}
+
+STARTDATE="$(rfc_email_date)"
 STARTTIME="$(date +%s)"
 echo "Started on: $STARTDATE" | tee "$CASENAME.log" 2>&1
 
 close_log() {
-    echo "Started on:  $STARTDATE" | tee --append "$LOGFILE" 2>&1
-    ENDDATE="$(date --rfc-email)"
+    echo "Started on:  $STARTDATE" | tee -a "$LOGFILE" 2>&1
+    ENDDATE="$(rfc_email_date)"
     ENDTIME="$(date +%s)"
-    echo "Finished on: $ENDDATE" | tee --append "$LOGFILE" 2>&1
-    echo "Duration:    $((ENDTIME-STARTTIME)) seconds (wall-clock time, including time waiting for participants)" | tee --append "$LOGFILE" 2>&1
+    echo "Finished on: $ENDDATE" | tee -a "$LOGFILE" 2>&1
+    echo "Duration:    $((ENDTIME-STARTTIME)) seconds (wall-clock time, including time waiting for participants)" | tee -a "$LOGFILE" 2>&1
 }

--- a/tools/log.sh
+++ b/tools/log.sh
@@ -6,7 +6,7 @@ LOGFILE="$CASENAME.log"
 export LOGFILE
 
 rfc_email_date() {
-    date --rfc-email 2>/dev/null || date -u '+%a, %d %b %Y %H:%M:%S %z'
+    date --rfc-email 2>/dev/null || date '+%a, %d %b %Y %H:%M:%S %z'
 }
 
 STARTDATE="$(rfc_email_date)"
@@ -14,7 +14,7 @@ STARTTIME="$(date +%s)"
 echo "Started on: $STARTDATE" | tee "$CASENAME.log" 2>&1
 
 close_log() {
-    echo "Started on:  $STARTDATE" | tee -a "$LOGFILE" 2>&1
+    echo "Started on: $STARTDATE" | tee -a "$LOGFILE" 2>&1
     ENDDATE="$(rfc_email_date)"
     ENDTIME="$(date +%s)"
     echo "Finished on: $ENDDATE" | tee -a "$LOGFILE" 2>&1


### PR DESCRIPTION
<!-- Please submit your Pull Request to the `develop` branch.
It may help to have a look at the file `CONTRIBUTING.md` for a few hints and guidelines. -->

## Summary 

tools/log.sh used GNU-specific flags that are not available on macOS.

This change makes the script portable by:

- Replacing `date --rfc-email` with a helper that falls back to a compatible `date` format when the flag is unavailable.
- Replacing `tee --append` with the portable `tee -a`.

The behavior of the script remains the same, but it now works correctly on macOS systems.

---
Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
