### PR TITLE
Add a basic precice test suite (and rename release_test)

### DIFF
--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       suites:
         description: 'Test suites to execute (comma-separated)'
-        default: 'release_test'
+        default: 'release'
         required: true
         type: string
       system_tests_branch:

--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -150,7 +150,7 @@ jobs:
     needs: gather-refs
     uses: precice/tutorials/.github/workflows/run_testsuite_workflow.yml@develop
     with:
-      suites: release_test
+      suites: release
       build_args: "PLATFORM:ubuntu_2404,\
         PRECICE_REF:${{ needs.gather-refs.outputs.ref-precice }},\
         PYTHON_BINDINGS_REF:${{ needs.gather-refs.outputs.ref-python-bindings }},\

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -25,7 +25,7 @@ Workflow for the preCICE v3 release testing:
 3. Trigger the GitHub Actions Workflow. Until we merge the workflow to develop, this can only happen via the [GitHub CLI](https://cli.github.com/):
 
     ```bash
-    gh workflow run run_testsuite_manual.yml -f suites=release_test -f build_args="PRECICE_REF:v3.1.1,PRECICE_PRESET:production-audit,OPENFOAM_ADAPTER_REF:v1.3.0,PYTHON_BINDINGS_REF:v3.1.0,FENICS_ADAPTER_REF:v2.1.0,SU2_VERSION:7.5.1,SU2_ADAPTER_REF:64d4aff,DEALII_ADAPTER_REF:02c5d18,TUTORIALS_REF:340b447" --ref=develop
+    gh workflow run run_testsuite_manual.yml -f suites=release -f build_args="PRECICE_REF:v3.1.1,PRECICE_PRESET:production-audit,OPENFOAM_ADAPTER_REF:v1.3.0,PYTHON_BINDINGS_REF:v3.1.0,FENICS_ADAPTER_REF:v2.1.0,SU2_VERSION:7.5.1,SU2_ADAPTER_REF:64d4aff,DEALII_ADAPTER_REF:02c5d18,TUTORIALS_REF:340b447" --ref=develop
     ```
 
 4. Go to the tutorials [Actions](https://github.com/precice/tutorials/actions) page and find the running workflow

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -1,6 +1,6 @@
 # Test suites that can be triggered by the system tests.
 # Define test suites per tutorial in the beginning of the file,
-# then refer to these in the release_test and in the individual test
+# then refer to these in the release test suite and in the individual test
 # suites for repositories, at the lower part of the file.
 #
 # Conventions:
@@ -500,7 +500,7 @@ test_suites:
 #####################################################################
 ## Test suites referring to the test suites defined above
 
-  release_test:
+  release:
     tutorials:
       - *breaking-dam-2d_fluid-openfoam_solid-calculix
       - *channel-transport_fluid-openfoam_transport-nutils

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -573,6 +573,8 @@ test_suites:
       - *flow-over-heated-plate-nearest-projection_fluid-openfoam_solid-openfoam # serial-implicit (IQN-ILS), nearest-projection
       - *elastic-tube-1d_fluid-cpp_solid-cpp                                     # serial-implicit (IQN-ILS), nearest-neighbor
       - *partitioned-pipe-multiscale_fluid1d-left-nutils_fluid3d-right-openfoam  # parallel-implicit (IQN-ILS), axial-geometric-multiscale
+      - *elastic-tube-1d_fluid-fortran-module_solid-fortran-module               # integration with Fortran (module)
+      - *perpendicular-flap_fluid-openfoam_solid-calculix                        # integration with C
       
   calculix-adapter:
     tutorials:

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -551,7 +551,7 @@ test_suites:
       - *water-hammer_fluid1d-left-nutils_fluid3d-right-openfoam
       - *wolf-sheep-soil-creep_soil-creep-landlab_wolf-sheep-grass-mesa
 
-  # These test suites take longer to run. They are available, but not regularly executed.
+  # These tests take longer to run. They are available, but not regularly executed.
   extra:
     tutorials:
       - *channel-transport_fluid-nutils_transport-nutils
@@ -564,6 +564,16 @@ test_suites:
       - *elastic-tube-3d_fluid-openfoam_solid-fenics # too small values to compare
       - *two-scale-heat-conduction_macro-dumux_micro-dumux # too small values to compare
 
+  # A selection of tests that cover a wide range of main features, meant for quicker CI executions
+  precice:
+    tutorials:
+      - *quickstart_openfoam_cpp                                                 # serial-explicit, RBF
+      - *channel-transport_fluid-openfoam_transport-nutils                       # parallel-explicit, RBF, python bindings
+      - *flow-over-heated-plate_fluid-openfoam_solid-openfoam                    # serial-implicit (Aitken), nearest-neighbor
+      - *flow-over-heated-plate-nearest-projection_fluid-openfoam_solid-openfoam # serial-implicit (IQN-ILS), nearest-projection
+      - *elastic-tube-1d_fluid-cpp_solid-cpp                                     # serial-implicit (IQN-ILS), nearest-neighbor
+      - *partitioned-pipe-multiscale_fluid1d-left-nutils_fluid3d-right-openfoam  # parallel-implicit (IQN-ILS), axial-geometric-multiscale
+      
   calculix-adapter:
     tutorials:
       - *breaking-dam-2d_fluid-openfoam_solid-calculix


### PR DESCRIPTION
## Description

This PR adds a basic `precice` test suite, meant to run always on PRs in the preCICE repository. I selected cases that are rather short and cover a range of features:

```yaml
  precice:
    tutorials:
      - *quickstart_openfoam_cpp                                                 # serial-explicit, RBF
      - *channel-transport_fluid-openfoam_transport-nutils                       # parallel-explicit, RBF, python bindings
      - *flow-over-heated-plate_fluid-openfoam_solid-openfoam                    # serial-implicit (Aitken), nearest-neighbor
      - *flow-over-heated-plate-nearest-projection_fluid-openfoam_solid-openfoam # serial-implicit (IQN-ILS), nearest-projection
      - *elastic-tube-1d_fluid-cpp_solid-cpp                                     # serial-implicit (IQN-ILS), nearest-neighbor
      - *partitioned-pipe-multiscale_fluid1d-left-nutils_fluid3d-right-openfoam  # parallel-implicit (IQN-ILS), axial-geometric-multiscale
```

Example run: https://github.com/precice/tutorials/actions/runs/26751220367

With cached components, this test suite takes < 5min to run.

## Checklist

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.