### PR TITLE
Revert "Make clean-tutorial.sh executable from any directory"

### DIFF
--- a/changelog-entries/716.md
+++ b/changelog-entries/716.md
@@ -1,2 +1,0 @@
-- Allow running tutorial cleaning scripts (`clean-tutorial.sh`, `clean-all.sh`) from the repository root by resolving paths relative to the script location.
-

--- a/clean-all.sh
+++ b/clean-all.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env sh
 set -e -u
 
-# Always operate relative to the directory of this script
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-cd "$SCRIPT_DIR"
-
 echo "Cleaning up all tutorials..."
 
 find . -maxdepth 2 -mindepth 2 -name clean-tutorial.sh -execdir sh -c './clean-tutorial.sh' \;

--- a/tools/clean-tutorial-base.sh
+++ b/tools/clean-tutorial-base.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env sh
 set -e -u
 
-# Determine the tutorial directory (where the symlink is located)
-TUTORIAL_DIR="$(cd "$(dirname "$0")" && pwd)"
-cd "$TUTORIAL_DIR"
-
 # shellcheck disable=SC1091
 . ../tools/cleaning-tools.sh
 


### PR DESCRIPTION
Reverts precice/tutorials#716

Since #716, running `./clean-tutorial.sh` seems to be triggering the [OpenFOAM `cleanCase`](https://gitlab.com/openfoam/core/openfoam/-/blob/master/bin/tools/CleanFunctions), which deletes `*.xml`, deleting the `precice-config.xml`.

Not sure if there is an easy fix, but I am opening this as a reminder for the next release.