### PR TITLE
Do not try to create the venv if it already exists

### DIFF
--- a/channel-transport-particles/fluid-nutils/run.sh
+++ b/channel-transport-particles/fluid-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/channel-transport-reaction/chemical-fenics/run.sh
+++ b/channel-transport-reaction/chemical-fenics/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-package .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/channel-transport-reaction/fluid-fenics/run.sh
+++ b/channel-transport-reaction/fluid-fenics/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-package .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/channel-transport/fluid-nutils/run.sh
+++ b/channel-transport/fluid-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/channel-transport/transport-nutils/run.sh
+++ b/channel-transport/transport-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/elastic-tube-1d/fluid-python/run.sh
+++ b/elastic-tube-1d/fluid-python/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/elastic-tube-1d/solid-python/run.sh
+++ b/elastic-tube-1d/solid-python/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/elastic-tube-3d/solid-fenics/run.sh
+++ b/elastic-tube-3d/solid-fenics/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-package .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/flow-around-controlled-moving-cylinder/controller-fmi/run.sh
+++ b/flow-around-controlled-moving-cylinder/controller-fmi/run.sh
@@ -17,7 +17,9 @@ fi
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/flow-around-controlled-moving-cylinder/solid-python/run.sh
+++ b/flow-around-controlled-moving-cylinder/solid-python/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/flow-over-heated-plate/fluid-su2/run.sh
+++ b/flow-over-heated-plate/fluid-su2/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-package .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/flow-over-heated-plate/solid-dunefem/run.sh
+++ b/flow-over-heated-plate/solid-dunefem/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/flow-over-heated-plate/solid-fenics/run.sh
+++ b/flow-over-heated-plate/solid-fenics/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-package .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/flow-over-heated-plate/solid-fenicsx/run.sh
+++ b/flow-over-heated-plate/solid-fenicsx/run.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -e -u
 
-python3 -m venv --system-site-packages .venv
+if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
 . .venv/bin/activate
 pip install -r requirements.txt
 

--- a/flow-over-heated-plate/solid-nutils/run.sh
+++ b/flow-over-heated-plate/solid-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/oscillator-overlap/mass-left-python/run.sh
+++ b/oscillator-overlap/mass-left-python/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r ../solver-python/requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/oscillator-overlap/mass-right-python/run.sh
+++ b/oscillator-overlap/mass-right-python/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r ../solver-python/requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/oscillator/mass-left-fmi/run.sh
+++ b/oscillator/mass-left-fmi/run.sh
@@ -20,7 +20,9 @@ fi
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/oscillator/mass-left-python/run.sh
+++ b/oscillator/mass-left-python/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r ../solver-python/requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/oscillator/mass-right-fmi/run.sh
+++ b/oscillator/mass-right-fmi/run.sh
@@ -20,7 +20,9 @@ fi
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/oscillator/mass-right-python/run.sh
+++ b/oscillator/mass-right-python/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r ../solver-python/requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/partitioned-heat-conduction-complex/dirichlet-fenics/run.sh
+++ b/partitioned-heat-conduction-complex/dirichlet-fenics/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-packages .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r ../solver-fenics/requirements.txt
 fi

--- a/partitioned-heat-conduction-complex/neumann-fenics/run.sh
+++ b/partitioned-heat-conduction-complex/neumann-fenics/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-packages .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r ../solver-fenics/requirements.txt
 fi

--- a/partitioned-heat-conduction-direct/dirichlet-nutils/run.sh
+++ b/partitioned-heat-conduction-direct/dirichlet-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/partitioned-heat-conduction-direct/neumann-nutils/run.sh
+++ b/partitioned-heat-conduction-direct/neumann-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/partitioned-heat-conduction-overlap/left-fenics/run.sh
+++ b/partitioned-heat-conduction-overlap/left-fenics/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-packages .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r ../solver-fenics/requirements.txt
 fi

--- a/partitioned-heat-conduction-overlap/right-fenics/run.sh
+++ b/partitioned-heat-conduction-overlap/right-fenics/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-packages .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r ../solver-fenics/requirements.txt
 fi

--- a/partitioned-heat-conduction/dirichlet-fenics/run.sh
+++ b/partitioned-heat-conduction/dirichlet-fenics/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-packages .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r ../solver-fenics/requirements.txt
 fi

--- a/partitioned-heat-conduction/dirichlet-fenicsx/run.sh
+++ b/partitioned-heat-conduction/dirichlet-fenicsx/run.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -e -u
 
-python3 -m venv --system-site-packages .venv
+if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
 . .venv/bin/activate
 pip install -r ../solver-fenicsx/requirements.txt
 

--- a/partitioned-heat-conduction/dirichlet-nutils/run.sh
+++ b/partitioned-heat-conduction/dirichlet-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/partitioned-heat-conduction/neumann-fenics/run.sh
+++ b/partitioned-heat-conduction/neumann-fenics/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-packages .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r ../solver-fenics/requirements.txt
 fi

--- a/partitioned-heat-conduction/neumann-fenicsx/run.sh
+++ b/partitioned-heat-conduction/neumann-fenicsx/run.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -e -u
 
-python3 -m venv --system-site-packages .venv
+if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
 . .venv/bin/activate
 pip install -r ../solver-fenicsx/requirements.txt
 python3 ../solver-fenicsx/heat.py Neumann

--- a/partitioned-heat-conduction/neumann-nutils/run.sh
+++ b/partitioned-heat-conduction/neumann-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/partitioned-pipe-multiscale/fluid1d-left-nutils/run.sh
+++ b/partitioned-pipe-multiscale/fluid1d-left-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/partitioned-pipe-multiscale/fluid1d-right-nutils/run.sh
+++ b/partitioned-pipe-multiscale/fluid1d-right-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/perpendicular-flap/fluid-fake/run.sh
+++ b/perpendicular-flap/fluid-fake/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/perpendicular-flap/fluid-nutils/run.sh
+++ b/perpendicular-flap/fluid-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/perpendicular-flap/fluid-su2/run.sh
+++ b/perpendicular-flap/fluid-su2/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-packages .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/perpendicular-flap/solid-fake/run.sh
+++ b/perpendicular-flap/solid-fake/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/perpendicular-flap/solid-fenics/run.sh
+++ b/perpendicular-flap/solid-fenics/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-packages .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/perpendicular-flap/solid-nutils/run.sh
+++ b/perpendicular-flap/solid-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/resonant-circuit/capacitor-python/run.sh
+++ b/resonant-circuit/capacitor-python/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/resonant-circuit/coil-python/run.sh
+++ b/resonant-circuit/coil-python/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/tools/visualize-configs.sh
+++ b/tools/visualize-configs.sh
@@ -30,7 +30,9 @@ visualize_config(){
 
 export -f visualize_config
 
-python3 -m venv .venv
+if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
 . .venv/bin/activate
 pip install precice-config-visualizer
 

--- a/turek-hron-fsi3/fluid-nutils/run.sh
+++ b/turek-hron-fsi3/fluid-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/turek-hron-fsi3/solid-nutils/run.sh
+++ b/turek-hron-fsi3/solid-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/two-scale-heat-conduction/macro-nutils/run.sh
+++ b/two-scale-heat-conduction/macro-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/two-scale-heat-conduction/micro-nutils/run.sh
+++ b/two-scale-heat-conduction/micro-nutils/run.sh
@@ -8,7 +8,9 @@ usage() { echo "Usage: cmd [-s] [-p n]" 1>&2; exit 1; }
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/volume-coupled-diffusion/drain-fenics/run.sh
+++ b/volume-coupled-diffusion/drain-fenics/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-packages .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r ../solver-fenics/requirements.txt
 fi

--- a/volume-coupled-diffusion/source-fenics/run.sh
+++ b/volume-coupled-diffusion/source-fenics/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv --system-site-packages .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv --system-site-packages .venv
+    fi
     . .venv/bin/activate
     pip install -r ../solver-fenics/requirements.txt
 fi

--- a/volume-coupled-flow/source-nutils/run.sh
+++ b/volume-coupled-flow/source-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/water-hammer/fluid1d-left-nutils/run.sh
+++ b/water-hammer/fluid1d-left-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi

--- a/water-hammer/fluid1d-right-nutils/run.sh
+++ b/water-hammer/fluid1d-right-nutils/run.sh
@@ -6,7 +6,9 @@ exec > >(tee --append "$LOGFILE") 2>&1
 
 if [ ! -v PRECICE_TUTORIALS_NO_VENV ]
 then
-    python3 -m venv .venv
+    if [ ! -d .venv ]; then
+        python3 -m venv .venv
+    fi
     . .venv/bin/activate
     pip install -r requirements.txt && pip freeze > pip-installed-packages.log
 fi


### PR DESCRIPTION
Follow-up of https://github.com/precice/tutorials/pull/680

Resolves the following error:

```
Error: [Errno 13] Permission denied: '/path/to/venv/bin/activate'
```

when running any of our Python tutorials a second time.

It also fixes a few `--system-site-package` to `--system-site-packages`.