### PR TITLE
Fix typos across various README files

### DIFF
--- a/elastic-tube-1d/README.md
+++ b/elastic-tube-1d/README.md
@@ -45,7 +45,7 @@ Both fluid and solid participant are supported in:
 
 ## Running the Simulation
 
-Choose one solver for each pariticipant, then open two separate terminals and start each soler by calling the respective run script.
+Choose one solver for each participant, then open two separate terminals and start each solver by calling the respective run script.
 Here we use both C++ solvers:
 
 ```bash

--- a/flow-around-controlled-moving-cylinder/README.md
+++ b/flow-around-controlled-moving-cylinder/README.md
@@ -115,6 +115,6 @@ Many thanks to [Mosayeb Shams](https://github.com/mosayebshams) from Herriot Wat
 
 [2] Placzek, A. and Sigrist, J.F. and Hamdouni, A. [Numerical Simulation of an oscillating cylinder in a cross-flow at low Reynolds number: Forced and free oscillations](https://dx.doi.org/10.1016/j.compfluid.2008.01.007), Computers and Fluids, 2009, 38 (1), pp.80-100
 
-[3] Anagnostopoulus, P. and Bearman, P.W. Response Characteristics of a vortex-excited cylinder at low Reynolds numbers, Journal of Fluids and Structures, January 1992, DOI: 10.1016/0889-9746(92)90054-7
+[3] Anagnostopoulos, P. and Bearman, P.W. Response Characteristics of a vortex-excited cylinder at low Reynolds numbers, Journal of Fluids and Structures, January 1992, DOI: 10.1016/0889-9746(92)90054-7
 
 [4] Sicklinger, S. [Stabilized Co-Simulation of Coupled Problems including Fields and Signals](https://www.researchgate.net/publication/269705153_Stabilized_Co-Simulation_of_Coupled_Problems_Including_Fields_and_Signals), Technical University of Munich, Dissertation

--- a/flow-over-heated-plate-two-meshes/README.md
+++ b/flow-over-heated-plate-two-meshes/README.md
@@ -27,7 +27,7 @@ By default, the fluid participant reads heat-flux values and the solid participa
 Fluid participant:
 
 * OpenFOAM (buoyantPimpleFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
-* SU2 (copy the `fluid-su2` directory from the `flow-over-heated-plate` tutorial as-is). For more information, have a look at the [SU2 adapter docmentation](https://precice.org/adapter-su2-overview.html).
+* SU2 (copy the `fluid-su2` directory from the `flow-over-heated-plate` tutorial as-is). For more information, have a look at the [SU2 adapter documentation](https://precice.org/adapter-su2-overview.html).
 
 Solid participant:
 

--- a/flow-over-heated-plate/README.md
+++ b/flow-over-heated-plate/README.md
@@ -33,7 +33,7 @@ Fluid participant:
 
 * OpenFOAM (buoyantPimpleFoam). For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
-* SU2. For more information, have a look at the [SU2 adapter docmentation](https://precice.org/adapter-su2-overview.html).
+* SU2. For more information, have a look at the [SU2 adapter documentation](https://precice.org/adapter-su2-overview.html).
 
 Solid participant:
 

--- a/free-flow-over-porous-media/README.md
+++ b/free-flow-over-porous-media/README.md
@@ -53,7 +53,7 @@ cd porous-media-dumux
 ./run.sh
 ```
 
-This assumes a DuMux and DUNE modules installation in the case folder. You can specify the path to an existing DUNE installation with with `-l`:
+This assumes a DuMux and DUNE modules installation in the case folder. You can specify the path to an existing DUNE installation with `-l`:
 
 ```bash
 ./run.sh -l <path-to-DUNE-common>

--- a/heat-exchanger/README.md
+++ b/heat-exchanger/README.md
@@ -53,7 +53,7 @@ In order to run the coupled simulation, you can simply step into the participant
 
 After the first results are written (a new time directory will be created), you may visualize the results.
 
-For the OpenFOAM results, you can use ParaView and open the allready-provided `fluid-inner-openfoam.foam` and `fluid-outer-openfoam.foam` files. You can then group the two cases and visualize them together.
+For the OpenFOAM results, you can use ParaView and open the already-provided `fluid-inner-openfoam.foam` and `fluid-outer-openfoam.foam` files. You can then group the two cases and visualize them together.
 
 Unfortunately, ParaView does not support CalculiX result files. You may see the results in CGX or convert them using 3rd-party tools.
 

--- a/multiple-perpendicular-flaps/README.md
+++ b/multiple-perpendicular-flaps/README.md
@@ -48,9 +48,9 @@ The participant that has the control is the one that it is connected to all othe
 
 ## About the Solvers
 
-For the fluid participant we use OpenFOAM. In particular, we use the application `pimpleFoam`. The geometry of the Fluid participant is defined in the file `Fluid/system/blockMeshDict`. Besides, we must specify where are we exchanging data with the other participants. The interfaces are set in the file `Fluid/system/preciceDict`. In this file, we set to exchange stress and displacement on the surface of each flap.
+For the fluid participant we use OpenFOAM. In particular, we use the application `pimpleFoam`. The geometry of the Fluid participant is defined in the file `Fluid/system/blockMeshDict`. Besides, we must specify where we are exchanging data with the other participants. The interfaces are set in the file `Fluid/system/preciceDict`. In this file, we set to exchange stress and displacement on the surface of each flap.
 
-Most of the coupling details are specified in the file `precice-config.xml`. Here we estipulate the order in which we read/write data from one participant to another or how we map from the fluid to the solid's mesh. In particular, we have chosen the nearest-neighbor mapping scheme.
+Most of the coupling details are specified in the file `precice-config.xml`. Here we set the order in which we read/write data from one participant to another or how we map from the fluid to the solid's mesh. In particular, we have chosen the nearest-neighbor mapping scheme.
 
 For the simulation of the solid participants we use the deal.II adapter. In deal.II, the geometry of the domain is specified directly on the solver. The two flaps in our case are essentially the same but for the x-coordinate. The flap geometry is given to the solver when we select the scenario in the `.prm` file.
 

--- a/partitioned-heat-conduction/README.md
+++ b/partitioned-heat-conduction/README.md
@@ -19,7 +19,7 @@ Case setup from [3]. `D` denotes the Dirichlet participant and `N` denotes the N
 
 The heat equation is solved on a rectangular domain `Omega = [0,2] x [0,1]` with given Dirichlet boundary conditions. We split the domain at `x_c = 1` using a straight vertical line, the coupling interface. The left part of the domain will be referred to as the Dirichlet partition and the right part as the Neumann partition. To couple the two participants we use Dirichlet-Neumann coupling. Here, the Dirichlet participant receives Dirichlet boundary conditions (`Temperature`) at the coupling interface and solves the heat equation using these boundary conditions on the left part of the domain. Then the Dirichlet participant computes the resulting heat flux (`Flux`) from the solution and sends it to the Neumann participant. The Neumann participant uses the flux as a Neumann boundary condition to solve the heat equation on the right part of the domain. We then extract the temperature from the solution and send it back to the Dirichlet participant. This establishes the coupling between the two participants.
 
-This simple case allows us to compare the solution for the partitioned case to a known analytical solution (method of manufactures solutions, see [1, p.37ff]). For more usage examples and details, please refer to [3, sect. 4.1].
+This simple case allows us to compare the solution for the partitioned case to a known analytical solution (method of manufactured solutions, see [1, p.37ff]). For more usage examples and details, please refer to [3, sect. 4.1].
 
 ## Configuration
 
@@ -129,4 +129,4 @@ Visualization in paraview for `x_c = 1.5`.
 [2] Azahar Monge and Philipp Birken. "Convergence Analysis of the Dirichlet-Neumann Iteration for Finite Element Discretizations." (2016). Proceedings in Applied Mathematics and Mechanics. [doi](https://doi.org/10.1002/pamm.201610355)  
 [3] Benjamin Rüth, Benjamin Uekermann, Miriam Mehl, Philipp Birken, Azahar Monge, and Hans Joachim Bungartz. "Quasi-Newton waveform iteration for partitioned surface-coupled multiphysics applications." (2020). International Journal for Numerical Methods in Engineering. [doi](https://doi.org/10.1002/nme.6443)  
 [4] Niklas Vinnitchenko. "Evaluation of Higher-Order Coupling Schemes with FEniCS-preCICE." (2024). Bachelor's thesis at Technical University of Munich. [pdf](https://mediatum.ub.tum.de/1732367)
-[5] Tobias Eppacher. "Parallel-in-Time Integration with preCICE" (2024). Bachlor's thesis at Technical University of Munich. [pdf](https://mediatum.ub.tum.de/1755012)
+[5] Tobias Eppacher. "Parallel-in-Time Integration with preCICE" (2024). Bachelor's thesis at Technical University of Munich. [pdf](https://mediatum.ub.tum.de/1755012)

--- a/partitioned-pipe-two-phase/README.md
+++ b/partitioned-pipe-two-phase/README.md
@@ -2,7 +2,7 @@
 title: Partitioned pipe two phase
 permalink: tutorials-partitioned-pipe-two-phase.html
 keywords: tutorial, FF, fluid-fluid coupling, OpenFOAM, interFoam, multiphase
-summary: This tutorial describes how to run a partitioned two-phse fluid simulation using preCICE.
+summary: This tutorial describes how to run a partitioned two-phase fluid simulation using preCICE.
 ---
 
 {% note %}
@@ -11,7 +11,7 @@ Get the [case files of this tutorial](https://github.com/precice/tutorials/tree/
 
 ## Setup
 
-This scenario consists of two pipes connected in series, both simulated with OpenFOAM's interFoam solver. Fluids can enter from the left (here $$ z=0 $$) boundary of the Fluid1 participant with a uniform velocity profile ($$ u_{in} = 1 m/s $$) and fixed flux pressure boundary coundition.
+This scenario consists of two pipes connected in series, both simulated with OpenFOAM's interFoam solver. Fluids can enter from the left (here $$ z=0 $$) boundary of the Fluid1 participant with a uniform velocity profile ($$ u_{in} = 1 m/s $$) and fixed flux pressure boundary condition.
 The simulation begins with some water being present at the bottom left of the pipe. The volume fraction variable alpha is set to be 1 (water) at the bottom half of the inlet and 0 (air) at the top half. The water stream will approach the coupling interface at around $$ t=5s $$ in the simulation.
 At the right boundary of Fluid2 there is a zero gradient boundary condition for velocity and alpha as well as a total pressure set to zero.
 

--- a/perpendicular-flap/README.md
+++ b/perpendicular-flap/README.md
@@ -29,7 +29,7 @@ Fluid participant:
 
 * OpenFOAM (pimpleFoam). In case you are using a very old OpenFOAM version, you will need to adjust the solver to `pimpleDyMFoam` in the `Fluid/system/controlDict` file. For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
-* SU2. As opposed to the other two fluid codes, SU2 is in particular specialized for compressible flow. Therefore the default simulation parameters haven been adjusted in order to pull the setup into the compressible flow regime. For more information, have a look at the [SU2 adapter documentation](https://precice.org/adapter-su2-overview.html).
+* SU2. As opposed to the other two fluid codes, SU2 is in particular specialized for compressible flow. Therefore the default simulation parameters have been adjusted in order to pull the setup into the compressible flow regime. For more information, have a look at the [SU2 adapter documentation](https://precice.org/adapter-su2-overview.html).
 
 * Nutils. For more information, have a look at the [Nutils adapter documentation](https://precice.org/adapter-nutils.html). This Nutils solver requires at least Nutils v6.0. This case currently takes orders of magnitude longer than the OpenFOAM and SU2 cases, see [related issue](https://github.com/precice/tutorials/issues/506).
 

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -169,7 +169,7 @@ Metadata and workflow/script files:
     - ...
   - `dockerfiles/`
     - Multi-stage build Dockerfiles that define how to build each component, in a layered approach
-  - `docker-compose.template.yaml`: Describes how to prepare each test (Docker Componse service template)
+  - `docker-compose.template.yaml`: Describes how to prepare each test (Docker Compose service template)
   - `docker-compose.field_compare.template.yaml`: Describes how to compare results with fieldcompare (Docker Compose service template)
   - `components.yaml`: Declares the available components and their parameters/options
   - `reference_results.metadata.template`: Template for reporting the versions used to generate the reference results
@@ -235,7 +235,7 @@ Description:
 - `name`: A human-readable, descriptive name
 - `path`: Where the tutorial is located, relative to the tutorials repository
 - `url`: A web page with more information on the tutorial
-- `participants`: A list of preCICE participants, typically corresponing to different domains of the simulation
+- `participants`: A list of preCICE participants, typically corresponding to different domains of the simulation
 - `cases`: A list of solver configuration directories. Each element of the list includes:
   - `participant`: Which participant this solver case can serve as
   - `directory`: Where the case directory is located, relative to the tutorial directory
@@ -346,7 +346,7 @@ This defines two test suites, namely `openfoam_adapter_pr` and `openfoam_adapter
 
 #### via GitHub workflow (recommended)
 
-The preferred way of adding reference results is via the manual triggerable `Generate reference results (manual)` workflow. This takes two inputs:
+The preferred way of adding reference results is via the manual `Generate reference results (manual)` workflow. This takes two inputs:
 
 - `from_ref`: branch where the new test configuration (e.g added tests, new reference_versions.yaml) is
 - `commit_msg`: commit message for adding the reference results into the branch

--- a/two-scale-heat-conduction/README.md
+++ b/two-scale-heat-conduction/README.md
@@ -62,7 +62,7 @@ cd macro-dumux
 ./run.sh -s
 ```
 
-This assumes a DuMux and DUNE modules installation in the case folder. You can specify the path to an existing DUNE installation with with `-l`:
+This assumes a DuMux and DUNE modules installation in the case folder. You can specify the path to an existing DUNE installation with `-l`:
 
 ```bash
 ./run.sh -s -l <path-to-DUNE-common>


### PR DESCRIPTION
This PR fixes several typos across `README.md` files, as reported by @NishantSinghhhhh (not sure anymore where, but I still have the respective Gemini report).