### PR TITLE
Quickstart: Disable foam-extend related options by default

### DIFF
--- a/quickstart/fluid-openfoam/constant/dynamicMeshDict
+++ b/quickstart/fluid-openfoam/constant/dynamicMeshDict
@@ -14,7 +14,10 @@ motionSolverLibs ("libfvMotionSolvers.so");
 solver      displacementLaplacian;
 // OpenFOAM9 or newer: rename "solver" to "motionSolver"
 
-diffusivity uniform; // Only relevant to foam-extend
+// The following entries are only relevant to foam-extend
+/* uncomment
+diffusivity uniform;
+*/ // foam-extend
 
 displacementLaplacianCoeffs {
     diffusivity quadratic inverseDistance (flap);

--- a/quickstart/fluid-openfoam/system/controlDict
+++ b/quickstart/fluid-openfoam/system/controlDict
@@ -55,12 +55,14 @@ functions
         log                 true;
         rhoInf              10;
         // The following entries are only relevant to foam-extend
+        /* uncomment
         functionObjectLibs  ( "libforces.so" );
         outputControl       timeStep;
         outputInterval      1;
         pName               p;
         UName               U;
         rhoName             rhoInf;
+        */ // foam-extend
         CofR                (0 0 0);
     }
 

--- a/quickstart/fluid-openfoam/system/fvSchemes
+++ b/quickstart/fluid-openfoam/system/fvSchemes
@@ -21,7 +21,10 @@ divSchemes
 {
     default         none;
     div(phi,U)      Gauss linearUpwind grad(U);
-    div((nuEff*dev(T(grad(U))))) Gauss linear;  // Only relevant to foam-extend
+    // The following entries are only relevant to foam-extend
+    /* uncomment
+    div((nuEff*dev(T(grad(U))))) Gauss linear;
+    */ // foam-extend
     div((nuEff*dev2(T(grad(U))))) Gauss linear;
 }
 

--- a/quickstart/fluid-openfoam/system/fvSolution
+++ b/quickstart/fluid-openfoam/system/fvSolution
@@ -14,10 +14,12 @@ solvers
         tolerance        1e-6;
         relTol           1e-4;
         smoother         DICGaussSeidel;
-         // The following entries are only relevant to foam-extend
+        // The following entries are only relevant to foam-extend
+        /* uncomment
         agglomerator    faceAreaPair;
         nCellsInCoarsestLevel 10;
         mergeLevels 1;
+        */ // foam-extend
     }
 
     pFinal
@@ -83,7 +85,8 @@ potentialFlow
     nNonOrthogonalCorrectors 1;
 }
 
-// The relaxationFactors and fieldBounds are only relevant to foam-extend
+// The following entries are only relevant to foam-extend
+/* uncomment
 relaxationFactors
 {
     U          0.7;
@@ -95,4 +98,4 @@ fieldBounds
     p -1e5 1e5;
     U 100;
 }
-
+*/ // foam-extend

--- a/tools/run-foam-extend.sh
+++ b/tools/run-foam-extend.sh
@@ -22,7 +22,15 @@ sed -i "s,writeCompression    off,writeCompression    uncompressed,g" system/con
 sed -i "s,\/\* uncomment,// FOAMEXTENDBEGIN,g" system/controlDict
 sed -i "s,\*\/ // foam-extend,// FOAMEXTENDEND,g" system/controlDict
 
+sed -i "s,\/\* uncomment,// FOAMEXTENDBEGIN,g" system/fvSchemes
+sed -i "s,\*\/ // foam-extend,// FOAMEXTENDEND,g" system/fvSchemes
+
+sed -i "s,\/\* uncomment,// FOAMEXTENDBEGIN,g" system/fvSolution
+sed -i "s,\*\/ // foam-extend,// FOAMEXTENDEND,g" system/fvSolution
+
 sed -i "s/libfvMotionSolvers\./libfvMotionSolver\./g" constant/dynamicMeshDict
+sed -i "s,\/\* uncomment,// FOAMEXTENDBEGIN,g" constant/dynamicMeshDict
+sed -i "s,\*\/ // foam-extend,// FOAMEXTENDEND,g" constant/dynamicMeshDict
 
 # OpenFOAM run functions: getApplication, getNumberOfProcessors
 # shellcheck disable=SC1090 # This is an OpenFOAM file which we don't need to check
@@ -48,4 +56,12 @@ fi
 #sed -i "s,// FOAMEXTENDBEGIN,\/\* uncomment,g" system/controlDict
 #sed -i "s,// FOAMEXTENDEND,\*\/ // foam-extend,g" system/controlDict
 #
+#sed -i "s,// FOAMEXTENDBEGIN,\/\* uncomment,g" system/fvSchemes
+#sed -i "s,// FOAMEXTENDEND,\*\/ // foam-extend,g" system/fvSchemes
+#
+#sed -i "s,// FOAMEXTENDBEGIN,\/\* uncomment,g" system/fvSolution
+#sed -i "s,// FOAMEXTENDEND,\*\/ // foam-extend,g" system/fvSolution
+#
 #sed -i "s/libfvMotionSolver\./libfvMotionSolvers\./g" constant/dynamicMeshDict
+#sed -i "s,// FOAMEXTENDBEGIN,\/\* uncomment,g" constant/dynamicMeshDict
+#sed -i "s,// FOAMEXTENDEND,\*\/ // foam-extend,g" constant/dynamicMeshDict

--- a/tools/run-foam-extend.sh
+++ b/tools/run-foam-extend.sh
@@ -19,6 +19,8 @@ sed -i "s,// application     pimpleDyMFoam;,application     pimpleDyMFoam;,g" sy
 sed -i '41i\ \ \ \ "liblduSolvers.so"' system/controlDict
 sed -i '41i\ \ \ \ "libforces.so"' system/controlDict
 sed -i "s,writeCompression    off,writeCompression    uncompressed,g" system/controlDict
+sed -i "s,\/\* uncomment,// FOAMEXTENDBEGIN,g" system/controlDict
+sed -i "s,\*\/ // foam-extend,// FOAMEXTENDEND,g" system/controlDict
 
 sed -i "s/libfvMotionSolvers\./libfvMotionSolver\./g" constant/dynamicMeshDict
 
@@ -43,5 +45,7 @@ fi
 #sed -i '/   "liblduSolvers.so"/d' system/controlDict
 #sed -i '/   "libforces.so/d' system/controlDict
 #sed -i "s,writeCompression    uncompressed,writeCompression    off,g" system/controlDict
+#sed -i "s,// FOAMEXTENDBEGIN,\/\* uncomment,g" system/controlDict
+#sed -i "s,// FOAMEXTENDEND,\*\/ // foam-extend,g" system/controlDict
 #
 #sed -i "s/libfvMotionSolver\./libfvMotionSolvers\./g" constant/dynamicMeshDict


### PR DESCRIPTION
## Description

https://github.com/precice/tutorials/pull/654 added a `run-foam-extend.sh` script that prepares the Quickstart case for running with foam-extend. At the same time, it introduced a few options in the configuration files that foam-extend needs but OpenFOAM does not.

Still:

- the `outputControl` in `controlDict` was triggering a deprecation warning, which would give a wrong first impression,
- some of the other options were different than the defaults of OpenFOAM (not sure which), changing the results (I think only slightly): https://github.com/precice/tutorials/actions/runs/26435180245

This PR wraps the foam-extend specific options with

```cpp
        // The following entries are only relevant to foam-extend
        /* uncomment
        functionObjectLibs  ( "libforces.so" );
        outputControl       timeStep;
        outputInterval      1;
        pName               p;
        UName               U;
        rhoName             rhoInf;
        */ // foam-extend
```

and extend the script to convert them to

```cpp
        // The following entries are only relevant to foam-extend
        // FOAMEXTENDBEGIN
        functionObjectLibs  ( "libforces.so" );
        outputControl       timeStep;
        outputInterval      1;
        pName               p;
        UName               U;
        rhoName             rhoInf;
        // FOAMEXTENDEND
```

It also adds the reverse operation.

FYI @hoehnp 

Edit: The system tests pass: https://github.com/precice/tutorials/actions/runs/26441509575