### PR TITLE
Remove unused and conflictling export:vtu from geometric multiscale tutorials

### DIFF
--- a/partitioned-pipe-multiscale/precice-config-1d-1d.xml
+++ b/partitioned-pipe-multiscale/precice-config-1d-1d.xml
@@ -32,7 +32,6 @@
       from="Fluid1DLeft-Mesh"
       to="Fluid1DRight-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <participant name="Fluid1DLeft">
@@ -45,7 +44,6 @@
       from="Fluid1DRight-Mesh"
       to="Fluid1DLeft-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <m2n:sockets acceptor="Fluid1DRight" connector="Fluid1DLeft" exchange-directory=".." />

--- a/partitioned-pipe-multiscale/precice-config-1d-3d.xml
+++ b/partitioned-pipe-multiscale/precice-config-1d-3d.xml
@@ -37,7 +37,6 @@
       from="Fluid3DRight-Mesh"
       to="Fluid1DLeft-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <participant name="Fluid3DRight">
@@ -56,7 +55,6 @@
       from="Fluid1DLeft-Mesh"
       to="Fluid3DRight-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <m2n:sockets acceptor="Fluid1DLeft" connector="Fluid3DRight" exchange-directory=".." />

--- a/partitioned-pipe-multiscale/precice-config-3d-1d.xml
+++ b/partitioned-pipe-multiscale/precice-config-3d-1d.xml
@@ -37,7 +37,6 @@
       from="Fluid3DLeft-Mesh"
       to="Fluid1DRight-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <participant name="Fluid3DLeft">
@@ -56,7 +55,6 @@
       from="Fluid1DRight-Mesh"
       to="Fluid3DLeft-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <m2n:sockets acceptor="Fluid1DRight" connector="Fluid3DLeft" exchange-directory=".." />

--- a/partitioned-pipe-multiscale/precice-config-3d-3d.xml
+++ b/partitioned-pipe-multiscale/precice-config-3d-3d.xml
@@ -32,7 +32,6 @@
       from="Fluid3DLeft-Mesh"
       to="Fluid3DRight-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <participant name="Fluid3DLeft">
@@ -45,7 +44,6 @@
       from="Fluid3DRight-Mesh"
       to="Fluid3DLeft-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <m2n:sockets acceptor="Fluid3DRight" connector="Fluid3DLeft" exchange-directory=".." />

--- a/water-hammer/precice-config-1d-1d.xml
+++ b/water-hammer/precice-config-1d-1d.xml
@@ -32,7 +32,6 @@
       from="Fluid1DRight-Mesh"
       to="Fluid1DLeft-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <participant name="Fluid1DRight">
@@ -45,7 +44,6 @@
       from="Fluid1DLeft-Mesh"
       to="Fluid1DRight-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <m2n:sockets acceptor="Fluid1DLeft" connector="Fluid1DRight" exchange-directory=".." />

--- a/water-hammer/precice-config-1d-3d.xml
+++ b/water-hammer/precice-config-1d-3d.xml
@@ -38,7 +38,6 @@
       from="Fluid3DRight-Mesh"
       to="Fluid1DLeft-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <participant name="Fluid3DRight">
@@ -57,7 +56,6 @@
       from="Fluid1DLeft-Mesh"
       to="Fluid3DRight-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <m2n:sockets acceptor="Fluid1DLeft" connector="Fluid3DRight" exchange-directory=".." />

--- a/water-hammer/precice-config-3d-1d.xml
+++ b/water-hammer/precice-config-3d-1d.xml
@@ -38,7 +38,6 @@
       from="Fluid3DLeft-Mesh"
       to="Fluid1DRight-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <participant name="Fluid3DLeft">
@@ -57,7 +56,6 @@
       from="Fluid1DRight-Mesh"
       to="Fluid3DLeft-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <m2n:sockets acceptor="Fluid1DRight" connector="Fluid3DLeft" exchange-directory=".." />

--- a/water-hammer/precice-config-3d-3d.xml
+++ b/water-hammer/precice-config-3d-3d.xml
@@ -32,7 +32,6 @@
       from="Fluid3DLeft-Mesh"
       to="Fluid3DRight-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <participant name="Fluid3DLeft">
@@ -45,7 +44,6 @@
       from="Fluid3DRight-Mesh"
       to="Fluid3DLeft-Mesh"
       constraint="consistent" />
-    <export:vtu directory="precice-exports" />
   </participant>
 
   <m2n:sockets acceptor="Fluid3DRight" connector="Fluid3DLeft" exchange-directory=".." />


### PR DESCRIPTION
## Description

The system tests manually add an `<export:vtu directory="../precice-exports/" />` tag.

The `partitioned-pipe-multiscale` tutorial, now in the system tests since https://github.com/precice/tutorials/pull/807, seems to fail to generate reference results. The conflicting tags could be a reason, and they are anyway unused. -> False alarm, a simple typo in a filename was the reason.

Note that there are other tutorials that pre-define (and use) exporters for one of their participants:

- `quickstart`
- `flow-over-heated-plate`
- `flow-over-heated-plate-nearest-projection`

But we don't really need to check the same data on both participants - we typically do so mainly because of convenience in the testing infrastructure.

This PR removes the unused `<export:vtu directory="precice-exports" />` tags from the `partitioned-pipe-multiscale` and `water-wammer` tutorials.

These tutorials have not yet been released, so no changelog entry is needed.