### PR TITLE
Add apt retries in systemtest Dockerfiles

### DIFF
--- a/tools/tests/dockerfiles/ubuntu_2204/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2204/Dockerfile
@@ -20,8 +20,8 @@ USER precice
 FROM base_image AS precice_dependecies
 USER root
 # Installing necessary dependecies for preCICE
-RUN apt-get -qq update && \
-    apt-get -qq -y install \
+RUN apt-get -o Acquire::Retries=3 -qq update && \
+    apt-get -o Acquire::Retries=3 -qq -y install \
         build-essential \
         software-properties-common \
         cmake \
@@ -63,9 +63,9 @@ RUN git clone https://github.com/precice/precice.git precice && \
 FROM precice_dependecies AS openfoam_adapter
 ARG OPENFOAM_EXECUTABLE
 USER root
-RUN apt-get update &&\
-    wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | bash &&\
-    apt-get -qq install ${OPENFOAM_EXECUTABLE}-dev &&\
+RUN apt-get -o Acquire::Retries=3 update &&\
+    wget --tries=3 --waitretry=5 -q -O - https://dl.openfoam.com/add-debian-repo.sh | bash &&\
+    apt-get -o Acquire::Retries=3 -qq install ${OPENFOAM_EXECUTABLE}-dev &&\
     ln -s $(which ${OPENFOAM_EXECUTABLE} ) /usr/bin/openfoam
 USER precice
 COPY --from=precice /home/precice/.local/ /home/precice/.local/
@@ -95,8 +95,8 @@ FROM precice_dependecies AS fenics_adapter
 COPY --from=python_bindings /home/precice/.local /home/precice/.local
 USER root
 RUN add-apt-repository -y ppa:fenics-packages/fenics && \
-    apt-get -qq update && \
-    apt-get -qq install --no-install-recommends fenics
+    apt-get -o Acquire::Retries=3 -qq update && \
+    apt-get -o Acquire::Retries=3 -qq install --no-install-recommends fenics
 USER precice
 ARG FENICS_ADAPTER_REF
 # Building fenics-adapter
@@ -113,13 +113,13 @@ RUN pip3 install --user nutils
 FROM precice_dependecies AS calculix_adapter
 COPY --from=precice /home/precice/.local /home/precice/.local
 USER root
-RUN apt-get -qq update && \
-    apt-get -qq install libarpack2-dev libspooles-dev libyaml-cpp-dev
+RUN apt-get -o Acquire::Retries=3 -qq update && \
+    apt-get -o Acquire::Retries=3 -qq install libarpack2-dev libspooles-dev libyaml-cpp-dev
 ARG CALCULIX_VERSION
 USER precice
 #Download Calculix
 WORKDIR /home/precice
-RUN wget http://www.dhondt.de/ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
+RUN wget --tries=3 --waitretry=5 http://www.dhondt.de/ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
     tar xvjf ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
     rm -fv ccx_${CALCULIX_VERSION}.src.tar.bz2
 
@@ -136,14 +136,14 @@ RUN git clone https://github.com/precice/calculix-adapter.git && \
 FROM python_bindings AS su2_adapter
 COPY --from=precice /home/precice/.local /home/precice/.local
 USER root
-RUN apt-get -qq update && \
-    apt-get -qq install swig
+RUN apt-get -o Acquire::Retries=3 -qq update && \
+    apt-get -o Acquire::Retries=3 -qq install swig
 ARG SU2_VERSION
 USER precice
 
 # Download and build SU2 (We could also use pre-built binaries from the SU2 releases)
 WORKDIR /home/precice
-RUN wget https://github.com/su2code/SU2/archive/refs/tags/v${SU2_VERSION}.tar.gz && \
+RUN wget --tries=3 --waitretry=5 https://github.com/su2code/SU2/archive/refs/tags/v${SU2_VERSION}.tar.gz && \
     tar xvzf v${SU2_VERSION}.tar.gz && \
     rm -fv v${SU2_VERSION}.tar.gz
 RUN pip3 install --user mpi4py
@@ -165,8 +165,8 @@ RUN cd "${SU2_HOME}" &&\
 
 FROM precice_dependecies AS dealii_adapter
 USER root
-RUN apt-get update &&\
-    apt-get -qq install libdeal.ii-dev libdeal.ii-doc cmake make g++
+RUN apt-get -o Acquire::Retries=3 update &&\
+    apt-get -o Acquire::Retries=3 -qq install libdeal.ii-dev libdeal.ii-doc cmake make g++
 USER precice
 COPY --from=precice /home/precice/.local/ /home/precice/.local/
 ARG DEALII_ADAPTER_PR

--- a/tools/tests/dockerfiles/ubuntu_2204/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2204/Dockerfile
@@ -64,7 +64,7 @@ FROM precice_dependecies AS openfoam_adapter
 ARG OPENFOAM_EXECUTABLE
 USER root
 RUN apt-get -o Acquire::Retries=3 update &&\
-    wget --tries=3 --waitretry=5 -q -O - https://dl.openfoam.com/add-debian-repo.sh | bash &&\
+    wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | bash &&\
     apt-get -o Acquire::Retries=3 -qq install ${OPENFOAM_EXECUTABLE}-dev &&\
     ln -s $(which ${OPENFOAM_EXECUTABLE} ) /usr/bin/openfoam
 USER precice
@@ -119,7 +119,7 @@ ARG CALCULIX_VERSION
 USER precice
 #Download Calculix
 WORKDIR /home/precice
-RUN wget --tries=3 --waitretry=5 http://www.dhondt.de/ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
+RUN wget http://www.dhondt.de/ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
     tar xvjf ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
     rm -fv ccx_${CALCULIX_VERSION}.src.tar.bz2
 
@@ -143,7 +143,7 @@ USER precice
 
 # Download and build SU2 (We could also use pre-built binaries from the SU2 releases)
 WORKDIR /home/precice
-RUN wget --tries=3 --waitretry=5 https://github.com/su2code/SU2/archive/refs/tags/v${SU2_VERSION}.tar.gz && \
+RUN wget https://github.com/su2code/SU2/archive/refs/tags/v${SU2_VERSION}.tar.gz && \
     tar xvzf v${SU2_VERSION}.tar.gz && \
     rm -fv v${SU2_VERSION}.tar.gz
 RUN pip3 install --user mpi4py

--- a/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -83,7 +83,7 @@ FROM precice_dependecies AS openfoam_adapter
 ARG OPENFOAM_EXECUTABLE
 USER root
 RUN apt-get -o Acquire::Retries=3 update &&\
-    wget --tries=3 --waitretry=5 -q -O - https://dl.openfoam.com/add-debian-repo.sh | bash &&\
+    wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | bash &&\
     apt-get -o Acquire::Retries=3 -qq install ${OPENFOAM_EXECUTABLE}-dev &&\
     ln -s $(which ${OPENFOAM_EXECUTABLE} ) /usr/bin/openfoam
 USER precice
@@ -144,7 +144,7 @@ ARG CALCULIX_VERSION
 USER precice
 #Download Calculix
 WORKDIR /home/precice
-RUN wget --tries=3 --waitretry=5 http://www.dhondt.de/ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
+RUN wget http://www.dhondt.de/ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
     tar xvjf ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
     rm -fv ccx_${CALCULIX_VERSION}.src.tar.bz2
 
@@ -169,7 +169,7 @@ USER precice
 # Download and build SU2 (We could also use pre-built binaries from the SU2 releases)
 # The sed command applies a patch needed for Ubuntu 24.04.
 WORKDIR /home/precice
-RUN wget --tries=3 --waitretry=5 https://github.com/su2code/SU2/archive/refs/tags/v${SU2_VERSION}.tar.gz && \
+RUN wget https://github.com/su2code/SU2/archive/refs/tags/v${SU2_VERSION}.tar.gz && \
     tar xvzf v${SU2_VERSION}.tar.gz && \
     rm -fv v${SU2_VERSION}.tar.gz
 RUN python3 -m venv /home/precice/venv && \

--- a/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -39,8 +39,8 @@ USER precice
 FROM base_image AS precice_dependecies
 USER root
 # Installing necessary dependecies for preCICE
-RUN apt-get -qq update && \
-    apt-get -qq -y install \
+RUN apt-get -o Acquire::Retries=3 -qq update && \
+    apt-get -o Acquire::Retries=3 -qq -y install \
         build-essential \
         software-properties-common \
         cmake \
@@ -82,9 +82,9 @@ RUN git clone https://github.com/precice/precice.git precice && \
 FROM precice_dependecies AS openfoam_adapter
 ARG OPENFOAM_EXECUTABLE
 USER root
-RUN apt-get update &&\
-    wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | bash &&\
-    apt-get -qq install ${OPENFOAM_EXECUTABLE}-dev &&\
+RUN apt-get -o Acquire::Retries=3 update &&\
+    wget --tries=3 --waitretry=5 -q -O - https://dl.openfoam.com/add-debian-repo.sh | bash &&\
+    apt-get -o Acquire::Retries=3 -qq install ${OPENFOAM_EXECUTABLE}-dev &&\
     ln -s $(which ${OPENFOAM_EXECUTABLE} ) /usr/bin/openfoam
 USER precice
 COPY --from=precice /home/precice/.local/ /home/precice/.local/
@@ -116,8 +116,8 @@ FROM precice_dependecies AS fenics_adapter
 COPY --from=python_bindings /home/precice/.local /home/precice/.local
 USER root
 RUN add-apt-repository -y ppa:fenics-packages/fenics && \
-    apt-get -qq update && \
-    apt-get -qq install --no-install-recommends fenics
+    apt-get -o Acquire::Retries=3 -qq update && \
+    apt-get -o Acquire::Retries=3 -qq install --no-install-recommends fenics
 USER precice
 ARG FENICS_ADAPTER_REF
 # Building fenics-adapter
@@ -138,13 +138,13 @@ RUN python3 -m venv /home/precice/venv && \
 FROM precice_dependecies AS calculix_adapter
 COPY --from=precice /home/precice/.local /home/precice/.local
 USER root
-RUN apt-get -qq update && \
-    apt-get -qq install libarpack2-dev libspooles-dev libyaml-cpp-dev
+RUN apt-get -o Acquire::Retries=3 -qq update && \
+    apt-get -o Acquire::Retries=3 -qq install libarpack2-dev libspooles-dev libyaml-cpp-dev
 ARG CALCULIX_VERSION
 USER precice
 #Download Calculix
 WORKDIR /home/precice
-RUN wget http://www.dhondt.de/ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
+RUN wget --tries=3 --waitretry=5 http://www.dhondt.de/ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
     tar xvjf ccx_${CALCULIX_VERSION}.src.tar.bz2 && \
     rm -fv ccx_${CALCULIX_VERSION}.src.tar.bz2
 
@@ -161,15 +161,15 @@ RUN git clone https://github.com/precice/calculix-adapter.git && \
 FROM python_bindings AS su2_adapter
 COPY --from=precice /home/precice/.local /home/precice/.local
 USER root
-RUN apt-get -qq update && \
-    apt-get -qq install swig python3-mpi4py python3-setuptools
+RUN apt-get -o Acquire::Retries=3 -qq update && \
+    apt-get -o Acquire::Retries=3 -qq install swig python3-mpi4py python3-setuptools
 ARG SU2_VERSION
 USER precice
 
 # Download and build SU2 (We could also use pre-built binaries from the SU2 releases)
 # The sed command applies a patch needed for Ubuntu 24.04.
 WORKDIR /home/precice
-RUN wget https://github.com/su2code/SU2/archive/refs/tags/v${SU2_VERSION}.tar.gz && \
+RUN wget --tries=3 --waitretry=5 https://github.com/su2code/SU2/archive/refs/tags/v${SU2_VERSION}.tar.gz && \
     tar xvzf v${SU2_VERSION}.tar.gz && \
     rm -fv v${SU2_VERSION}.tar.gz
 RUN python3 -m venv /home/precice/venv && \
@@ -193,8 +193,8 @@ RUN cd "${SU2_HOME}" &&\
 
 FROM precice_dependecies AS dealii_adapter
 USER root
-RUN apt-get update &&\
-    apt-get -qq install libdeal.ii-dev libdeal.ii-doc cmake make g++
+RUN apt-get -o Acquire::Retries=3 update &&\
+    apt-get -o Acquire::Retries=3 -qq install libdeal.ii-dev libdeal.ii-doc cmake make g++
 USER precice
 COPY --from=precice /home/precice/.local/ /home/precice/.local/
 ARG DEALII_ADAPTER_PR


### PR DESCRIPTION
## Summary
This PR adds limited retries to the network-sensitive package and download commands in the systemtest Dockerfiles.

when we build the systemtest Docker images, we depend on external package mirrors and download servers. Sometimes these fail temporarily, even though nothing is wrong with our code or the tutorial setup. In those cases, a local run or CI job can fail just because a mirror was slow or unreachable.

tthis is especially relevant for steps such as installing packages, setting up OpenFOAM, and downloading CalculiX or SU2 sources. with a few bounded retries, we keep the normal behavior the same, but make the builds a bit more robust against temporary network issues.
## Changes

This PR adds bounded retry behavior in both systemtest Dockerfiles:
- `apt-get update` and `apt-get install` now use `Acquire::Retries=3`
- `wget` downloads now use `--tries=3 --waitretry=5`
- Scope is limited to:
  - `tools/tests/dockerfiles/ubuntu_2204/Dockerfile`
  - `tools/tests/dockerfiles/ubuntu_2404/Dockerfile`

This keeps the Dockerfile behavior the same in normal cases, but makes builds more robust against temporary network or mirror issues.

Fixes #768.

## Validation
<img width="550" height="160" alt="image" src="https://github.com/user-attachments/assets/7d05b544-e3cb-41d7-97ac-779a1e7d9398" />

#### Both ran successfully .

Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
