### PR TITLE
Prune Docker networks before and after running each system test

### DIFF
--- a/.github/workflows/generate_reference_results_workflow.yml
+++ b/.github/workflows/generate_reference_results_workflow.yml
@@ -104,6 +104,3 @@ jobs:
           runs/*/system-tests-stdout.log
           runs/*/system-tests-stderr.log
           runs/*/*/system-tests_*.log
-    - name: tidy up the docker
-      run: |
-        docker network prune -f

--- a/.github/workflows/run_testsuite_workflow.yml
+++ b/.github/workflows/run_testsuite_workflow.yml
@@ -93,6 +93,3 @@ jobs:
           runs/*/system-tests-stdout.log
           runs/*/system-tests-stderr.log
           runs/*/*/system-tests_*.log
-    - name: tidy up the docker
-      run: |
-        docker network prune -f

--- a/changelog-entries/820.md
+++ b/changelog-entries/820.md
@@ -1,0 +1,1 @@
+- The system tests now call `docker network prune` on the host before and after executing a test [#820](https://github.com/precice/tutorials/pull/820)

--- a/tools/tests/systemtests/Systemtest.py
+++ b/tools/tests/systemtests/Systemtest.py
@@ -399,6 +399,35 @@ class Systemtest:
             logging.error(error_message)
             return False, error_message
 
+    def _cleanup_docker_networks(self):
+        """
+        Prunes the unused Docker networks, since there is an upper limit on the number of custom networks defined.
+        """
+        logging.debug(f"Deleting unused Docker networks...")
+        stdout_data = []
+        stderr_data = []
+        try:
+            # Execute docker-network-prune command
+            process = subprocess.Popen(['docker',
+                                        'network',
+                                        'prune',
+                                        '-f'],
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE,
+                                       start_new_session=True,
+                                       cwd=self.system_test_dir)
+            try:
+                stdout, stderr = process.communicate(timeout=self.timeout)
+            except KeyboardInterrupt as k:
+                process.kill()
+                raise KeyboardInterrupt from k
+        except Exception as e:
+            logging.critical(
+                f"Systemtest {self} could not prune the Docker networks. This might prevent tests from starting.")
+            stdout_data.extend(stdout.decode().splitlines())
+            stderr_data.extend(stderr.decode().splitlines())
+            process.poll()
+
     def _run_field_compare(self):
         """
         Executes the field comparison step after unpacking reference results.
@@ -635,6 +664,7 @@ class Systemtest:
         std_out: List[str] = []
         std_err: List[str] = []
 
+        self._cleanup_docker_networks()
         docker_build_result = self._build_docker()
         std_out.extend(docker_build_result.stdout_data)
         std_err.extend(docker_build_result.stderr_data)

--- a/tools/tests/systemtests/Systemtest.py
+++ b/tools/tests/systemtests/Systemtest.py
@@ -712,6 +712,7 @@ class Systemtest:
                 fieldcompare_time=fieldcompare_result.runtime)
 
         # self.__cleanup()
+        self._cleanup_docker_networks()
         self.__write_logs(std_out, std_err)
         return SystemtestResult(
             True,


### PR DESCRIPTION
## Description

Trying to run several tests (each one asking Docker Compose to create a custom network), we now hit a limit on how many custom networks one can create on a given system (see [this failing system tests job](https://github.com/precice/tutorials/actions/runs/26639827375)). While we were already calling `docker network prune` in the CI workflows, we now hit the limit within one run.

This could be seen in the `system-tests-stderr.log` as:

```
failed to create network partitioned-heat-conduction_dirichlet-fenics-neumann-fenics_2026-05-29-165802_default: Error response from daemon: all predefined address pools have been fully subnetted
```

This PR implements a new function in the `Systemtest.py` to prune networks before (from previous runs) and after (from this run) running the tests.

## Checklist

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.