### PR TITLE
Add missing checks for PRECICE_TUTORIALS_NO_VENV

### DIFF
--- a/oscillator-overlap/mass-left-python/run.sh
+++ b/oscillator-overlap/mass-left-python/run.sh
@@ -4,9 +4,12 @@ set -e -u
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -r ../solver-python/requirements.txt
+if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
+then
+    python3 -m venv .venv
+    . .venv/bin/activate
+    pip install -r ../solver-python/requirements.txt && pip freeze > pip-installed-packages.log
+fi
 
 python3 ../solver-python/oscillator.py Mass-Left
 

--- a/oscillator-overlap/mass-right-python/run.sh
+++ b/oscillator-overlap/mass-right-python/run.sh
@@ -4,9 +4,12 @@ set -e -u
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -r ../solver-python/requirements.txt
+if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
+then
+    python3 -m venv .venv
+    . .venv/bin/activate
+    pip install -r ../solver-python/requirements.txt && pip freeze > pip-installed-packages.log
+fi
 
 python3 ../solver-python/oscillator.py Mass-Right
 

--- a/oscillator/mass-left-python/run.sh
+++ b/oscillator/mass-left-python/run.sh
@@ -4,9 +4,12 @@ set -e -u
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -r ../solver-python/requirements.txt
+if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
+then
+    python3 -m venv .venv
+    . .venv/bin/activate
+    pip install -r ../solver-python/requirements.txt && pip freeze > pip-installed-packages.log
+fi
 
 python3 ../solver-python/oscillator.py Mass-Left
 

--- a/oscillator/mass-right-python/run.sh
+++ b/oscillator/mass-right-python/run.sh
@@ -4,9 +4,12 @@ set -e -u
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -r ../solver-python/requirements.txt
+if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
+then
+    python3 -m venv .venv
+    . .venv/bin/activate
+    pip install -r ../solver-python/requirements.txt && pip freeze > pip-installed-packages.log
+fi
 
 python3 ../solver-python/oscillator.py Mass-Right
 

--- a/water-hammer/fluid1d-left-nutils/run.sh
+++ b/water-hammer/fluid1d-left-nutils/run.sh
@@ -4,9 +4,12 @@ set -e -u
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -r requirements.txt && pip freeze > pip-installed-packages.log
+if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
+then
+    python3 -m venv .venv
+    . .venv/bin/activate
+    pip install -r requirements.txt && pip freeze > pip-installed-packages.log
+fi
 
 NUTILS_RICHOUTPUT=no python3 ../solver-fluid1d-nutils/Fluid1D.py side=Left
 

--- a/water-hammer/fluid1d-right-nutils/run.sh
+++ b/water-hammer/fluid1d-right-nutils/run.sh
@@ -4,9 +4,12 @@ set -e -u
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 
-python3 -m venv .venv
-. .venv/bin/activate
-pip install -r requirements.txt && pip freeze > pip-installed-packages.log
+if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
+then
+    python3 -m venv .venv
+    . .venv/bin/activate
+    pip install -r requirements.txt && pip freeze > pip-installed-packages.log
+fi
 
 NUTILS_RICHOUTPUT=no python3 ../solver-fluid1d-nutils/Fluid1D.py side=Right
 


### PR DESCRIPTION
These were missing from the `oscillator`, `oscillator-overlap`, and `water-hammer` cases.