### PR TITLE
Fix warnings/error messages related to cleaning scripts

### DIFF
--- a/perpendicular-flap/fluid-fake/clean.sh
+++ b/perpendicular-flap/fluid-fake/clean.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -e -u
+
+. ../../tools/cleaning-tools.sh
+
+rm -rvf ./output/*.vtk
+clean_precice_logs .
+clean_case_logs .

--- a/perpendicular-flap/fluid-fake/run.sh
+++ b/perpendicular-flap/fluid-fake/run.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e -u
 
+. ../../tools/log.sh
+exec > >(tee --append "$LOGFILE") 2>&1
+
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
     python3 -m venv .venv
@@ -8,3 +11,5 @@ then
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi
 python3 fake.py
+
+close_log

--- a/perpendicular-flap/solid-fake/clean.sh
+++ b/perpendicular-flap/solid-fake/clean.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -e -u
+
+. ../../tools/cleaning-tools.sh
+
+rm -rvf ./output/*.vtk
+clean_precice_logs .
+clean_case_logs .

--- a/perpendicular-flap/solid-fake/run.sh
+++ b/perpendicular-flap/solid-fake/run.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e -u
 
+. ../../tools/log.sh
+exec > >(tee --append "$LOGFILE") 2>&1
+
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
     python3 -m venv .venv
@@ -8,3 +11,5 @@ then
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi
 python3 fake.py
+
+close_log

--- a/tools/cleaning-tools.sh
+++ b/tools/cleaning-tools.sh
@@ -149,7 +149,7 @@ clean_openfoam() {
         if [ -n "${WM_PROJECT:-}" ] || error "No OpenFOAM environment is active."; then
             # shellcheck disable=SC1090 # This is an OpenFOAM file which we don't need to check
             . "${WM_PROJECT_DIR}/bin/tools/CleanFunctions"
-            cleanCase > /dev/null
+            region="*" cleanCase > /dev/null
             rm -rfv 0/uniform/functionObjects/functionObjectProperties history
         fi
         clean_precice_logs .

--- a/tools/cleaning-tools.sh
+++ b/tools/cleaning-tools.sh
@@ -18,7 +18,7 @@ clean_tutorial() {
         fi
 
         for case in */; do
-            if [ "${case}" = images/ ] || [ "${case}" = reference-results/ ]; then
+            if [ "${case}" = images/ ] || [ "${case}" = reference-results/ ] || [ "${case}" = dumux/ ]; then
                 continue
             fi
             case "${case}" in solver*)


### PR DESCRIPTION
## Description

This PR:

- Fixes the error message `./clean.sh: 137: region: parameter not set` emmited by newer OpenFOAM versions by cleaning all regions by default. This is just an environment variable set when executing, so it should be backwards compatible.
- Adds missing logging in the `run.sh` and missing `clean.sh` for the `perpendicular-flap/fake-fluid` and `perpendicular-flap/fake-solid`.
- Adds the `dumux/` directory to the exceptions of `clean_tutorial()` (created by [setup-dumux.sh](https://github.com/precice/tutorials/blob/develop/free-flow-over-porous-media/setup-dumux.sh))

