### PR TITLE
System tests: More robust setup of DUNE modules

### DIFF
--- a/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -238,15 +238,60 @@ USER precice
 WORKDIR /home/precice/dumux
 ENV PATH="/home/precice/dumux/dune-common/bin:${PATH}"
 # This cascade of git clones often led to HTTP 502. Adding some delay and retries in between as a workaround.
-RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/core/dune-common.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]] && sleep 10 && rm -rf dune-common; done
-RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/core/dune-geometry.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dune-geometry; done
-RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/core/dune-grid.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dune-grid; done
-RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/core/dune-istl.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dune-istl; done
-RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/extensions/dune-subgrid.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dune-subgrid; done
-RUN for i in $(seq 1 3); do git clone --depth 1 https://git.iws.uni-stuttgart.de/dumux-repositories/dumux.git -b releases/${DUMUX_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dumux; done
-RUN for i in $(seq 1 3); do git clone -b cell_problems https://git.iws.uni-stuttgart.de/dumux-appl/dumux-phasefield.git && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dumux-phasefield; done
-RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/extensions/dune-SPGrid.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dune-SPGrid; done
-RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/core/dune-localfunctions.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dune-localfunctions; done
+RUN for i in $(seq 1 3); do \
+        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-common.git -b releases/${DUNE_VERSION}; then break; fi \
+        rm -rf dune-common \
+        if [[ $i -eq 3 ]]; then exit 1; fi; \
+        sleep 10; \
+    done
+RUN for i in $(seq 1 3); do \
+        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-geometry.git -b releases/${DUNE_VERSION}; then break; fi \
+        rm -rf dune-geometry \
+        if [[ $i -eq 3 ]]; then exit 1; fi; \
+        sleep 10; \
+    done
+RUN for i in $(seq 1 3); do \
+        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-grid.git -b releases/${DUNE_VERSION}; then break; fi \
+        rm -rf dune-grid \
+        if [[ $i -eq 3 ]]; then exit 1; fi; \
+        sleep 10; \
+    done
+RUN for i in $(seq 1 3); do \
+        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-istl.git -b releases/${DUNE_VERSION}; then break; fi \
+        rm -rf dune-istl \
+        if [[ $i -eq 3 ]]; then exit 1; fi; \
+        sleep 10; \
+    done
+RUN for i in $(seq 1 3); do \
+        if git clone --depth 1 https://gitlab.dune-project.org/extensions/dune-subgrid.git -b releases/${DUNE_VERSION}; then break; fi \
+        rm -rf dune-subgrid \
+        if [[ $i -eq 3 ]]; then exit 1; fi; \
+        sleep 10; \
+    done
+RUN for i in $(seq 1 3); do \
+        if git clone --depth 1 https://git.iws.uni-stuttgart.de/dumux-repositories/dumux.git -b releases/${DUMUX_VERSION}; then break; fi \
+        rm -rf dumux \
+        if [[ $i -eq 3 ]]; then exit 1; fi; \
+        sleep 10; \
+    done
+RUN for i in $(seq 1 3); do \
+        if git clone -b cell_problems https://git.iws.uni-stuttgart.de/dumux-appl/dumux-phasefield.git; then break; fi \
+        rm -rf dumux-phasefield \
+        if [[ $i -eq 3 ]]; then exit 1; fi; \
+        sleep 10; \
+    done
+RUN for i in $(seq 1 3); do \
+        if git clone --depth 1 https://gitlab.dune-project.org/extensions/dune-SPGrid.git -b releases/${DUNE_VERSION}; then break; fi \
+        rm -rf dune-SPGrid \
+        if [[ $i -eq 3 ]]; then exit 1; fi; \
+        sleep 10; \
+    done
+RUN for i in $(seq 1 3); do \
+        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-localfunctions.git -b releases/${DUNE_VERSION}; then break; fi \
+        rm -rf dune-localfunctions \
+        if [[ $i -eq 3 ]]; then exit 1; fi; \
+        sleep 10; \
+    done
 # build core DUNE, DuMuX and the adapter
 ARG DUMUX_ADAPTER_PR
 ARG DUMUX_ADAPTER_REF

--- a/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -235,20 +235,18 @@ COPY --from=precice /home/precice/.local/ /home/precice/.local/
 ARG DUNE_VERSION
 ARG DUMUX_VERSION
 USER precice
-WORKDIR /home/precice
-RUN mkdir dumux&&\
-    cd dumux&&\
-    git clone --depth 1 https://gitlab.dune-project.org/core/dune-common.git -b releases/${DUNE_VERSION} &&\
-    git clone --depth 1 https://gitlab.dune-project.org/core/dune-geometry.git -b releases/${DUNE_VERSION} &&\
-    git clone --depth 1 https://gitlab.dune-project.org/core/dune-grid.git -b releases/${DUNE_VERSION} &&\
-    git clone --depth 1 https://gitlab.dune-project.org/core/dune-istl.git -b releases/${DUNE_VERSION} &&\
-    git clone --depth 1 https://gitlab.dune-project.org/extensions/dune-subgrid.git -b releases/${DUNE_VERSION} &&\
-    git clone --depth 1 https://git.iws.uni-stuttgart.de/dumux-repositories/dumux.git -b releases/${DUMUX_VERSION} &&\
-    git clone -b cell_problems https://git.iws.uni-stuttgart.de/dumux-appl/dumux-phasefield.git &&\
-    git clone --depth 1 https://gitlab.dune-project.org/extensions/dune-SPGrid.git -b releases/${DUNE_VERSION} &&\
-    git clone --depth 1 https://gitlab.dune-project.org/core/dune-localfunctions.git -b releases/${DUNE_VERSION}
 WORKDIR /home/precice/dumux
 ENV PATH="/home/precice/dumux/dune-common/bin:${PATH}"
+# This cascade of git clones often led to HTTP 502. Adding some delay and retries in between as a workaround.
+RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/core/dune-common.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]] && sleep 10 && rm -rf dune-common; done
+RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/core/dune-geometry.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dune-geometry; done
+RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/core/dune-grid.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dune-grid; done
+RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/core/dune-istl.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dune-istl; done
+RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/extensions/dune-subgrid.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dune-subgrid; done
+RUN for i in $(seq 1 3); do git clone --depth 1 https://git.iws.uni-stuttgart.de/dumux-repositories/dumux.git -b releases/${DUMUX_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dumux; done
+RUN for i in $(seq 1 3); do git clone -b cell_problems https://git.iws.uni-stuttgart.de/dumux-appl/dumux-phasefield.git && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dumux-phasefield; done
+RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/extensions/dune-SPGrid.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dune-SPGrid; done
+RUN for i in $(seq 1 3); do git clone --depth 1 https://gitlab.dune-project.org/core/dune-localfunctions.git -b releases/${DUNE_VERSION} && break && [[ $i -eq 3 ]]  && sleep 10 && rm -rf dune-localfunctions; done
 # build core DUNE, DuMuX and the adapter
 ARG DUMUX_ADAPTER_PR
 ARG DUMUX_ADAPTER_REF

--- a/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -239,56 +239,56 @@ WORKDIR /home/precice/dumux
 ENV PATH="/home/precice/dumux/dune-common/bin:${PATH}"
 # This cascade of git clones often led to HTTP 502. Adding some delay and retries in between as a workaround.
 RUN for i in $(seq 1 3); do \
-        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-common.git -b releases/${DUNE_VERSION}; then break; fi \
-        rm -rf dune-common \
+        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-common.git -b releases/${DUNE_VERSION}; then break; fi; \
+        rm -rf dune-common; \
         if [[ $i -eq 3 ]]; then exit 1; fi; \
         sleep 10; \
     done
 RUN for i in $(seq 1 3); do \
-        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-geometry.git -b releases/${DUNE_VERSION}; then break; fi \
-        rm -rf dune-geometry \
+        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-geometry.git -b releases/${DUNE_VERSION}; then break; fi; \
+        rm -rf dune-geometry; \
         if [[ $i -eq 3 ]]; then exit 1; fi; \
         sleep 10; \
     done
 RUN for i in $(seq 1 3); do \
-        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-grid.git -b releases/${DUNE_VERSION}; then break; fi \
-        rm -rf dune-grid \
+        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-grid.git -b releases/${DUNE_VERSION}; then break; fi; \
+        rm -rf dune-grid; \
         if [[ $i -eq 3 ]]; then exit 1; fi; \
         sleep 10; \
     done
 RUN for i in $(seq 1 3); do \
-        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-istl.git -b releases/${DUNE_VERSION}; then break; fi \
-        rm -rf dune-istl \
+        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-istl.git -b releases/${DUNE_VERSION}; then break; fi; \
+        rm -rf dune-istl; \
         if [[ $i -eq 3 ]]; then exit 1; fi; \
         sleep 10; \
     done
 RUN for i in $(seq 1 3); do \
-        if git clone --depth 1 https://gitlab.dune-project.org/extensions/dune-subgrid.git -b releases/${DUNE_VERSION}; then break; fi \
-        rm -rf dune-subgrid \
+        if git clone --depth 1 https://gitlab.dune-project.org/extensions/dune-subgrid.git -b releases/${DUNE_VERSION}; then break; fi; \
+        rm -rf dune-subgrid; \
         if [[ $i -eq 3 ]]; then exit 1; fi; \
         sleep 10; \
     done
 RUN for i in $(seq 1 3); do \
-        if git clone --depth 1 https://git.iws.uni-stuttgart.de/dumux-repositories/dumux.git -b releases/${DUMUX_VERSION}; then break; fi \
-        rm -rf dumux \
+        if git clone --depth 1 https://git.iws.uni-stuttgart.de/dumux-repositories/dumux.git -b releases/${DUMUX_VERSION}; then break; fi; \
+        rm -rf dumux; \
         if [[ $i -eq 3 ]]; then exit 1; fi; \
         sleep 10; \
     done
 RUN for i in $(seq 1 3); do \
-        if git clone -b cell_problems https://git.iws.uni-stuttgart.de/dumux-appl/dumux-phasefield.git; then break; fi \
-        rm -rf dumux-phasefield \
+        if git clone -b cell_problems https://git.iws.uni-stuttgart.de/dumux-appl/dumux-phasefield.git; then break; fi; \
+        rm -rf dumux-phasefield; \
         if [[ $i -eq 3 ]]; then exit 1; fi; \
         sleep 10; \
     done
 RUN for i in $(seq 1 3); do \
-        if git clone --depth 1 https://gitlab.dune-project.org/extensions/dune-SPGrid.git -b releases/${DUNE_VERSION}; then break; fi \
-        rm -rf dune-SPGrid \
+        if git clone --depth 1 https://gitlab.dune-project.org/extensions/dune-SPGrid.git -b releases/${DUNE_VERSION}; then break; fi; \
+        rm -rf dune-SPGrid; \
         if [[ $i -eq 3 ]]; then exit 1; fi; \
         sleep 10; \
     done
 RUN for i in $(seq 1 3); do \
-        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-localfunctions.git -b releases/${DUNE_VERSION}; then break; fi \
-        rm -rf dune-localfunctions \
+        if git clone --depth 1 https://gitlab.dune-project.org/core/dune-localfunctions.git -b releases/${DUNE_VERSION}; then break; fi; \
+        rm -rf dune-localfunctions; \
         if [[ $i -eq 3 ]]; then exit 1; fi; \
         sleep 10; \
     done


### PR DESCRIPTION
- Split the git clones into multiple Docker run steps
- Retry if a `git clone` fails, for three times, with delay

I am only adding this to the Ubuntu 24.04 Dockerfile, since we anyway don't have this in 22.04.

Workaround (partial fix) for #768 

GitHub Actions run: https://github.com/precice/tutorials/actions/runs/25845382737

Note that the two-scale-heat-conduction test is known to fail at the fieldcompare test. I am executing the `dumux-test` instead of the `release-test`, for convenience.