### PR TITLE
Introduce a verbosity option to check.sh/check-size.sh and make CI non-verbose

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install pre-commit
         run: pip install pre-commit
       - name: Run checks
-        run: pre-commit run -a -v
+        run: pre-commit run -a
       - name: Git status
         if: always()
         run: |

--- a/tools/check-size.sh
+++ b/tools/check-size.sh
@@ -27,14 +27,18 @@ for tutorial in $tutorials; do
           echo -e "$img:$RED $actualsize kb exceeds the limit of $MAXIMUMGIFSIZE kb. $NOCOLOR"
           CODE=1
       else
+        if [ "${1:-}" = "-v" ]; then
           echo -e "$img: $actualsize kb (Ok)."
+        fi
       fi
     else
       if [ "${actualsize}" -ge "${MAXIMUMSIZE}" ]; then
          echo -e "$img:$RED $actualsize kb exceeds the limit of $MAXIMUMSIZE kb. $NOCOLOR"
          CODE=1
       else
-        echo -e "$img: $actualsize kb (Ok)."
+        if [ "${1:-}" = "-v" ]; then
+          echo -e "$img: $actualsize kb (Ok)."
+        fi
       fi
     fi
   done

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -20,12 +20,15 @@ for tutorial in $tutorials; do
     if ! [[ $link =~ ^$prefix ]]; then
       echo "$doc: error: wrong permalink"
       echo "$doc: note: permalink \"$link\" does not start with \"$prefix\""
+      echo
       CODE=1
     else
-      echo "$doc: info: correct permalink"
-      echo "$doc: note: permalink is \"$link\""
+      if [ "${1:-}" = "-v" ]; then
+        echo "$doc: info: correct permalink"
+        echo "$doc: note: permalink is \"$link\""
+        echo
+      fi
     fi
-    echo
   done
 
   images=$(find "./$tutorial/images" -type f 2> /dev/null | sed "s/^.\///")
@@ -36,11 +39,14 @@ for tutorial in $tutorials; do
     if ! [[ $img =~ ^$tutorial/images/$prefix ]]; then
       echo "$img: error: wrong filename"
       echo "$img: note: expected prefix \"$prefix\""
+      echo
       CODE=1
     else
-      echo "$img: info: correct filename"
+      if [ "${1:-}" = "-v" ]; then
+        echo "$img: info: correct filename"
+        echo
+      fi
     fi
-    echo
   done
 done
 
@@ -55,12 +61,15 @@ for doc in $docs; do
   if ! [[ $link =~ ^$prefix ]]; then
     echo "$doc: error: wrong permalink"
     echo "$doc: note: permalink \"$link\" does not start with \"$prefix\""
+    echo
     CODE=1
   else
-    echo "$doc: info: correct permalink"
-    echo "$doc: note: permalink is \"$link\""
+    if [ "${1:-}" = "-v" ]; then
+      echo "$doc: info: correct permalink"
+      echo "$doc: note: permalink is \"$link\""
+      echo
+    fi
   fi
-  echo
 done
 
 images=$(find ./quickstart/images -type f 2> /dev/null | sed "s/^.\///")
@@ -71,11 +80,14 @@ for img in $images; do
   if ! [[ $img =~ ^quickstart/images/$prefix ]]; then
     echo "$img: error: wrong filename"
     echo "$img: note: expected prefix \"$prefix\""
+    echo
     CODE=1
   else
-    echo "$img: info: correct filename"
+    if [ "${1:-}" = "-v" ]; then
+      echo "$img: info: correct filename"
+      echo
+    fi
   fi
-  echo
 done
 
 


### PR DESCRIPTION
The output of the `check-style.yaml` workflow is inaccessibly long, as it includes all the filenames and images that are fine.

This PR:

- Makes the `pre-commit` run non-verbose. Since this is working fine since a while, the verbosity is not needed on every run.
- Adds a verbosity option to the `check.sh` and `check-size.sh` scripts, in case this is still needed at some point. If not, it could also be removed in a future PR.

I have tested both scripts locally, in verbose and non-verbose mode, stand-alone and in pre-commit. The `pre-commit run -v` would not automatically append the `-v` option in the scripts.

Of course, in case the scripts or pre-commit fail, the failing cases (only) are still reported.

