### PR TITLE
Add extra and perpendicular-flap_fluid-nutils_solid-calculix test suites

### DIFF
--- a/.github/workflows/generate_reference_results_manual.yml
+++ b/.github/workflows/generate_reference_results_manual.yml
@@ -8,7 +8,7 @@ on:
         type: string
       commit_msg:
         description: 'Commit msg for commit that adds the reference results'
-        default: "Adding reference results"
+        default: "Add reference results"
         type: string
       suites:
         description: 'Comma-separated test suites to generate reference results for (leave empty for all)'

--- a/.github/workflows/generate_reference_results_workflow.yml
+++ b/.github/workflows/generate_reference_results_workflow.yml
@@ -8,7 +8,7 @@ on:
         type: string
       commit_msg:
         description: 'Commit msg for commit that adds the reference results'
-        default: "Adding reference results"
+        default: "Add reference results"
         type: string
       suites:
         description: 'Comma-separated test suites to generate reference results for. If empty, all suites are generated.'

--- a/perpendicular-flap/reference-results/fluid-nutils_solid-calculix.tar.gz
+++ b/perpendicular-flap/reference-results/fluid-nutils_solid-calculix.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19316047524c56e1675cae8e80014bc6f845f074ce8b225b880fa7a7e140e567
+size 103799

--- a/perpendicular-flap/reference-results/reference_results.metadata
+++ b/perpendicular-flap/reference-results/reference_results.metadata
@@ -11,11 +11,7 @@ We also include some information on the machine used to generate them
 
 | name | time | sha256 |
 |------|------|-------|
-| fluid-openfoam_solid-fenics.tar.gz | 2026-05-28 11:46:06 | 002d647077d0f4558bdf692c858a12d8078bf460dbb336bdba22389f8f54eac9 |
-| fluid-openfoam_solid-openfoam.tar.gz | 2026-05-28 11:46:06 | 347c9e1a521146c2855f17798edd9ca2aa1ed8e24b2f1412655c8260d860a96a |
-| fluid-su2_solid-fenics.tar.gz | 2026-05-28 11:46:06 | 6f77d1458d64b243af525c09d62cfa7da217d6ea5d0924a769c73ef50e500757 |
-| fluid-openfoam_solid-calculix.tar.gz | 2026-05-28 11:46:06 | 1d8b37c6aa705766f5a9013381a044cc825b807bfcfc06b26adaea88c4de8afb |
-| fluid-openfoam_solid-dealii.tar.gz | 2026-05-28 11:46:06 | 562d713526dcd4d2daaa10b92fc09d01fcae88017d0d50b7dd78394c661410f9 |
+| fluid-nutils_solid-calculix.tar.gz | 2026-05-29 11:36:41 | 19316047524c56e1675cae8e80014bc6f845f074ce8b225b880fa7a7e140e567 |
 
 ## List of arguments used to generate the files
 
@@ -36,7 +32,7 @@ We also include some information on the machine used to generate them
 | PRECICE_REF | v3.4.1 |
 | PYTHON_BINDINGS_REF | v3.4.0 |
 | SU2_ADAPTER_REF | 5abe79b |
-| TUTORIALS_REF | 9cb7068 |
+| TUTORIALS_REF | 0fc4468 |
 | PRECICE_PRESET | production-audit |
 | PRECICE_UID | 1003 |
 | PRECICE_GID | 1003 |

--- a/tools/tests/reference_versions.yaml
+++ b/tools/tests/reference_versions.yaml
@@ -21,7 +21,7 @@ OPENFOAM_ADAPTER_REF: "2c3062c" # develop, May 27, 2026
 PRECICE_REF: "v3.4.1"
 PYTHON_BINDINGS_REF: "v3.4.0"
 SU2_ADAPTER_REF: "5abe79b"      # develop, May 27, 2026
-TUTORIALS_REF: "8a9593b"        # develop, May 29, 2026
+TUTORIALS_REF: "0fc4468"        # develop, May 29, 2026
 
 # Additional settings
 PRECICE_PRESET: "production-audit"

--- a/tools/tests/reference_versions.yaml
+++ b/tools/tests/reference_versions.yaml
@@ -21,7 +21,7 @@ OPENFOAM_ADAPTER_REF: "2c3062c" # develop, May 27, 2026
 PRECICE_REF: "v3.4.1"
 PYTHON_BINDINGS_REF: "v3.4.0"
 SU2_ADAPTER_REF: "5abe79b"      # develop, May 27, 2026
-TUTORIALS_REF: "49a49bd"        # develop, May 29, 2026
+TUTORIALS_REF: "8a9593b"        # develop, May 29, 2026
 
 # Additional settings
 PRECICE_PRESET: "production-audit"

--- a/tools/tests/reference_versions.yaml
+++ b/tools/tests/reference_versions.yaml
@@ -21,7 +21,7 @@ OPENFOAM_ADAPTER_REF: "2c3062c" # develop, May 27, 2026
 PRECICE_REF: "v3.4.1"
 PYTHON_BINDINGS_REF: "v3.4.0"
 SU2_ADAPTER_REF: "5abe79b"      # develop, May 27, 2026
-TUTORIALS_REF: "bf5323c"        # develop, May 28, 2026
+TUTORIALS_REF: "49a49bd"        # develop, May 29, 2026
 
 # Additional settings
 PRECICE_PRESET: "production-audit"

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -282,6 +282,7 @@ test_suites:
           - fluid-nutils
           - solid-calculix
         max_time: 0.1
+        timeout: 1200
         reference_result: ./perpendicular-flap/reference-results/fluid-nutils_solid-calculix.tar.gz
 
   two-scale-heat-conduction:

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -276,6 +276,13 @@ test_suites:
           - solid-fenics
         max_time: 0.1
         reference_result: ./perpendicular-flap/reference-results/fluid-su2_solid-fenics.tar.gz
+      - &perpendicular-flap_fluid-nutils_solid-calculix
+        path: perpendicular-flap
+        case_combination:
+          - fluid-nutils
+          - solid-calculix
+        max_time: 0.1
+        reference_result: ./perpendicular-flap/reference-results/fluid-nutils_solid-calculix.tar.gz
 
   two-scale-heat-conduction:
     tutorials:
@@ -301,7 +308,6 @@ test_suites:
   release_test:
     tutorials:
       - *channel-transport_fluid-openfoam_transport-nutils
-      - *channel-transport_fluid-nutils_transport-nutils
       - *channel-transport-reaction_fluid-fenics_chemical-fenics
       - *elastic-tube-1d_fluid-cpp_solid-cpp
       - *elastic-tube-1d_fluid-cpp_solid-python
@@ -319,7 +325,6 @@ test_suites:
       - *multiple-perpendicular-flaps_fluid-openfoam_solid-upstream-dealii_solid-downstream-dealii
       - *partitioned-elastic-beam_dirichlet-calculix_neumann-calculix
       - *partitioned-heat-conduction_dirichlet-fenics_neumann-fenics
-      - *partitioned-heat-conduction_dirichlet-nutils_neumann-nutils
       - *partitioned-heat-conduction_dirichlet-openfoam_neumann-openfoam
       - *partitioned-heat-conduction-complex_dirichlet-fenics_neumann-fenics
       - *partitioned-pipe_fluid1-openfoam-pimplefoam_fluid2-openfoam-pimplefoam
@@ -333,6 +338,13 @@ test_suites:
       - *perpendicular-flap_fluid-su2_solid-fenics
       # *two-scale-heat-conduction_macro-dumux_micro-dumux # excluded - too small values to compare
       - *quickstart_openfoam_cpp
+
+  # These test suites take longer to run. They are available, but not regularly executed.
+  extra:
+    tutorials:
+      - *channel-transport_fluid-nutils_transport-nutils
+      - *partitioned-heat-conduction_dirichlet-nutils_neumann-nutils
+      - *perpendicular-flap_fluid-nutils_solid-calculix
 
   calculix-adapter:
     tutorials:

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -342,8 +342,8 @@ test_suites:
   # These test suites take longer to run. They are available, but not regularly executed.
   extra:
     tutorials:
-      - *channel-transport_fluid-nutils_transport-nutils
-      - *partitioned-heat-conduction_dirichlet-nutils_neumann-nutils
+      # - *channel-transport_fluid-nutils_transport-nutils
+      # - *partitioned-heat-conduction_dirichlet-nutils_neumann-nutils
       - *perpendicular-flap_fluid-nutils_solid-calculix
 
   calculix-adapter:
@@ -386,6 +386,7 @@ test_suites:
       - *flow-over-heated-plate_fluid-openfoam_solid-nutils
       - *partitioned-heat-conduction_dirichlet-nutils_neumann-nutils
       - *partitioned-pipe-multiscale_fluid1d-left-nutils_fluid3d-right-openfoam
+      - *perpendicular-flap_fluid-nutils_solid-calculix
 
   openfoam-adapter:
     tutorials:


### PR DESCRIPTION
## Description

Some tests take longer to run, without covering much more than the specific tutorial setups/codes. I think it would be useful to have a test suite that can on-demand run these additional tests.

This PR:

- Adds the `perpendicular-flap_fluid-nutils_solid-calculix test suite` as an option
- Adds the `extra` test suite, with:
   - `channel-transport_fluid-nutils_transport-nutils` (and removes it from `release_test`)
   - `partitioned-heat-conduction_dirichlet-nutils_neumann-nutils` (and removes it from `release_test`)
   - `perpendicular-flap_fluid-nutils_solid-calculix`

I am adding reference results in this branch.