### PR TITLE
Add Quickstart to the system tests

### DIFF
--- a/changelog-entries/771.md
+++ b/changelog-entries/771.md
@@ -1,0 +1,1 @@
+- Added the Quickstart to the system tests [#771](https://github.com/precice/tutorials/pull/771)

--- a/quickstart/metadata.yaml
+++ b/quickstart/metadata.yaml
@@ -1,0 +1,20 @@
+name: Quickstart
+path: quickstart # relative to git repo 
+url: https://precice.org/quickstart.html
+
+participants:
+  - Fluid 
+  - Solid 
+
+cases:
+  fluid-openfoam:
+    participant: Fluid
+    directory: ./fluid-openfoam
+    run: ./run.sh 
+    component: openfoam-adapter
+  
+  solid-cpp:
+    participant: Solid
+    directory: ./solid-cpp
+    run: cmake . && make && ./run.sh 
+    component: bare 

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -1,6 +1,15 @@
 test_suites:
+  quickstart_test:
+    tutorials:
+      - &quickstart
+        path: quickstart
+        case_combination:
+          - fluid-openfoam
+          - solid-cpp
+        reference_result: ./quickstart/reference-results/fluid-openfoam_solid-cpp.tar.gz
   openfoam_adapter_pr:
     tutorials:
+      - *quickstart
       - path: flow-over-heated-plate
         case_combination:
           - fluid-openfoam
@@ -136,6 +145,7 @@ test_suites:
         reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-python.tar.gz
   release_test:
     tutorials:
+      - *quickstart
       - path: elastic-tube-1d
         case_combination:
           - fluid-cpp


### PR DESCRIPTION
Adds the Quickstart tutorial to the system tests. I have some trouble running this locally at the moment, but I will test it in https://github.com/precice/tutorials/pull/769.

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
