### PR TITLE
Make the partitioned-pipe with sonicliquidfoam tutorial automatic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ profiling.db
 profiling.csv
 trace.json
 profiling.pftrace
+precice-config.xml.orig
 
 # C++
 *.o

--- a/changelog-entries/810.md
+++ b/changelog-entries/810.md
@@ -1,0 +1,1 @@
+- Automated the execution of the sonicliquidfoam participants in the partitioned-pipe tutorial. Manually editing the precice-config.xml is no longer required to run these cases. [#810](https://github.com/precice/tutorials/pull/810)

--- a/partitioned-pipe/README.md
+++ b/partitioned-pipe/README.md
@@ -27,7 +27,7 @@ Both for Fluid1 and Fluid2, the following participants are available:
 
 * OpenFOAM (pimpleFoam). An incompressible OpenFOAM solver. For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
 
-* OpenFOAM (sonicLiquidFoam). A compressible OpenFOAM solver. For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html).
+* OpenFOAM (sonicLiquidFoam). A compressible OpenFOAM solver. For more information, have a look at the [OpenFOAM adapter documentation](https://precice.org/adapter-openfoam-overview.html). This setup gives better results if we also couple the pressure gradient. The run scripts enable the respective comments in the `precice-config.xml`.
 
 ## Running the Simulation
 

--- a/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/clean.sh
+++ b/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/clean.sh
@@ -8,4 +8,5 @@ clean_openfoam .
 if [ -f ../precice-config.xml.orig ]; then
   echo "Restoring the precice-config.xml from precice-config.xml.orig"
   cp -r ../precice-config.xml.orig ../precice-config.xml
+  rm ../precice-config.xml.orig
 fi

--- a/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/clean.sh
+++ b/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/clean.sh
@@ -4,3 +4,8 @@ set -e -u
 . ../../tools/cleaning-tools.sh
 
 clean_openfoam .
+
+if [ -f ../precice-config.xml.orig ]; then
+  echo "Restoring the precice-config.xml from precice-config.xml.orig"
+  cp -r ../precice-config.xml.orig ../precice-config.xml
+fi

--- a/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/run.sh
+++ b/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/run.sh
@@ -6,9 +6,12 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 # The precice-config.xml has the PressureGradient field commented out.
 # That improves the results for the compressible case, so we un-comment it.
-cp -r ../precice-config.xml ../precice-config.xml.orig
-sed -i "s,\<!--,,g" ../precice-config.xml
-sed -i "s,\-->,,g" ../precice-config.xml
+if [ ! -f ../precice-config.xml.orig ]; then
+  echo "Modifying the ../precice-config.xml to enable PressureGradient (see precice-config.xml.orig for the original)"
+  cp -r ../precice-config.xml ../precice-config.xml.orig
+  sed -i "s,\<!--,,g" ../precice-config.xml
+  sed -i "s,\-->,,g" ../precice-config.xml
+fi
 
 blockMesh
 

--- a/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/run.sh
+++ b/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/run.sh
@@ -4,6 +4,12 @@ set -e -u
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 
+# The precice-config.xml has the PressureGradient field commented out.
+# That improves the results for the compressible case, so we un-comment it.
+cp -r ../precice-config.xml ../precice-config.xml.orig
+sed -i "s,\<!--,,g" ../precice-config.xml
+sed -i "s,\-->,,g" ../precice-config.xml
+
 blockMesh
 
 ../../tools/run-openfoam.sh "$@"

--- a/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/run.sh
+++ b/partitioned-pipe/fluid1-openfoam-sonicliquidfoam/run.sh
@@ -9,8 +9,8 @@ exec > >(tee --append "$LOGFILE") 2>&1
 if [ ! -f ../precice-config.xml.orig ]; then
   echo "Modifying the ../precice-config.xml to enable PressureGradient (see precice-config.xml.orig for the original)"
   cp -r ../precice-config.xml ../precice-config.xml.orig
-  sed -i "s,\<!--,,g" ../precice-config.xml
-  sed -i "s,\-->,,g" ../precice-config.xml
+  sed -i "s,<!--,,g" ../precice-config.xml
+  sed -i "s,-->,,g" ../precice-config.xml
 fi
 
 blockMesh

--- a/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/clean.sh
+++ b/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/clean.sh
@@ -8,4 +8,5 @@ clean_openfoam .
 if [ -f ../precice-config.xml.orig ]; then
   echo "Restoring the precice-config.xml from precice-config.xml.orig"
   cp -r ../precice-config.xml.orig ../precice-config.xml
+  rm ../precice-config.xml.orig
 fi

--- a/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/clean.sh
+++ b/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/clean.sh
@@ -4,3 +4,8 @@ set -e -u
 . ../../tools/cleaning-tools.sh
 
 clean_openfoam .
+
+if [ -f ../precice-config.xml.orig ]; then
+  echo "Restoring the precice-config.xml from precice-config.xml.orig"
+  cp -r ../precice-config.xml.orig ../precice-config.xml
+fi

--- a/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/run.sh
+++ b/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/run.sh
@@ -6,9 +6,12 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 # The precice-config.xml has the PressureGradient field commented out.
 # That improves the results for the compressible case, so we un-comment it.
-cp -r ../precice-config.xml ../precice-config.xml.orig
-sed -i "s,\<!--,,g" ../precice-config.xml
-sed -i "s,\-->,,g" ../precice-config.xml
+if [ ! -f ../precice-config.xml.orig ]; then
+  echo "Modifying the ../precice-config.xml to enable PressureGradient (see precice-config.xml.orig for the original)"
+  cp -r ../precice-config.xml ../precice-config.xml.orig
+  sed -i "s,\<!--,,g" ../precice-config.xml
+  sed -i "s,\-->,,g" ../precice-config.xml
+fi
 
 blockMesh
 

--- a/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/run.sh
+++ b/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/run.sh
@@ -4,6 +4,12 @@ set -e -u
 . ../../tools/log.sh
 exec > >(tee --append "$LOGFILE") 2>&1
 
+# The precice-config.xml has the PressureGradient field commented out.
+# That improves the results for the compressible case, so we un-comment it.
+cp -r ../precice-config.xml ../precice-config.xml.orig
+sed -i "s,\<!--,,g" ../precice-config.xml
+sed -i "s,\-->,,g" ../precice-config.xml
+
 blockMesh
 
 ../../tools/run-openfoam.sh "$@"

--- a/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/run.sh
+++ b/partitioned-pipe/fluid2-openfoam-sonicliquidfoam/run.sh
@@ -9,8 +9,8 @@ exec > >(tee --append "$LOGFILE") 2>&1
 if [ ! -f ../precice-config.xml.orig ]; then
   echo "Modifying the ../precice-config.xml to enable PressureGradient (see precice-config.xml.orig for the original)"
   cp -r ../precice-config.xml ../precice-config.xml.orig
-  sed -i "s,\<!--,,g" ../precice-config.xml
-  sed -i "s,\-->,,g" ../precice-config.xml
+  sed -i "s,<!--,,g" ../precice-config.xml
+  sed -i "s,-->,,g" ../precice-config.xml
 fi
 
 blockMesh


### PR DESCRIPTION
## Description

At the moment, the sonicliquidfoam cases in the partitioned-pipe tutorial require manually commenting-out the `PressureGradient` related tags in the `precice-config.xml`. This would also require a special case handling in the system tests.

This PR automates the process: each `run.sh` keeps a copy, and each `clean.sh` restores the original and deletes the copy.

## Checklist

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [x] I updated the documentation.
