### PR TITLE
Add runtime estimate to elastic-tube-1d tutorial

### DIFF
--- a/elastic-tube-1d/README.md
+++ b/elastic-tube-1d/README.md
@@ -9,6 +9,8 @@ summary: The 1D Elastic Tube is a FSI case, that consists of an internal flow in
 Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/develop/elastic-tube-1d), as continuously rendered here, or see the [latest released version](https://github.com/precice/tutorials/tree/master/elastic-tube-1d) (if there is already one). Read how in the [tutorials introduction](https://precice.org/tutorials.html).
 {% endnote %}
 
+> ⚠️ **Runtime estimate:** This tutorial typically runs in about **1–2 minutes** when executed in serial mode on a typical laptop. Actual runtime may vary depending on hardware.
+
 ## Setup
 
 We want to simulate the internal flow in a flexible tube as shown in the figure below (image from [1]).


### PR DESCRIPTION
Adds a runtime estimate note to the elastic-tube-1d tutorial.

This follows the suggestion in #672 to provide users with a rough expectation of how long tutorials take to run. The estimate assumes serial execution on a typical laptop and matches the runtime mentioned in the tutorial summary.

If the format is acceptable, similar notes can be added to other tutorials.