### PR TITLE
Add the heat exchanger to the system tests

### DIFF
--- a/changelog-entries/806.md
+++ b/changelog-entries/806.md
@@ -1,0 +1,1 @@
+- Added the heat-exchanger tutorial to the system tests [#806](https://github.com/precice/tutorials/pull/806)

--- a/heat-exchanger/metadata.yaml
+++ b/heat-exchanger/metadata.yaml
@@ -1,0 +1,29 @@
+name: Heat exchanger
+path: heat-exchanger # relative to git repo 
+url: https://precice.org/tutorials-heat-exchanger.html
+
+participants:
+  - Fluid-Inner 
+  - Fluid-Outer
+  - Solid
+
+cases:
+  fluid-inner-openfoam:
+    participant: Fluid-Inner
+    directory: ./fluid-inner-openfoam
+    run: ./run.sh
+    component: openfoam-adapter
+  
+  fluid-outer-openfoam:
+    participant: Fluid-Outer
+    directory: ./fluid-outer-openfoam
+    run: ./run.sh
+    component: openfoam-adapter
+
+  solid-calculix:
+    participant: Solid
+    directory: ./solid-calculix
+    run: ./run.sh
+    component: calculix-adapter
+
+

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -101,6 +101,17 @@ test_suites:
           - porous-media-dumux
         reference_result: ./free-flow-over-porous-media/reference-results/free-flow-dumux_porous-media-dumux.tar.gz
 
+  heat-exchanger:
+    tutorials:
+      - &heat-exchanger_fluid-inner-openfoam_solid-calculix_fluid-outer-openfoam
+        path: heat-exchanger
+        case_combination:
+          - fluid-inner-openfoam
+          - fluid-outer-openfoam
+          - solid-calculix
+        max_time_windows: 3
+        reference_result: ./heat-exchanger/reference-results/fluid-inner-openfoam_solid-calculix_fluid-outer-openfoam.tar.gz
+
   heat-exchanger-simplified:
     tutorials:
       - &heat-exchanger-simplified_fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix
@@ -193,6 +204,7 @@ test_suites:
       - *flow-over-heated-plate-nearest-projection_fluid-openfoam_solid-openfoam
       - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
       - *free-flow-over-porous-media_free-flow-dumux_porous-media-dumux
+      - *heat-exchanger_fluid-inner-openfoam_solid-calculix_fluid-outer-openfoam
       - *heat-exchanger-simplified_fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix
       - *multiple-perpendicular-flaps_fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii
       - *perpendicular-flap_fluid-openfoam_solid-calculix
@@ -207,6 +219,7 @@ test_suites:
     tutorials:
       - *elastic-tube-3d_fluid-openfoam_solid-calculix
       - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
+      - *heat-exchanger_fluid-inner-openfoam_solid-calculix_fluid-outer-openfoam
       - *heat-exchanger-simplified_fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix
       - *perpendicular-flap_fluid-openfoam_solid-calculix
 
@@ -244,6 +257,7 @@ test_suites:
       - *flow-over-heated-plate_fluid-openfoam_solid-openfoam
       - *flow-over-heated-plate-nearest-projection_fluid-openfoam_solid-openfoam
       - *flow-over-heated-plate-two-meshes_fluid-openfoam_solid-calculix
+      - *heat-exchanger_fluid-inner-openfoam_solid-calculix_fluid-outer-openfoam
       - *heat-exchanger-simplified_fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix
       - *multiple-perpendicular-flaps_fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii
       - *perpendicular-flap_fluid-openfoam_solid-calculix


### PR DESCRIPTION
## Description

A long-overdue addition to the system tests.

The heat exchanger is a rather heavy case, and the only tutorial that uses a compositional coupling scheme (two parallel-explicit schemes).

This PR adds it to the system tests, restricting it to three coupling time windows, which should take around a minute to run.

I will generate the reference results in a separate PR.

Related: #805 