### PR TITLE
Deduplicate system test entries in tests.yaml

### DIFF
--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -10,62 +10,62 @@ test_suites:
   openfoam_adapter_pr:
     tutorials:
       - *quickstart
-      - path: flow-over-heated-plate
+      - &flow_over_heated_plate_openfoam
+        path: flow-over-heated-plate
         case_combination:
           - fluid-openfoam
           - solid-openfoam
         reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - path: perpendicular-flap
+      - &perpendicular_flap_openfoam_calculix
+        path: perpendicular-flap
         case_combination:
           - fluid-openfoam
           - solid-calculix
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-calculix.tar.gz
-      - path: perpendicular-flap
+      - &perpendicular_flap_openfoam
+        path: perpendicular-flap
         case_combination:
           - fluid-openfoam
           - solid-openfoam
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - path: flow-over-heated-plate-nearest-projection
+      - &flow_over_heated_plate_nearest_projection
+        path: flow-over-heated-plate-nearest-projection
         case_combination:
           - fluid-openfoam
           - solid-openfoam
         reference_result: ./flow-over-heated-plate-nearest-projection/reference-results/fluid-openfoam_solid-openfoam.tar.gz
   openfoam_adapter_release:
     tutorials:
-      - path: flow-over-heated-plate
-        case_combination:
-          - fluid-openfoam
-          - solid-openfoam
-        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+      - *flow_over_heated_plate_openfoam
   fenics_test:
     tutorials:
-      - path: flow-over-heated-plate
+      - &flow_over_heated_plate_fenics
+        path: flow-over-heated-plate
         case_combination:
          - fluid-openfoam
          - solid-fenics
         reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-fenics.tar.gz
-      - path: perpendicular-flap
+      - &perpendicular_flap_fenics
+        path: perpendicular-flap
         case_combination:
           - fluid-openfoam
           - solid-fenics
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-fenics.tar.gz
   nutils_test:
     tutorials:
-      - path: flow-over-heated-plate
+      - &flow_over_heated_plate_nutils
+        path: flow-over-heated-plate
         case_combination:
           - fluid-openfoam
           - solid-nutils
         reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-nutils.tar.gz
   calculix_test:
     tutorials:
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-calculix
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-calculix.tar.gz
+      - *perpendicular_flap_openfoam_calculix
   dumux_test:
     tutorials:
-      - path: two-scale-heat-conduction
+      - &two_scale_heat_conduction
+        path: two-scale-heat-conduction
         case_combination:
           - macro-dumux
           - micro-dumux
@@ -77,14 +77,11 @@ test_suites:
         reference_result: ./free-flow-over-porous-media/reference-results/free-flow-dumux_porous-media-dumux.tar.gz
   micro_manager_test:
     tutorials:
-      - path: two-scale-heat-conduction
-        case_combination:
-          - macro-dumux
-          - micro-dumux
-        reference_result: ./two-scale-heat-conduction/reference-results/macro-dumux_micro-dumux.tar.gz # Too small values, expected to fail the comparisons.
+      - *two_scale_heat_conduction
   su2_test:
     tutorials:
-      - path: perpendicular-flap
+      - &perpendicular_flap_su2_fenics
+        path: perpendicular-flap
         case_combination:
           - fluid-su2
           - solid-fenics
@@ -100,27 +97,17 @@ test_suites:
         reference_result: ./heat-exchanger-simplified/reference-results/fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix.tar.gz
   dealii_test:
     tutorials:
-      - path: perpendicular-flap
+      - &perpendicular_flap_dealii
+        path: perpendicular-flap
         case_combination:
           - fluid-openfoam
           - solid-dealii
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-dealii.tar.gz
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-openfoam
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-fenics
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-fenics.tar.gz
-      - path: flow-over-heated-plate-nearest-projection
-        case_combination:
-          - fluid-openfoam
-          - solid-openfoam
-        reference_result: ./flow-over-heated-plate-nearest-projection/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - path: multiple-perpendicular-flaps
+      - *perpendicular_flap_openfoam
+      - *perpendicular_flap_fenics
+      - *flow_over_heated_plate_nearest_projection
+      - &multiple_perpendicular_flaps
+        path: multiple-perpendicular-flaps
         case_combination:
           - fluid-openfoam
           - solid-upstream-dealii
@@ -128,17 +115,20 @@ test_suites:
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii.tar.gz
   elastic_tube_1d_test:
     tutorials:
-      - path: elastic-tube-1d
+      - &elastic_tube_1d_cpp_cpp
+        path: elastic-tube-1d
         case_combination:
           - fluid-cpp
           - solid-cpp
         reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-cpp.tar.gz
-      - path: elastic-tube-1d
+      - &elastic_tube_1d_python_python
+        path: elastic-tube-1d
         case_combination:
           - fluid-python
           - solid-python
         reference_result: ./elastic-tube-1d/reference-results/fluid-python_solid-python.tar.gz
-      - path: elastic-tube-1d
+      - &elastic_tube_1d_cpp_python
+        path: elastic-tube-1d
         case_combination:
           - fluid-cpp
           - solid-python
@@ -146,57 +136,16 @@ test_suites:
   release_test:
     tutorials:
       - *quickstart
-      - path: elastic-tube-1d
-        case_combination:
-          - fluid-cpp
-          - solid-cpp
-        reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-cpp.tar.gz
-      - path: elastic-tube-1d
-        case_combination:
-          - fluid-python
-          - solid-python
-        reference_result: ./elastic-tube-1d/reference-results/fluid-python_solid-python.tar.gz
-      - path: elastic-tube-1d
-        case_combination:
-          - fluid-cpp
-          - solid-python
-        reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-python.tar.gz
-      - path: flow-over-heated-plate
-        case_combination:
-          - fluid-openfoam
-          - solid-nutils
-        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-nutils.tar.gz
-      - path: flow-over-heated-plate
-        case_combination:
-          - fluid-openfoam
-          - solid-fenics
-        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-fenics.tar.gz
-      - path: flow-over-heated-plate
-        case_combination:
-          - fluid-openfoam
-          - solid-openfoam
-        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-calculix
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-calculix.tar.gz
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-su2
-          - solid-fenics
-        reference_result: ./perpendicular-flap/reference-results/fluid-su2_solid-fenics.tar.gz
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-dealii
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-dealii.tar.gz
-      - path: multiple-perpendicular-flaps
-        case_combination:
-          - fluid-openfoam
-          - solid-upstream-dealii
-          - solid-downstream-dealii
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii.tar.gz
+      - *elastic_tube_1d_cpp_cpp
+      - *elastic_tube_1d_python_python
+      - *elastic_tube_1d_cpp_python
+      - *flow_over_heated_plate_nutils
+      - *flow_over_heated_plate_fenics
+      - *flow_over_heated_plate_openfoam
+      - *perpendicular_flap_openfoam_calculix
+      - *perpendicular_flap_su2_fenics
+      - *perpendicular_flap_dealii
+      - *multiple_perpendicular_flaps
       - *heat_exchanger_simplified
       - path: free-flow-over-porous-media
         case_combination:


### PR DESCRIPTION
## Summary

This PR addresses #767 by reducing duplication in " tools/tests/tests.yaml" , We use YAML anchors and aliases for tutorial entries that appear in multiple test suites. The resolved test configuration stays the same, but the file becomes shorter and easier to maintain when we need to update shared tutorial entries later.

##### What changed

- Added YAML anchors for repeated tutorial entries.
- Replaced duplicated entries with YAML aliases.
- Kept the same test suites, tutorial paths, case combinations, and reference result paths.

#### Why

Before this change, we had the same tutorial entries repeated in several suites. If we wanted to update one shared entry later, we would have to remember to update every copy. With this change, we define the repeated entries once and reuse them where needed. This should make future maintenance simpler without changing how the system tests behave.

## Validation
I checked that this only changes the YAML structure, not the resolved test configuration.
Ran locally:
bash
`git diff --check
python3 -m compileall tools/tests
python3 tools/tests/systemtests.py --help`
I also compared the parsed `tests.yaml` against `upstream/develop`; both resolved to the same `13` test suites and `37` tutorial entries.


Checklist:

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] I will remember to squash-and-merge, providing a useful summary of the changes of this PR.
