### PR TITLE
CI: Always upload main log files of system tests

### DIFF
--- a/.github/workflows/generate_reference_results_workflow.yml
+++ b/.github/workflows/generate_reference_results_workflow.yml
@@ -85,10 +85,18 @@ jobs:
         fi
         git commit -m "${{inputs.commit_msg}}"
         git push
-    - name: Upload artifacts for debugging
+    - name: Archive main log files
+      uses: actions/upload-artifact@v4
+      with:
+        name: system_tests_run_${{ github.run_id }}_${{ github.run_attempt }}_reference_logs
+        path: |
+          runs/*/system-tests-stdout.log
+          runs/*/system-tests-stderr.log
+          runs/*/*/system-tests_*.log
+    - name: Archive run files
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: system_tests_run_${{ github.run_id }}_${{ github.run_attempt }}_reference
+        name: system_tests_run_${{ github.run_id }}_${{ github.run_attempt }}_reference_full
         path: |
           runs/*

--- a/.github/workflows/run_testsuite_workflow.yml
+++ b/.github/workflows/run_testsuite_workflow.yml
@@ -77,11 +77,19 @@ jobs:
         cd tools/tests
         python systemtests.py --build_args=${{ inputs.build_args}} --suites=${{ inputs.suites}} --log-level=${{ inputs.log_level}}
         cd ../../
+    - name: Archive main log files
+      uses: actions/upload-artifact@v4
+      with:
+        name: system_tests_run_${{ github.run_id }}_${{ github.run_attempt }}_logs
+        path: |
+          runs/*/system-tests-stdout.log
+          runs/*/system-tests-stderr.log
+          runs/*/*/system-tests_*.log
     - name: Archive run files
       if: ${{  failure() || inputs.upload_artifacts == 'TRUE' }}
       uses: actions/upload-artifact@v4
       with:
-        name: system_tests_run_${{ github.run_id }}_${{ github.run_attempt }}
+        name: system_tests_run_${{ github.run_id }}_${{ github.run_attempt }}_full
         path: |
           runs/*
     - name: tidy up the docker


### PR DESCRIPTION
In case of failure in the system tests, one typically has to download the full archive of results. As an easy improvement, this PR separately archives the main log files separately, to always have a smaller file to peek into.

Tested in https://github.com/precice/tutorials/actions/runs/25798154036