### PR TITLE
Restrict the max-time in some system tests

### DIFF
--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -24,6 +24,7 @@ test_suites:
         case_combination:
           - fluid-cpp
           - solid-python
+        max_time: 0.1
         reference_result: ./elastic-tube-1d/reference-results/fluid-cpp_solid-python.tar.gz
       - &elastic-tube-1d_fluid-python_solid-python
         path: elastic-tube-1d
@@ -62,6 +63,7 @@ test_suites:
         case_combination:
           - fluid-openfoam
           - solid-nutils
+        max_time: 0.1
         reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-nutils.tar.gz
       - &flow-over-heated-plate_fluid-openfoam_solid-openfoam
         path: flow-over-heated-plate
@@ -77,6 +79,7 @@ test_suites:
         case_combination:
           - fluid-openfoam
           - solid-openfoam
+        max_time: 0.1
         reference_result: ./flow-over-heated-plate-nearest-projection/reference-results/fluid-openfoam_solid-openfoam.tar.gz
 
   flow-over-heated-plate-two-meshes:
@@ -86,6 +89,7 @@ test_suites:
         case_combination:
           - fluid-openfoam
           - solid-calculix
+        max_time: 0.1
         reference_result: ./flow-over-heated-plate-two-meshes/reference-results/fluid-openfoam_solid-openfoam.tar.gz
 
   free-flow-over-porous-media:
@@ -105,6 +109,7 @@ test_suites:
           - fluid-top-openfoam
           - fluid-bottom-openfoam
           - solid-calculix
+        max_time: 0.1
         reference_result: ./heat-exchanger-simplified/reference-results/fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix.tar.gz
 
   multiple-perpendicular-flaps:
@@ -115,6 +120,7 @@ test_suites:
           - fluid-openfoam
           - solid-upstream-dealii
           - solid-downstream-dealii
+        max_time: 0.1
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii.tar.gz
 
   perpendicular-flap:
@@ -136,18 +142,21 @@ test_suites:
         case_combination:
           - fluid-openfoam
           - solid-fenics
+        max_time: 0.1
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-fenics.tar.gz
       - &perpendicular-flap_fluid-openfoam_solid-openfoam
         path: perpendicular-flap
         case_combination:
           - fluid-openfoam
           - solid-openfoam
+        max_time: 0.1
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-openfoam.tar.gz
       - &perpendicular-flap_fluid-su2_solid-fenics
         path: perpendicular-flap
         case_combination:
           - fluid-su2
           - solid-fenics
+        max_time: 0.1
         reference_result: ./perpendicular-flap/reference-results/fluid-su2_solid-fenics.tar.gz
 
   two-scale-heat-conduction:


### PR DESCRIPTION
## Description

Some tests take much longer than other, and cumulatively the complete `release_test` is quite long, with limited value of running the complete tests till the end.

A recent [snapshot](https://github.com/precice/tutorials/actions/runs/26494171731), with some images cached (focus on the "solver time"):

| systemtest                                                                                      | success | building time [s] | solver time [s] | fieldcompare time [s] |
| --- | --- | --- | --- | --- |
| Quickstart (fluid-openfoam, solid-cpp)                                                          |    1    |       224.0       |      12.6       |         36.1          |
| Elastic tube 1D (fluid-cpp, solid-cpp)                                                          |    1    |        1.5        |      12.0       |          4.6          |
| Elastic tube 1D (fluid-python, solid-python)                                                    |    1    |       38.8        |      50.0       |          5.2          |
| Elastic tube 1D (fluid-cpp, solid-python)                                                       |    1    |        1.2        |      38.9       |          4.8          |
| Flow over heated plate (fluid-openfoam, solid-nutils)                                           |    1    |       12.1        |      106.9      |          4.9          |
| Flow over heated plate (fluid-openfoam, solid-fenics)                                           |    1    |       67.6        |      59.6       |          4.9          |
| Flow over heated plate (fluid-openfoam, solid-openfoam)                                         |    1    |        1.2        |      28.3       |          4.7          |
| Flow over heated plate nearest projection (fluid-openfoam, solid-openfoam)                      |    1    |        1.2        |      38.9       |         15.2          |
| Flow over heated plate with two meshes (fluid-openfoam, solid-calculix)                         |    1    |       83.9        |      273.1      |          6.7          |
| Perpendicular flap (fluid-openfoam, solid-calculix)                                             |    1    |        1.3        |      75.0       |         16.1          |
| Perpendicular flap (fluid-su2, solid-fenics)                                                    |    1    |       427.5       |      469.0      |         16.0          |
| Perpendicular flap (fluid-openfoam, solid-dealii)                                               |    1    |       99.5        |      70.5       |         14.0          |
| Multiple perpendicular flaps (fluid-openfoam, solid-upstream-dealii, solid-downstream-dealii)   |    1    |        1.4        |      202.0      |         34.0          |
| Heat Exchanger simplified (fluid-top-openfoam, fluid-bottom-openfoam, solid-calculix)           |    1    |        1.7        |      383.0      |         10.7          |
| Free flow over porous media (free-flow-dumux, porous-media-dumux)                               |    1    |       330.5       |      57.1       |          2.6          |

This PR restricts the `max-time` of some cases, while still letting some of the faster solvers run till the end:

- elastic-tube-1d_fluid-cpp_solid-python
   - the C++/Python-only cases are tested in full
- flow-over-heated-plate_fluid-openfoam_solid-nutils
   - the Nutils case takes long
- flow-over-heated-plate-nearest-projection_fluid-openfoam_solid-openfoam
   - the main flow-over-heated-plate is tested in full
- flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
   - the main flow-over-heated-plate is tested in full
- heat-exchanger-simplified_fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix
   - the whole case takes too long, all features are also tested elsewhere
- multiple-perpendicular-flaps_fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii
   - the whole case takes too long, all features are also tested elsewhere
- perpendicular-flap_fluid-openfoam_solid-fenics 
- perpendicular-flap_fluid-openfoam_solid-openfoam
- perpendicular-flap_fluid-su2_solid-fenics
   - we already test many perpendicular flaps and all solvers elsewhere. 

On top of this, making some cases parallel (introduced in #803) should make the simulation part of the tests even shorter.

I will update the reference results in another PR.