### PR TITLE
Fix nutils 6 treelog compat

### DIFF
--- a/perpendicular-flap/fluid-nutils/requirements.txt
+++ b/perpendicular-flap/fluid-nutils/requirements.txt
@@ -1,4 +1,5 @@
 setuptools # required by nutils
-nutils==6
+nutils~=6.0
 numpy >1, <2
 pyprecice~=3.0
+treelog <2


### PR DESCRIPTION
This PR updates the perpendicular flap nutils 6 solver to use treelog<2.

Related to #760

Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
