### PR TITLE
Add some parallel cases to the system tests

### DIFF
--- a/flow-over-heated-plate-nearest-projection/metadata.yaml
+++ b/flow-over-heated-plate-nearest-projection/metadata.yaml
@@ -10,11 +10,11 @@ cases:
   fluid-openfoam:
     participant: Fluid
     directory: ./fluid-openfoam
-    run: ./run.sh
+    run: ./run.sh -parallel
     component: openfoam-adapter
 
   solid-openfoam:
     participant: Solid
     directory: ./solid-openfoam
-    run: ./run.sh
+    run: ./run.sh -parallel
     component: openfoam-adapter

--- a/flow-over-heated-plate-two-meshes/metadata.yaml
+++ b/flow-over-heated-plate-two-meshes/metadata.yaml
@@ -10,7 +10,7 @@ cases:
   fluid-openfoam:
     participant: Fluid
     directory: ./fluid-openfoam
-    run: ./run.sh 
+    run: ./run.sh -parallel
     component: openfoam-adapter
   
   solid-calculix:

--- a/flow-over-heated-plate/metadata.yaml
+++ b/flow-over-heated-plate/metadata.yaml
@@ -10,7 +10,7 @@ cases:
   fluid-openfoam:
     participant: Fluid
     directory: ./fluid-openfoam
-    run: ./run.sh 
+    run: ./run.sh -parallel
     component: openfoam-adapter
   
   solid-fenics:
@@ -28,7 +28,7 @@ cases:
   solid-openfoam:
     participant: Solid
     directory: ./solid-openfoam
-    run: ./run.sh 
+    run: ./run.sh -parallel
     component: openfoam-adapter 
 
 

--- a/perpendicular-flap/metadata.yaml
+++ b/perpendicular-flap/metadata.yaml
@@ -16,7 +16,7 @@ cases:
   fluid-openfoam:
     participant: Fluid
     directory: ./fluid-openfoam
-    run: ./run.sh 
+    run: ./run.sh -parallel
     component: openfoam-adapter
   
   fluid-su2:
@@ -52,7 +52,7 @@ cases:
   solid-openfoam:
     participant: Solid
     directory: ./solid-openfoam
-    run: ./run.sh
+    run: ./run.sh -parallel
     component: openfoam-adapter
   
   # solid-solids4foam:


### PR DESCRIPTION
## Description

We currently don't have any MPI-parallel cases in the system tests (besides the elastic-tube-3d that I just added in #800).

This PR switches OpenFOAM to run in parallel in the following tests:

- flow-over-heated-plate (fluid and solid participants)
- flow-over-heated-plate-nearest-projection (fluild and solid participants)
- flow-over-heated-plate-two-meshes (fluid participant)
- perpendicular-flap (fluid and solid participants)

I excluded cases that would lead to more than 4 ranks, since the runner we use has 4 cores.

I will update the reference results in a separate PR.