### PR TITLE
Fix nutils version specs in requirements

### DIFF
--- a/channel-transport-particles/fluid-nutils/requirements.txt
+++ b/channel-transport-particles/fluid-nutils/requirements.txt
@@ -1,5 +1,5 @@
 setuptools # required by nutils
-nutils==7
+nutils~=7.3
 numpy >1, <2
 pyprecice~=3.0
 setuptools

--- a/channel-transport/fluid-nutils/requirements.txt
+++ b/channel-transport/fluid-nutils/requirements.txt
@@ -1,5 +1,5 @@
 setuptools # required by nutils
-nutils==7
+nutils~=7.3
 numpy >1, <2
 pyprecice~=3.0
 setuptools

--- a/channel-transport/transport-nutils/requirements.txt
+++ b/channel-transport/transport-nutils/requirements.txt
@@ -1,5 +1,5 @@
 setuptools # required by nutils
-nutils==7
+nutils~=7.3
 numpy >1, <2
 # remeshing support will be released with preCICE version 3.2
 pyprecice @ git+https://github.com/precice/python-bindings.git@develop

--- a/flow-over-heated-plate/solid-nutils/requirements.txt
+++ b/flow-over-heated-plate/solid-nutils/requirements.txt
@@ -1,4 +1,4 @@
 setuptools # required by nutils
-nutils==7
+nutils~=7.3
 numpy >1, <2
 pyprecice~=3.0

--- a/partitioned-heat-conduction-direct/dirichlet-nutils/requirements.txt
+++ b/partitioned-heat-conduction-direct/dirichlet-nutils/requirements.txt
@@ -1,4 +1,4 @@
 setuptools # required by nutils
-nutils==7
+nutils~=7.3
 numpy >1, <2
 pyprecice~=3.0

--- a/partitioned-heat-conduction-direct/neumann-nutils/requirements.txt
+++ b/partitioned-heat-conduction-direct/neumann-nutils/requirements.txt
@@ -1,4 +1,4 @@
 setuptools # required by nutils
-nutils==7
+nutils~=7.3
 numpy >1, <2
 pyprecice~=3.0

--- a/partitioned-heat-conduction/dirichlet-nutils/requirements.txt
+++ b/partitioned-heat-conduction/dirichlet-nutils/requirements.txt
@@ -1,4 +1,4 @@
 setuptools # required by nutils
-nutils==7
+nutils~=7.3
 numpy >1, <2
 pyprecice~=3.0

--- a/partitioned-heat-conduction/neumann-nutils/requirements.txt
+++ b/partitioned-heat-conduction/neumann-nutils/requirements.txt
@@ -1,4 +1,4 @@
 setuptools # required by nutils
-nutils==7
+nutils~=7.3
 numpy >1, <2
 pyprecice~=3.0

--- a/partitioned-pipe-multiscale/fluid1d-left-nutils/requirements.txt
+++ b/partitioned-pipe-multiscale/fluid1d-left-nutils/requirements.txt
@@ -1,5 +1,5 @@
 setuptools # required by nutils
-nutils==9
+nutils~=9.0
 numpy >1, <2
 pyprecice~=3.0
 matplotlib

--- a/partitioned-pipe-multiscale/fluid1d-right-nutils/requirements.txt
+++ b/partitioned-pipe-multiscale/fluid1d-right-nutils/requirements.txt
@@ -1,5 +1,5 @@
 setuptools # required by nutils
-nutils==9
+nutils~=9.0
 numpy >1, <2
 pyprecice~=3.0
 matplotlib

--- a/turek-hron-fsi3/fluid-nutils/requirements.txt
+++ b/turek-hron-fsi3/fluid-nutils/requirements.txt
@@ -1,5 +1,5 @@
 setuptools # required by nutils
-nutils==9
+nutils~=9.0
 numpy >1, <2
 pyprecice~=3.0
 meshio

--- a/turek-hron-fsi3/solid-nutils/requirements.txt
+++ b/turek-hron-fsi3/solid-nutils/requirements.txt
@@ -1,5 +1,5 @@
 setuptools # required by nutils
-nutils==9
+nutils~=9.0
 numpy >1, <2
 pyprecice~=3.0
 meshio

--- a/two-scale-heat-conduction/macro-nutils/requirements.txt
+++ b/two-scale-heat-conduction/macro-nutils/requirements.txt
@@ -1,4 +1,4 @@
 setuptools # required by nutils
-nutils==7
+nutils~=7.3
 numpy >1, <2
 pyprecice~=3.0

--- a/two-scale-heat-conduction/micro-nutils/requirements.txt
+++ b/two-scale-heat-conduction/micro-nutils/requirements.txt
@@ -1,5 +1,5 @@
 setuptools # required by nutils
-nutils==7
+nutils~=7.3
 numpy >1, <2
 pyprecice~=3.0
 micro-manager-precice

--- a/water-hammer/fluid1d-left-nutils/requirements.txt
+++ b/water-hammer/fluid1d-left-nutils/requirements.txt
@@ -1,5 +1,5 @@
 setuptools # required by nutils
-nutils==9
+nutils~=9.0
 numpy >1, <2
 pyprecice~=3.0
 matplotlib

--- a/water-hammer/fluid1d-right-nutils/requirements.txt
+++ b/water-hammer/fluid1d-right-nutils/requirements.txt
@@ -1,5 +1,5 @@
 setuptools # required by nutils
-nutils==9
+nutils~=9.0
 numpy >1, <2
 pyprecice~=3.0
 matplotlib


### PR DESCRIPTION
This PR fixes the requirements to allow using newer minor versions.
This allows the nutils maintainers to react to breaking future releases of their dependencies.
Concrete example is the 7.3 fixing the breaking treelog 2.0 release.

Note that `==7` requests `7.0`

@MakisH Please have a look how bad this is with respect to the systemtests.

Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
