### PR TITLE
Fix Ubuntu 24.04 systemtest Docker user setup

### DIFF
--- a/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -8,7 +8,26 @@ ENV DEBIAN_FRONTEND=noninteractive
 # If not built via the systemtests.py its either possible to specify manually but 1000 would be the default anyway.
 ARG PRECICE_UID=1000
 ARG PRECICE_GID=1000
-RUN groupadd -g ${PRECICE_GID} precice && useradd -u ${PRECICE_UID} -g ${PRECICE_GID} -ms /bin/bash precice
+RUN set -eux; \
+    if getent group "${PRECICE_GID}" >/dev/null; then \
+        existing_group="$(getent group "${PRECICE_GID}" | cut -d: -f1)"; \
+        if [ "${existing_group}" != "precice" ]; then \
+            groupmod -n precice "${existing_group}"; \
+        fi; \
+    else \
+        groupadd -g "${PRECICE_GID}" precice; \
+    fi; \
+    if getent passwd "${PRECICE_UID}" >/dev/null; then \
+        existing_user="$(getent passwd "${PRECICE_UID}" | cut -d: -f1)"; \
+        if [ "${existing_user}" != "precice" ]; then \
+            usermod -l precice -d /home/precice -m "${existing_user}"; \
+        fi; \
+        usermod -g "${PRECICE_GID}" precice; \
+    else \
+        useradd -u "${PRECICE_UID}" -g "${PRECICE_GID}" -ms /bin/bash precice; \
+    fi; \
+    mkdir -p /home/precice; \
+    chown -R "${PRECICE_UID}:${PRECICE_GID}" /home/precice
 ENV PATH="${PATH}:/home/precice/.local/bin" 
 ENV LD_LIBRARY_PATH="/home/precice/.local/lib:${LD_LIBRARY_PATH}" 
 ENV CPATH="/home/precice/.local/include:$CPATH"


### PR DESCRIPTION
 ### Summary

This fixes the Ubuntu 24.04 systemtest Docker build when the requested host UID/GID already exists inside the base image.

With "ubuntu:24.04", UID/GID `1000` can already be used by the default `ubuntu` user/group. The previous Dockerfile always tried to create a new `precice` group and user with those IDs, which failed with:

groupadd: GID '1000' already exists

### Changes

The Dockerfile now checks whether the requested group or user already exists:
- If the requested GID already exists, it reuses that group by renaming it to precice.
- If the requested UID already exists, it reuses that user by renaming it to precice.
- If the UID/GID are unused, it creates the precice group/user as before.
- It ensures /home/precice exists and is owned by the requested UID/GID.
- This keeps the later USER precice behavior working while preserving the host UID/GID mapping used by local system tests.
Fixes  #766.

<img width="955" height="230" alt="image" src="https://github.com/user-attachments/assets/49cfcd9c-cb23-4b29-873d-18875abdc8ad" />

 ##### Both builds ran successfully

Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
