### PR TITLE
Remove redundant default substeps options

### DIFF
--- a/changelog-entries/786.md
+++ b/changelog-entries/786.md
@@ -1,0 +1,1 @@
+- Remove redundant `substeps="true"` option (default) from the oscillator, oscillator-overlap, partitioned-heat-condiction, and resonant-circuit tutorials. [#786](https://github.com/precice/tutorials/pull/786)

--- a/oscillator-overlap/precice-config.xml
+++ b/oscillator-overlap/precice-config.xml
@@ -56,14 +56,12 @@
       mesh="Mass-Left-Mesh"
       from="Mass-Left"
       to="Mass-Right"
-      initialize="true"
-      substeps="true" />
+      initialize="true" />
     <exchange
       data="Displacement-Right"
       mesh="Mass-Left-Mesh"
       from="Mass-Right"
       to="Mass-Left"
-      initialize="true"
-      substeps="true" />
+      initialize="true" />
   </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/oscillator/precice-config.xml
+++ b/oscillator/precice-config.xml
@@ -56,14 +56,12 @@
       mesh="Mass-Left-Mesh"
       from="Mass-Left"
       to="Mass-Right"
-      initialize="true"
-      substeps="true" />
+      initialize="true" />
     <exchange
       data="Force-Right"
       mesh="Mass-Left-Mesh"
       from="Mass-Right"
       to="Mass-Left"
-      initialize="true"
-      substeps="true" />
+      initialize="true" />
   </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/partitioned-heat-conduction/precice-config.xml
+++ b/partitioned-heat-conduction/precice-config.xml
@@ -58,15 +58,13 @@
       mesh="Dirichlet-Mesh"
       from="Dirichlet"
       to="Neumann"
-      initialize="true"
-      substeps="true" />
+      initialize="true" />
     <exchange
       data="Temperature"
       mesh="Neumann-Mesh"
       from="Neumann"
       to="Dirichlet"
-      initialize="true"
-      substeps="true" />
+      initialize="true" />
     <relative-convergence-measure data="Heat-Flux" mesh="Dirichlet-Mesh" limit="1e-10" />
     <relative-convergence-measure data="Temperature" mesh="Neumann-Mesh" limit="1e-10" />
     <!-- <acceleration:IQN-ILS>

--- a/resonant-circuit/precice-config.xml
+++ b/resonant-circuit/precice-config.xml
@@ -44,8 +44,8 @@
     <max-time value="10" />
     <time-window-size value="1" />
     <max-iterations value="100" />
-    <exchange data="Current" mesh="Coil-Mesh" from="Coil" to="Capacitor" substeps="true" />
-    <exchange data="Voltage" mesh="Coil-Mesh" from="Capacitor" to="Coil" substeps="true" />
+    <exchange data="Current" mesh="Coil-Mesh" from="Coil" to="Capacitor" />
+    <exchange data="Voltage" mesh="Coil-Mesh" from="Capacitor" to="Coil" />
     <relative-convergence-measure limit="1e-3" data="Current" mesh="Coil-Mesh" />
     <relative-convergence-measure limit="1e-3" data="Voltage" mesh="Coil-Mesh" />
   </coupling-scheme:serial-implicit>


### PR DESCRIPTION
This PR removes the now redundant default `substeps="true"` option from all tutorial cases where this was defined. Closes https://github.com/precice/tutorials/issues/377.

Related to https://github.com/precice/tutorials/pull/281, https://github.com/precice/tutorials/pull/388, https://github.com/precice/tutorials/pull/498, and https://github.com/precice/tutorials/pull/597 and 

@uekerman any reason to still keep these explicit?

Checklist:

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
