### PR TITLE
Make logger in precice-config.xml consistent across tutorials

### DIFF
--- a/elastic-tube-1d/precice-config.xml
+++ b/elastic-tube-1d/precice-config.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <log enabled="1">
-    <sink filter="%Severity% > debug" />
+  <log>
+    <sink
+      filter="%Severity% > debug and %Rank% = 0"
+      format="---[precice] %ColorizedSeverity% %Message%"
+      enabled="true" />
   </log>
 
   <profiling mode="fundamental" synchronize="false" />

--- a/free-flow-over-porous-media/precice-config.xml
+++ b/free-flow-over-porous-media/precice-config.xml
@@ -2,10 +2,9 @@
 <precice-configuration>
   <log>
     <sink
-      type="stream"
-      output="stdout"
-      filter="(%Severity% > debug) or (%Severity% >= trace and %Module% contains SolverInterfaceImpl)"
-      enabled="false" />
+      filter="%Severity% > debug and %Rank% = 0"
+      format="---[precice] %ColorizedSeverity% %Message%"
+      enabled="true" />
   </log>
 
   <data:scalar name="Velocity" />

--- a/oscillator-overlap/precice-config.xml
+++ b/oscillator-overlap/precice-config.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <log enabled="1">
-    <sink filter="%Severity% > debug" />
+  <log>
+    <sink
+      filter="%Severity% > debug and %Rank% = 0"
+      format="---[precice] %ColorizedSeverity% %Message%"
+      enabled="true" />
   </log>
 
   <profiling mode="fundamental" synchronize="false" />

--- a/oscillator/precice-config.xml
+++ b/oscillator/precice-config.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <log enabled="1">
-    <sink filter="%Severity% > debug" />
+  <log>
+    <sink
+      filter="%Severity% > debug and %Rank% = 0"
+      format="---[precice] %ColorizedSeverity% %Message%"
+      enabled="true" />
   </log>
 
   <profiling mode="fundamental" synchronize="false" />

--- a/two-scale-heat-conduction/precice-config.xml
+++ b/two-scale-heat-conduction/precice-config.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration experimental="true">
   <log>
-    <sink type="stream" output="stdout" filter="%Severity% > debug" enabled="true" />
+    <sink
+      filter="%Severity% > debug and %Rank% = 0"
+      format="---[precice] %ColorizedSeverity% %Message%"
+      enabled="true" />
   </log>
 
   <profiling mode="fundamental" synchronize="false" />


### PR DESCRIPTION
## Description

A few tutorials have `<log>` tags that did not have the usual filtering/format, or are otherwise inconsistent without clear reason (seemingly leftovers from development). This PR makes all current tutorials consistent.
