### PR TITLE
System tests components.yaml: Fix description for various arguments

### DIFF
--- a/tools/tests/components.yaml
+++ b/tools/tests/components.yaml
@@ -32,7 +32,7 @@ python-bindings:
       description: Tutorial git reference to use
       default: "master"
     PYTHON_BINDINGS_REF:
-      semnantic: Git ref of the Python bindings to use
+      description: Git ref of the Python bindings to use
       default: "master"
 
 openfoam-adapter:
@@ -75,10 +75,10 @@ fenics-adapter:
       description: Tutorial git reference to use
       default: "master"
     PYTHON_BINDINGS_REF:
-      semnantic: Git ref of the Python bindings to use
+      description: Git ref of the Python bindings to use
       default: "master"
     FENICS_ADAPTER_REF:
-      semnantic: Git ref of the fenics adapter to use
+      description: Git ref of the fenics adapter to use
       default: "master"
 
 nutils-adapter:
@@ -98,7 +98,7 @@ nutils-adapter:
       description: Tutorial git reference to use
       default: "master"
     PYTHON_BINDINGS_REF:
-      semnantic: Git ref of the Python bindings to use
+      description: Git ref of the Python bindings to use
       default: "master"
 
 calculix-adapter:
@@ -190,7 +190,7 @@ dumux-adapter:
       description: Version of DuMux to use
       default: "3.7"
     DUMUX_ADAPTER_REF:
-      semnantic: Git ref of the dumux adapter to use
+      description: Git ref of the dumux adapter to use
       default: "main"
 
 micro-manager:


### PR DESCRIPTION
There is currently a recurrent typo in the `components.yaml`: a `semnantic:` that should be `description:`.

Still, I am wondering whether this is actually used at the moment. I see a reference in https://github.com/precice/tutorials/blob/develop/tools/tests/metadata_parser/metdata.py, but I have not looked closer.

@PranjalManhgaye what do you think?