### PR TITLE
Add partitioned-pipe tutorials to the system tests

### DIFF
--- a/partitioned-pipe-multiscale/fluid1d-left-nutils/run.sh
+++ b/partitioned-pipe-multiscale/fluid1d-left-nutils/run.sh
@@ -4,9 +4,12 @@ set -e -u
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -r requirements.txt && pip freeze > pip-installed-packages.log
+if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
+then
+    python3 -m venv .venv
+    . .venv/bin/activate
+    pip install -r requirements.txt && pip freeze > pip-installed-packages.log
+fi
 
 NUTILS_RICHOUTPUT=no python3 ../solver-fluid1d-nutils/Fluid1D.py side=Left
 

--- a/partitioned-pipe-multiscale/fluid1d-right-nutils/run.sh
+++ b/partitioned-pipe-multiscale/fluid1d-right-nutils/run.sh
@@ -4,9 +4,12 @@ set -e -u
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -r requirements.txt && pip freeze > pip-installed-packages.log
+if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
+then
+    python3 -m venv .venv
+    . .venv/bin/activate
+    pip install -r requirements.txt && pip freeze > pip-installed-packages.log
+fi
 
 NUTILS_RICHOUTPUT=no python3 ../solver-fluid1d-nutils/Fluid1D.py side=Right
 

--- a/partitioned-pipe-multiscale/metadata.yaml
+++ b/partitioned-pipe-multiscale/metadata.yaml
@@ -1,0 +1,20 @@
+name: Partitioned pipe multiscale
+path: partitioned-pipe-multiscale # relative to git repo 
+url: https://precice.org/tutorials-partitioned-pipe-multiscale.html
+
+participants:
+  - Fluid1DLeft
+  - Fluid3DRight
+
+cases:
+  fluid1d-left-nutils:
+    participant: Fluid1DLeft
+    directory: ./fluid1d-left-nutils
+    run: ./run.sh
+    component: nutils-adapter
+
+  fluid3d-right-openfoam:
+    participant: Fluid3DRight
+    directory: ./fluid3d-right-openfoam
+    run: ./run.sh
+    component: openfoam-adapter

--- a/partitioned-pipe-two-phase/metadata.yaml
+++ b/partitioned-pipe-two-phase/metadata.yaml
@@ -1,0 +1,20 @@
+name: Partitioned pipe two phase
+path: partitioned-pipe-two-phase # relative to git repo 
+url: https://precice.org/tutorials-partitioned-pipe-two-phase.html
+
+participants:
+  - Fluid1
+  - Fluid2
+
+cases:
+  fluid1-openfoam:
+    participant: Fluid1
+    directory: ./fluid1-openfoam
+    run: ./run.sh
+    component: openfoam-adapter
+
+  fluid2-openfoam:
+    participant: Fluid2
+    directory: ./fluid2-openfoam
+    run: ./run.sh
+    component: openfoam-adapter

--- a/partitioned-pipe/metadata.yaml
+++ b/partitioned-pipe/metadata.yaml
@@ -1,0 +1,32 @@
+name: Partitioned pipe
+path: partitioned-pipe # relative to git repo 
+url: https://precice.org/tutorials-partitioned-pipe.html
+
+participants:
+  - Fluid1
+  - Fluid2
+
+cases:
+  fluid1-openfoam-pimplefoam:
+    participant: Fluid1
+    directory: ./fluid1-openfoam-pimplefoam
+    run: ./run.sh -parallel
+    component: openfoam-adapter
+  
+  fluid1-openfoam-sonicliquidfoam:
+    participant: Fluid1
+    directory: ./fluid1-openfoam-sonicliquidfoam
+    run: ./run.sh -parallel
+    component: openfoam-adapter
+
+  fluid2-openfoam-pimplefoam:
+    participant: Fluid2
+    directory: ./fluid2-openfoam-pimplefoam
+    run: ./run.sh -parallel
+    component: openfoam-adapter
+
+  fluid2-openfoam-sonicliquidfoam:
+    participant: Fluid2
+    directory: ./fluid2-openfoam-sonicliquidfoam
+    run: ./run.sh -parallel
+    component: openfoam-adapter

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -134,6 +134,23 @@ test_suites:
         max_time: 0.1
         reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii.tar.gz
 
+  partitioned-pipe:
+    tutorials:
+      - &partitioned-pipe_fluid1-openfoam-pimplefoam_fluid2-openfoam-pimplefoam
+        path: partitioned-pipe
+        case_combination:
+          - fluid1-openfoam-pimplefoam
+          - fluid2-openfoam-pimplefoam
+        max_time: 0.1
+        reference_result: ./perpendicular-flap/reference-results/fluid1-openfoam-pimplefoam_fluid2-openfoam-pimplefoam.tar.gz
+      - &partitioned-pipe_fluid1-openfoam-sonicliquidfoam_fluid2-openfoam-sonicliquidfoam
+        path: partitioned-pipe
+        case_combination:
+          - fluid1-openfoam-sonicliquidfoam
+          - fluid2-openfoam-sonicliquidfoam
+        max_time: 0.1
+        reference_result: ./perpendicular-flap/reference-results/fluid1-openfoam-sonicliquidfoam_fluid2-openfoam-sonicliquidfoam.tar.gz
+
   perpendicular-flap:
     tutorials:
       - &perpendicular-flap_fluid-openfoam_solid-calculix
@@ -207,6 +224,8 @@ test_suites:
       - *heat-exchanger_fluid-inner-openfoam_solid-calculix_fluid-outer-openfoam
       - *heat-exchanger-simplified_fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix
       - *multiple-perpendicular-flaps_fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii
+      - *partitioned-pipe_fluid1-openfoam-pimplefoam_fluid2-openfoam-pimplefoam
+      - *partitioned-pipe_fluid1-openfoam-sonicliquidfoam_fluid2-openfoam-sonicliquidfoam
       - *perpendicular-flap_fluid-openfoam_solid-calculix
       - *perpendicular-flap_fluid-openfoam_solid-dealii
       - *perpendicular-flap_fluid-openfoam_solid-fenics
@@ -260,6 +279,8 @@ test_suites:
       - *heat-exchanger_fluid-inner-openfoam_solid-calculix_fluid-outer-openfoam
       - *heat-exchanger-simplified_fluid-top-openfoam_fluid-bottom-openfoam_solid-calculix
       - *multiple-perpendicular-flaps_fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii
+      - *partitioned-pipe_fluid1-openfoam-pimplefoam_fluid2-openfoam-pimplefoam
+      - *partitioned-pipe_fluid1-openfoam-sonicliquidfoam_fluid2-openfoam-sonicliquidfoam
       - *perpendicular-flap_fluid-openfoam_solid-calculix
       - *perpendicular-flap_fluid-openfoam_solid-dealii
       - *perpendicular-flap_fluid-openfoam_solid-fenics

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -132,7 +132,7 @@ test_suites:
           - solid-upstream-dealii
           - solid-downstream-dealii
         max_time: 0.1
-        reference_result: ./perpendicular-flap/reference-results/fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii.tar.gz
+        reference_result: ./multiple-perpendicular-flaps/reference-results/fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii.tar.gz
 
   partitioned-pipe:
     tutorials:
@@ -142,14 +142,24 @@ test_suites:
           - fluid1-openfoam-pimplefoam
           - fluid2-openfoam-pimplefoam
         max_time: 0.1
-        reference_result: ./perpendicular-flap/reference-results/fluid1-openfoam-pimplefoam_fluid2-openfoam-pimplefoam.tar.gz
+        reference_result: ./partitioned-pipe/reference-results/fluid1-openfoam-pimplefoam_fluid2-openfoam-pimplefoam.tar.gz
       - &partitioned-pipe_fluid1-openfoam-sonicliquidfoam_fluid2-openfoam-sonicliquidfoam
         path: partitioned-pipe
         case_combination:
           - fluid1-openfoam-sonicliquidfoam
           - fluid2-openfoam-sonicliquidfoam
         max_time: 0.1
-        reference_result: ./perpendicular-flap/reference-results/fluid1-openfoam-sonicliquidfoam_fluid2-openfoam-sonicliquidfoam.tar.gz
+        reference_result: ./partitioned-pipe/reference-results/fluid1-openfoam-sonicliquidfoam_fluid2-openfoam-sonicliquidfoam.tar.gz
+
+  partitioned-pipe-two-phase:
+    tutorials:
+      - &partitioned-pipe-two-phase_fluid1-openfoam_fluid2-openfoam
+        path: partitioned-pipe-two-phase
+        case_combination:
+          - fluid1-openfoam
+          - fluid2-openfoam
+        max_time: 0.1
+        reference_result: ./partitioned-pipe-two-phase/reference-results/fluid1-openfoam_fluid2-openfoam.tar.gz
 
   perpendicular-flap:
     tutorials:

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -151,6 +151,16 @@ test_suites:
         max_time: 0.1
         reference_result: ./partitioned-pipe/reference-results/fluid1-openfoam-sonicliquidfoam_fluid2-openfoam-sonicliquidfoam.tar.gz
 
+  partitioned-pipe-multiscale:
+    tutorials:
+      - &partitioned-pipe-multiscale_fluid1d-left-nutils_fluid3d-right-openfoam
+        path: partitioned-pipe-multiscale
+        case_combination:
+          - fluid1d-left-nutils
+          - fluid3d-right-openfoam
+        max_time: 0.1
+        reference_result: ./partitioned-pipe-multiscale/reference-results/fluid1d-left-nutils_fluid3d-right-openfoam
+
   partitioned-pipe-two-phase:
     tutorials:
       - &partitioned-pipe-two-phase_fluid1-openfoam_fluid2-openfoam
@@ -236,6 +246,8 @@ test_suites:
       - *multiple-perpendicular-flaps_fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii
       - *partitioned-pipe_fluid1-openfoam-pimplefoam_fluid2-openfoam-pimplefoam
       - *partitioned-pipe_fluid1-openfoam-sonicliquidfoam_fluid2-openfoam-sonicliquidfoam
+      - *partitioned-pipe-multiscale_fluid1d-left-nutils_fluid3d-right-openfoam
+      - *partitioned-pipe-two-phase_fluid1-openfoam_fluid2-openfoam
       - *perpendicular-flap_fluid-openfoam_solid-calculix
       - *perpendicular-flap_fluid-openfoam_solid-dealii
       - *perpendicular-flap_fluid-openfoam_solid-fenics
@@ -276,6 +288,7 @@ test_suites:
   nutils-adapter: # Not a repository
     tutorials:
       - *flow-over-heated-plate_fluid-openfoam_solid-nutils
+      - *partitioned-pipe-multiscale_fluid1d-left-nutils_fluid3d-right-openfoam
 
   openfoam-adapter:
     tutorials:
@@ -291,6 +304,8 @@ test_suites:
       - *multiple-perpendicular-flaps_fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii
       - *partitioned-pipe_fluid1-openfoam-pimplefoam_fluid2-openfoam-pimplefoam
       - *partitioned-pipe_fluid1-openfoam-sonicliquidfoam_fluid2-openfoam-sonicliquidfoam
+      - *partitioned-pipe-multiscale_fluid1d-left-nutils_fluid3d-right-openfoam
+      - *partitioned-pipe-two-phase_fluid1-openfoam_fluid2-openfoam
       - *perpendicular-flap_fluid-openfoam_solid-calculix
       - *perpendicular-flap_fluid-openfoam_solid-dealii
       - *perpendicular-flap_fluid-openfoam_solid-fenics


### PR DESCRIPTION
## Description

This PR adds the following test cases:

- partitioned-pipe: We currently have no system tests case checking the OpenFOAM FF module
- partitioned-pipe-two-phase
- partitioned-pipe-multiscale: We currently have no system tests case checking the geometric multiscale

I will generate the reference results in a separate PR.