### PR TITLE
System tests: Restructure and cleanup the tests.yaml

### DIFF
--- a/changelog-entries/799.md
+++ b/changelog-entries/799.md
@@ -1,0 +1,1 @@
+- Restructured the list of system tests. Repositories triggering a test suite besides the `release_test` need to be updated. [#799](https://github.com/precice/tutorials/pull/799)

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -45,7 +45,7 @@ Workflow for the preCICE v3 release testing:
 To test a certain test-suite defined in `tests.yaml`, use:
 
 ```bash
-python3 systemtests.py --suites=fenics_test,<someothersuite>
+python3 systemtests.py --suites=fenics-adapter,<someothersuite>
 ```
 
 To discover all tests, use `python print_test_suites.py`.
@@ -59,13 +59,13 @@ Go to Actions > [Run Testsuite (manual)](https://github.com/precice/tutorials/ac
 After bringing these changes to `master`, the manual triggering option should be visible on the top right. Until that happens, we can only trigger this workflow manually from the [GitHub CLI](https://github.blog/changelog/2021-04-15-github-cli-1-9-enables-you-to-work-with-github-actions-from-your-terminal/):
 
 ```shell
-gh workflow run run_testsuite_manual.yml -f suites=fenics_test --ref=develop
+gh workflow run run_testsuite_manual.yml -f suites=fenics-adapter --ref=develop
 ```
 
 Another example, to use the latest releases and enable debug information of the tests:
 
 ```shell
-gh workflow run run_testsuite_manual.yml -f suites=fenics_test -f build_args="PRECICE_REF:v3.1.1,PRECICE_PRESET:production-audit,OPENFOAM_ADAPTER_REF:v1.3.0,PYTHON_BINDINGS_REF:v3.1.0,FENICS_ADAPTER_REF:v2.1.0,SU2_VERSION:7.5.1,SU2_ADAPTER_REF:64d4aff,DEALII_ADAPTER_REF:02c5d18,TUTORIALS_REF:340b447" -f log_level=DEBUG --ref=develop
+gh workflow run run_testsuite_manual.yml -f suites=fenics-adapter -f build_args="PRECICE_REF:v3.1.1,PRECICE_PRESET:production-audit,OPENFOAM_ADAPTER_REF:v1.3.0,PYTHON_BINDINGS_REF:v3.1.0,FENICS_ADAPTER_REF:v2.1.0,SU2_VERSION:7.5.1,SU2_ADAPTER_REF:64d4aff,DEALII_ADAPTER_REF:02c5d18,TUTORIALS_REF:340b447" -f log_level=DEBUG --ref=develop
 ```
 
 where the `*_REF` should be a specific [commit-ish](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefcommit-ishacommit-ishalsocommittish).
@@ -75,7 +75,7 @@ Example output:
 ```text
 Run cd tools/tests
   cd tools/tests
-  python systemtests.py --build_args=PRECICE_REF:v3.1.1,PRECICE_PRESET:production-audit,OPENFOAM_ADAPTER_REF:v1.3.0,PYTHON_BINDINGS_REF:v3.1.0,FENICS_ADAPTER_REF:v2.1.0 --suites=fenics_test --log-level=DEBUG
+  python systemtests.py --build_args=PRECICE_REF:v3.1.1,PRECICE_PRESET:production-audit,OPENFOAM_ADAPTER_REF:v1.3.0,PYTHON_BINDINGS_REF:v3.1.0,FENICS_ADAPTER_REF:v2.1.0 --suites=fenics-adapter --log-level=DEBUG
   cd ../../
   shell: /usr/bin/bash -e {0}
 INFO: About to run the following systemtest in the directory /home/precice/runners_root/actions-runner-tutorial/_work/tutorials/tutorials/runs:
@@ -316,14 +316,7 @@ Concrete tests are specified centrally in the file `tests.yaml`. For example:
 
 ```yaml
 test_suites:
-  openfoam_adapter_pr:
-    tutorials:
-      - path: flow-over-heated-plate
-        case_combination:
-          - fluid-openfoam
-          - solid-openfoam
-        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-  openfoam_adapter_release:
+  openfoam-adapter:
     tutorials:
       - path: flow-over-heated-plate
         case_combination:
@@ -340,7 +333,7 @@ test_suites:
 
 The optional `timeout` field (in seconds) sets the maximum time for the solver run and fieldcompare phases of that specific case. If omitted, it defaults to `GLOBAL_TIMEOUT` (currently 900s, overridable via the `PRECICE_SYSTEMTESTS_TIMEOUT` environment variable).
 
-This defines two test suites, namely `openfoam_adapter_pr` and `openfoam_adapter_release`. Each of them defines which case combinations of which tutorials to run.
+This defines the test suite `openfoam-adapter`, with a case combination to run.
 
 ### Generate Reference Results
 

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -2,6 +2,13 @@
 # Define test suites per tutorial in the beginning of the file,
 # then refer to these in the release_test and in the individual test
 # suites for repositories, at the lower part of the file.
+#
+# Conventions:
+# - Test suites follow the name of the respective tutorial
+# - Tests suites append the entries of the case_combination, separated by underscore
+# - Test suites and tests are sorted alphabetically
+# - Every test suite for a component includes by default all test cases that use that component.
+#   Skipped components are still mentioned in a comment.
 
 test_suites:
   elastic-tube-1d:

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -4,7 +4,7 @@
 # suites for repositories, at the lower part of the file.
 #
 # Conventions:
-# - Test suites follow the name of the respective tutorial
+# - Test suites follow the name of the respective tutorial or repository
 # - Tests suites append the entries of the case_combination, separated by underscore
 # - Test suites and tests are sorted alphabetically
 # - Every test suite for a component includes by default all test cases that use that component.

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -1,4 +1,51 @@
+# Test suites that can be triggered by the system tests.
+# Define test suites per tutorial in the beginning of the file,
+# then refer to these in the release_test and in the individual test
+# suites for repositories, at the lower part of the file.
+
 test_suites:
+  elastic-tube-1d:
+    tutorials:
+      - &elastic-tube-1d_fluid-cpp_solid-cpp
+        path: elastic-tube-1d
+        case_combination:
+          - fluid-cpp
+          - solid-cpp
+        reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-cpp.tar.gz
+      - &elastic-tube-1d_fluid-cpp_solid-python
+        path: elastic-tube-1d
+        case_combination:
+          - fluid-cpp
+          - solid-python
+        reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-python.tar.gz
+      - &elastic-tube-1d_fluid-python_solid-python
+        path: elastic-tube-1d
+        case_combination:
+          - fluid-python
+          - solid-python
+        reference_result: ./elastic-tube-1d/reference-results/fluid-python_solid-python.tar.gz
+
+  flow-over-heated-plate:
+    tutorials:
+      - &flow-over-heated-plate_fluid-openfoam_solid-fenics
+        path: flow-over-heated-plate
+        case_combination:
+         - fluid-openfoam
+         - solid-fenics
+        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-fenics.tar.gz
+      - &flow-over-heated-plate_fluid-openfoam_solid-nutils
+        path: flow-over-heated-plate
+        case_combination:
+          - fluid-openfoam
+          - solid-nutils
+        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-nutils.tar.gz
+      - &flow-over-heated-plate_fluid-openfoam_solid-openfoam
+        path: flow-over-heated-plate
+        case_combination:
+          - fluid-openfoam
+          - solid-openfoam
+        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+
   flow-over-heated-plate-nearest-projection:
     tutorials:
       - &flow-over-heated-plate-nearest-projection_fluid-openfoam_solid-openfoam
@@ -7,6 +54,7 @@ test_suites:
           - fluid-openfoam
           - solid-openfoam
         reference_result: ./flow-over-heated-plate-nearest-projection/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+
   flow-over-heated-plate-two-meshes:
     tutorials:
       - &flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
@@ -16,214 +64,153 @@ test_suites:
           - solid-calculix
         reference_result: ./flow-over-heated-plate-two-meshes/reference-results/fluid-openfoam_solid-openfoam.tar.gz
 
-  quickstart_test:
+  free-flow-over-porous-media:
     tutorials:
-      - &quickstart
-        path: quickstart
-        case_combination:
-          - fluid-openfoam
-          - solid-cpp
-        reference_result: ./quickstart/reference-results/fluid-openfoam_solid-cpp.tar.gz
-  openfoam_adapter_pr:
-    tutorials:
-      - *quickstart
-      - path: flow-over-heated-plate
-        case_combination:
-          - fluid-openfoam
-          - solid-openfoam
-        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-calculix
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-calculix.tar.gz
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-openfoam
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - *flow-over-heated-plate-nearest-projection_fluid-openfoam_solid-openfoam
-      - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
-  openfoam_adapter_release:
-    tutorials:
-      - path: flow-over-heated-plate
-        case_combination:
-          - fluid-openfoam
-          - solid-openfoam
-        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-calculix
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-calculix.tar.gz
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-openfoam
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - *flow-over-heated-plate-nearest-projection_fluid-openfoam_solid-openfoam
-      - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
-  fenics_test:
-    tutorials:
-      - path: flow-over-heated-plate
-        case_combination:
-         - fluid-openfoam
-         - solid-fenics
-        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-fenics.tar.gz
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-fenics
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-fenics.tar.gz
-  nutils_test:
-    tutorials:
-      - path: flow-over-heated-plate
-        case_combination:
-          - fluid-openfoam
-          - solid-nutils
-        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-nutils.tar.gz
-  calculix_test:
-    tutorials:
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-calculix
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-calculix.tar.gz
-      - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
-  dumux_test:
-    tutorials:
-      - path: two-scale-heat-conduction
-        case_combination:
-          - macro-dumux
-          - micro-dumux
-        reference_result: ./two-scale-heat-conduction/reference-results/macro-dumux_micro-dumux.tar.gz # Too small values, expected to fail the comparisons.
-      - path: free-flow-over-porous-media
+      - &free-flow-over-porous-media_free-flow-dumux_porous-media-dumux
+        path: free-flow-over-porous-media
         case_combination:
           - free-flow-dumux
           - porous-media-dumux
         reference_result: ./free-flow-over-porous-media/reference-results/free-flow-dumux_porous-media-dumux.tar.gz
-  micro_manager_test:
+
+  heat-exchanger-simplified:
     tutorials:
-      - path: two-scale-heat-conduction
-        case_combination:
-          - macro-dumux
-          - micro-dumux
-        reference_result: ./two-scale-heat-conduction/reference-results/macro-dumux_micro-dumux.tar.gz # Too small values, expected to fail the comparisons.
-  su2_test:
-    tutorials:
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-su2
-          - solid-fenics
-        reference_result: ./perpendicular-flap/reference-results/fluid-su2_solid-fenics.tar.gz
-  heat_exchanger_simplified_test:
-    tutorials:
-      - &heat_exchanger_simplified
+      - &heat-exchanger-simplified_fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix
         path: heat-exchanger-simplified
         case_combination:
           - fluid-top-openfoam
           - fluid-bottom-openfoam
           - solid-calculix
         reference_result: ./heat-exchanger-simplified/reference-results/fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix.tar.gz
-  dealii_test:
-    tutorials:
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-dealii
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-dealii.tar.gz
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-openfoam
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-openfoam
-          - solid-fenics
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-fenics.tar.gz
-      - path: multiple-perpendicular-flaps
+
+  multiple-perpendicular-flaps:
+      - &multiple-perpendicular-flaps_fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii
+        path: multiple-perpendicular-flaps
         case_combination:
           - fluid-openfoam
           - solid-upstream-dealii
           - solid-downstream-dealii
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii.tar.gz
-  elastic_tube_1d_test:
-    tutorials:
-      - path: elastic-tube-1d
-        case_combination:
-          - fluid-cpp
-          - solid-cpp
-        reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-cpp.tar.gz
-      - path: elastic-tube-1d
-        case_combination:
-          - fluid-python
-          - solid-python
-        reference_result: ./elastic-tube-1d/reference-results/fluid-python_solid-python.tar.gz
-      - path: elastic-tube-1d
-        case_combination:
-          - fluid-cpp
-          - solid-python
-        reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-python.tar.gz
-  release_test:
-    tutorials:
-      - *quickstart
-      - path: elastic-tube-1d
-        case_combination:
-          - fluid-cpp
-          - solid-cpp
-        reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-cpp.tar.gz
-      - path: elastic-tube-1d
-        case_combination:
-          - fluid-python
-          - solid-python
-        reference_result: ./elastic-tube-1d/reference-results/fluid-python_solid-python.tar.gz
-      - path: elastic-tube-1d
-        case_combination:
-          - fluid-cpp
-          - solid-python
-        reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-python.tar.gz
-      - path: flow-over-heated-plate
-        case_combination:
-          - fluid-openfoam
-          - solid-nutils
-        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-nutils.tar.gz
-      - path: flow-over-heated-plate
-        case_combination:
-          - fluid-openfoam
-          - solid-fenics
-        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-fenics.tar.gz
-      - path: flow-over-heated-plate
-        case_combination:
-          - fluid-openfoam
-          - solid-openfoam
-        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-openfoam.tar.gz
-      - *flow-over-heated-plate-nearest-projection_fluid-openfoam_solid-openfoam
-      - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
-      - path: perpendicular-flap
+
+  perpendicular-flap:
+      - &perpendicular-flap_fluid-openfoam_solid-calculix
+        path: perpendicular-flap
         case_combination:
           - fluid-openfoam
           - solid-calculix
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-calculix.tar.gz
-      - path: perpendicular-flap
-        case_combination:
-          - fluid-su2
-          - solid-fenics
-        reference_result: ./perpendicular-flap/reference-results/fluid-su2_solid-fenics.tar.gz
-      - path: perpendicular-flap
+      - &perpendicular-flap_fluid-openfoam_solid-dealii
+        path: perpendicular-flap
         case_combination:
           - fluid-openfoam
           - solid-dealii
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-dealii.tar.gz
-      - path: multiple-perpendicular-flaps
+      - &perpendicular-flap_fluid-openfoam_solid-fenics
+        path: perpendicular-flap
         case_combination:
           - fluid-openfoam
-          - solid-upstream-dealii
-          - solid-downstream-dealii
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii.tar.gz
-      - *heat_exchanger_simplified
-      - path: free-flow-over-porous-media
+          - solid-fenics
+        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-fenics.tar.gz
+      - &perpendicular-flap_fluid-openfoam_solid-openfoam
+        path: perpendicular-flap
         case_combination:
-          - free-flow-dumux
-          - porous-media-dumux
-        reference_result: ./free-flow-over-porous-media/reference-results/free-flow-dumux_porous-media-dumux.tar.gz
+          - fluid-openfoam
+          - solid-openfoam
+        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-openfoam.tar.gz
+      - &perpendicular-flap_fluid-su2_solid-fenics
+        path: perpendicular-flap
+        case_combination:
+          - fluid-su2
+          - solid-fenics
+        reference_result: ./perpendicular-flap/reference-results/fluid-su2_solid-fenics.tar.gz
+
+  two-scale-heat-conduction:
+    tutorials:
+      - &two-scale-heat-conduction_macro-dumux_micro-dumux
+        path: two-scale-heat-conduction
+        case_combination:
+          - macro-dumux
+          - micro-dumux
+        reference_result: ./two-scale-heat-conduction/reference-results/macro-dumux_micro-dumux.tar.gz # Too small values, expected to fail the comparisons.
+
+  quickstart:
+    tutorials:
+      - &quickstart_openfoam_cpp
+        path: quickstart
+        case_combination:
+          - fluid-openfoam
+          - solid-cpp
+        reference_result: ./quickstart/reference-results/fluid-openfoam_solid-cpp.tar.gz
+
+#####################################################################
+## Test suites referring to the test suites defined above
+
+  release_test:
+    tutorials:
+      - *elastic-tube-1d_fluid-cpp_solid-cpp
+      - *elastic-tube-1d_fluid-cpp_solid-python
+      - *elastic-tube-1d_fluid-python_solid-python
+      - *flow-over-heated-plate_fluid-openfoam_solid-fenics
+      - *flow-over-heated-plate_fluid-openfoam_solid-nutils
+      - *flow-over-heated-plate_fluid-openfoam_solid-openfoam
+      - *flow-over-heated-plate-nearest-projection_fluid-openfoam_solid-openfoam
+      - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
+      - *free-flow-over-porous-media_free-flow-dumux_porous-media-dumux
+      - *heat-exchanger-simplified_fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix
+      - *multiple-perpendicular-flaps_fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii
+      - *perpendicular-flap_fluid-openfoam_solid-calculix
+      - *perpendicular-flap_fluid-openfoam_solid-dealii
+      - *perpendicular-flap_fluid-openfoam_solid-fenics
+      - *perpendicular-flap_fluid-openfoam_solid-openfoam
+      - *perpendicular-flap_fluid-su2_solid-fenics
+      # two-scale-heat-conduction_macro-dumux_micro-dumux excluded
+      - *quickstart_openfoam_cpp
+
+  calculix-adapter:
+    tutorials:
+      - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
+      - *heat-exchanger-simplified_fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix
+      - *perpendicular-flap_fluid-openfoam_solid-calculix
+
+  dealii-adapter:
+    tutorials:
+      - *multiple-perpendicular-flaps_fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii
+      - *perpendicular-flap_fluid-openfoam_solid-dealii
+
+  dumux-adapter:
+    tutorials:
+      - *free-flow-over-porous-media_free-flow-dumux_porous-media-dumux
+      - *two-scale-heat-conduction_macro-dumux_micro-dumux
+
+  fenics-adapter:
+    tutorials:
+      - *flow-over-heated-plate_fluid-openfoam_solid-fenics
+      - *perpendicular-flap_fluid-openfoam_solid-fenics
+      - *perpendicular-flap_fluid-su2_solid-fenics
+
+  micro-manager:
+    tutorials:
+      - *two-scale-heat-conduction_macro-dumux_micro-dumux
+
+  nutils-adapter: # Not a repository
+    tutorials:
+      - *flow-over-heated-plate_fluid-openfoam_solid-nutils
+
+  openfoam-adapter:
+    tutorials:
+      - *flow-over-heated-plate_fluid-openfoam_solid-fenics
+      - *flow-over-heated-plate_fluid-openfoam_solid-nutils
+      - *flow-over-heated-plate_fluid-openfoam_solid-openfoam
+      - *flow-over-heated-plate-nearest-projection_fluid-openfoam_solid-openfoam
+      - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
+      - *heat-exchanger-simplified_fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix
+      - *multiple-perpendicular-flaps_fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii
+      - *perpendicular-flap_fluid-openfoam_solid-calculix
+      - *perpendicular-flap_fluid-openfoam_solid-dealii
+      - *perpendicular-flap_fluid-openfoam_solid-fenics
+      - *perpendicular-flap_fluid-openfoam_solid-openfoam
+      - *quickstart_openfoam_cpp
+
+  su2-adapter:
+    tutorials:
+      - *perpendicular-flap_fluid-su2_solid-fenics

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -91,6 +91,7 @@ test_suites:
         reference_result: ./heat-exchanger-simplified/reference-results/fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix.tar.gz
 
   multiple-perpendicular-flaps:
+    tutorials:
       - &multiple-perpendicular-flaps_fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii
         path: multiple-perpendicular-flaps
         case_combination:
@@ -100,6 +101,7 @@ test_suites:
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii.tar.gz
 
   perpendicular-flap:
+    tutorials:
       - &perpendicular-flap_fluid-openfoam_solid-calculix
         path: perpendicular-flap
         case_combination:


### PR DESCRIPTION
## Description

The `tests.yaml` has evolved a bit chaotically. This PR structures the file in the following way:

```yaml
test_suites:
  elastic-tube-1d:
    tutorials:
      - &elastic-tube-1d_fluid-cpp_solid-cpp
        path: elastic-tube-1d
        case_combination:
          - fluid-cpp
          - solid-cpp
        reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-cpp.tar.gz
      - &elastic-tube-1d_fluid-cpp_solid-python
        ...

  release_test:
    tutorials:
      - *elastic-tube-1d_fluid-cpp_solid-cpp
      - *elastic-tube-1d_fluid-cpp_solid-python
      ...

  calculix-adapter:
    tutorials:
      - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
      ...
```

Conventions:

- Test suites follow the name of the respective tutorial or repository
- Tests suites append the entries of the case_combination, separated by underscore
- Test suites and tests are sorted alphabetically
- Every test suite for a component includes by default all test cases that use that component.
   Skipped components are still mentioned in a comment.

The `release_test` stays as-is, to not have to change workflows in other repositories.

Triggered system tests (with the latest components): https://github.com/precice/tutorials/actions/runs/26500173873 -> Works

Supercedes #775, as it does not only reduce duplication, but it also structures the file.

Closes https://github.com/precice/tutorials/issues/767

## Checklist

- [x] I updated the system tests documentation
- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- After merging:
  - [x] Update the respective adapters: Updated the OpenFOAM and DuMux adapters. I think no other adapter uses a system tests workflow at the moment.