### PR TITLE
Append failed system test log tails to GHA job summary

### DIFF
--- a/changelog-entries/830.md
+++ b/changelog-entries/830.md
@@ -1,0 +1,1 @@
+- Failed system tests now append the last lines of the relevant stage log to the GitHub Actions job summary [#830](https://github.com/precice/tutorials/pull/830).

--- a/tools/tests/systemtests/Systemtest.py
+++ b/tools/tests/systemtests/Systemtest.py
@@ -14,6 +14,7 @@ from datetime import datetime
 import tarfile
 import time
 
+import html
 import unicodedata
 import re
 import logging
@@ -145,9 +146,14 @@ def _append_failure_log_tails_to_summary(results: List[SystemtestResult]) -> Non
                 print("<details>", file=summary_file)
                 print(f"<summary>{log_name} tail</summary>", file=summary_file)
                 print("", file=summary_file)
-                print("```text", file=summary_file)
-                print(tail, file=summary_file)
-                print("```", file=summary_file)
+                print(
+                    '<div style="max-height: 24em; overflow-y: auto; '
+                    'border: 1px solid #d0d7de; padding: 8px; '
+                    'font-family: monospace; font-size: 12px; white-space: pre-wrap;">',
+                    file=summary_file,
+                )
+                print(html.escape(tail), file=summary_file)
+                print("</div>", file=summary_file)
                 print("</details>", file=summary_file)
                 print("", file=summary_file)
 

--- a/tools/tests/systemtests/Systemtest.py
+++ b/tools/tests/systemtests/Systemtest.py
@@ -31,7 +31,7 @@ STAGE_LOG_FILES = {
     "compare": "system-tests-compare.log",
 }
 
-FAILURE_LOG_TAIL_LINES = 40
+FAILURE_LOG_TAIL_LINES = 100
 
 
 class _SystemtestLogSink:
@@ -121,6 +121,15 @@ def _failing_stage_for_result(result: SystemtestResult) -> str:
     return "build"
 
 
+def _stages_that_ran(result: SystemtestResult) -> List[str]:
+    stages = ["build"]
+    if result.solver_time > 0:
+        stages.append("run")
+    if result.fieldcompare_time > 0:
+        stages.append("compare")
+    return stages
+
+
 def _read_log_tail(log_path: Path, max_lines: int = FAILURE_LOG_TAIL_LINES) -> str:
     if not log_path.is_file():
         return f"(log file not found: {log_path.name})"
@@ -142,18 +151,26 @@ def _append_failure_log_tails_to_summary(results: List[SystemtestResult]) -> Non
     with open(summary_path, "a", encoding="utf-8") as summary_file:
         print("\n## Failed test logs (last lines)\n", file=summary_file)
         for result in failed_results:
-            stage = _failing_stage_for_result(result)
-            log_name = STAGE_LOG_FILES[stage]
-            log_path = result.systemtest.get_system_test_dir() / log_name
-            tail = _read_log_tail(log_path)
+            failing_stage = _failing_stage_for_result(result)
             print(
-                f"### {_success_status_symbol(False)} {result.systemtest} — "
-                f"{stage} log (last {FAILURE_LOG_TAIL_LINES} lines)\n",
+                f"### {_success_status_symbol(False)} {result.systemtest}\n",
                 file=summary_file,
             )
-            print("```text", file=summary_file)
-            print(tail, file=summary_file)
-            print("```\n", file=summary_file)
+            for stage in _stages_that_ran(result):
+                log_path = result.systemtest.get_system_test_dir() / STAGE_LOG_FILES[stage]
+                tail = _read_log_tail(log_path)
+                failure_label = " — failure stage" if stage == failing_stage else ""
+                summary_label = (
+                    f"{stage} log (last {FAILURE_LOG_TAIL_LINES} lines){failure_label}"
+                )
+                print("<details>", file=summary_file)
+                print(f"<summary>{summary_label}</summary>", file=summary_file)
+                print("", file=summary_file)
+                print("```text", file=summary_file)
+                print(tail, file=summary_file)
+                print("```", file=summary_file)
+                print("</details>", file=summary_file)
+                print("", file=summary_file)
 
 
 def display_systemtestresults_as_table(results: List[SystemtestResult]):
@@ -200,12 +217,10 @@ def display_systemtestresults_as_table(results: List[SystemtestResult]):
     _append_failure_log_tails_to_summary(results)
 
     if "GITHUB_STEP_SUMMARY" in os.environ:
-        with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as f:
-            print("\n", file=f)
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+            print("\n\n", file=f)
             print(
-                "For full logs, download the archive from the bottom of this page "
-                "(`system-tests-build.log`, `system-tests-run.log`, `system-tests-compare.log`). "
-                "The stage runtimes in the table above might already give useful hints.",
+                "In case a test fails, download the archive from the bottom of this page and inspect the per-stage logs (`system-tests-build.log`, `system-tests-run.log`, `system-tests-compare.log`). The stage runtimes might already give useful hints.",
                 file=f)
             print(
                 "See the [documentation](https://precice.org/dev-docs-system-tests.html#understanding-what-went-wrong).",

--- a/tools/tests/systemtests/Systemtest.py
+++ b/tools/tests/systemtests/Systemtest.py
@@ -113,26 +113,7 @@ def _success_status_symbol(success: bool) -> str:
     return "✅" if success else "❌"
 
 
-def _failing_stage_for_result(result: SystemtestResult) -> str:
-    if result.fieldcompare_time > 0:
-        return "compare"
-    if result.solver_time > 0:
-        return "run"
-    return "build"
-
-
-def _stages_that_ran(result: SystemtestResult) -> List[str]:
-    stages = ["build"]
-    if result.solver_time > 0:
-        stages.append("run")
-    if result.fieldcompare_time > 0:
-        stages.append("compare")
-    return stages
-
-
 def _read_log_tail(log_path: Path, max_lines: int = FAILURE_LOG_TAIL_LINES) -> str:
-    if not log_path.is_file():
-        return f"(log file not found: {log_path.name})"
     lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
     if not lines:
         return "(log file is empty)"
@@ -149,22 +130,20 @@ def _append_failure_log_tails_to_summary(results: List[SystemtestResult]) -> Non
         return
 
     with open(summary_path, "a", encoding="utf-8") as summary_file:
-        print("\n## Failed test logs (last lines)\n", file=summary_file)
+        print("\n## Failed test logs\n", file=summary_file)
         for result in failed_results:
-            failing_stage = _failing_stage_for_result(result)
             print(
                 f"### {_success_status_symbol(False)} {result.systemtest}\n",
                 file=summary_file,
             )
-            for stage in _stages_that_ran(result):
-                log_path = result.systemtest.get_system_test_dir() / STAGE_LOG_FILES[stage]
+            run_dir = result.systemtest.get_system_test_dir()
+            for log_name in STAGE_LOG_FILES.values():
+                log_path = run_dir / log_name
+                if not log_path.is_file():
+                    continue
                 tail = _read_log_tail(log_path)
-                failure_label = " — failure stage" if stage == failing_stage else ""
-                summary_label = (
-                    f"{stage} log (last {FAILURE_LOG_TAIL_LINES} lines){failure_label}"
-                )
                 print("<details>", file=summary_file)
-                print(f"<summary>{summary_label}</summary>", file=summary_file)
+                print(f"<summary>{log_name} tail</summary>", file=summary_file)
                 print("", file=summary_file)
                 print("```text", file=summary_file)
                 print(tail, file=summary_file)

--- a/tools/tests/systemtests/Systemtest.py
+++ b/tools/tests/systemtests/Systemtest.py
@@ -31,6 +31,8 @@ STAGE_LOG_FILES = {
     "compare": "system-tests-compare.log",
 }
 
+FAILURE_LOG_TAIL_LINES = 40
+
 
 class _SystemtestLogSink:
     """Writes subprocess output incrementally to per-stage log files."""
@@ -111,6 +113,49 @@ def _success_status_symbol(success: bool) -> str:
     return "✅" if success else "❌"
 
 
+def _failing_stage_for_result(result: SystemtestResult) -> str:
+    if result.fieldcompare_time > 0:
+        return "compare"
+    if result.solver_time > 0:
+        return "run"
+    return "build"
+
+
+def _read_log_tail(log_path: Path, max_lines: int = FAILURE_LOG_TAIL_LINES) -> str:
+    if not log_path.is_file():
+        return f"(log file not found: {log_path.name})"
+    lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    if not lines:
+        return "(log file is empty)"
+    return "\n".join(lines[-max_lines:])
+
+
+def _append_failure_log_tails_to_summary(results: List[SystemtestResult]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    failed_results = [result for result in results if not result.success]
+    if not failed_results:
+        return
+
+    with open(summary_path, "a", encoding="utf-8") as summary_file:
+        print("\n## Failed test logs (last lines)\n", file=summary_file)
+        for result in failed_results:
+            stage = _failing_stage_for_result(result)
+            log_name = STAGE_LOG_FILES[stage]
+            log_path = result.systemtest.get_system_test_dir() / log_name
+            tail = _read_log_tail(log_path)
+            print(
+                f"### {_success_status_symbol(False)} {result.systemtest} — "
+                f"{stage} log (last {FAILURE_LOG_TAIL_LINES} lines)\n",
+                file=summary_file,
+            )
+            print("```text", file=summary_file)
+            print(tail, file=summary_file)
+            print("```\n", file=summary_file)
+
+
 def display_systemtestresults_as_table(results: List[SystemtestResult]):
     """
     Prints the result in a nice tabluated way to get an easy overview
@@ -152,11 +197,15 @@ def display_systemtestresults_as_table(results: List[SystemtestResult]):
             with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
                 print(row, file=f)
 
+    _append_failure_log_tails_to_summary(results)
+
     if "GITHUB_STEP_SUMMARY" in os.environ:
-        with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
-            print("\n\n", file=f)
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as f:
+            print("\n", file=f)
             print(
-                "In case a test fails, download the archive from the bottom of this page and inspect the per-stage logs (`system-tests-build.log`, `system-tests-run.log`, `system-tests-compare.log`). The stage runtimes might already give useful hints.",
+                "For full logs, download the archive from the bottom of this page "
+                "(`system-tests-build.log`, `system-tests-run.log`, `system-tests-compare.log`). "
+                "The stage runtimes in the table above might already give useful hints.",
                 file=f)
             print(
                 "See the [documentation](https://precice.org/dev-docs-system-tests.html#understanding-what-went-wrong).",

--- a/tools/tests/systemtests/Systemtest.py
+++ b/tools/tests/systemtests/Systemtest.py
@@ -14,7 +14,6 @@ from datetime import datetime
 import tarfile
 import time
 
-import html
 import unicodedata
 import re
 import logging
@@ -146,14 +145,9 @@ def _append_failure_log_tails_to_summary(results: List[SystemtestResult]) -> Non
                 print("<details>", file=summary_file)
                 print(f"<summary>{log_name} tail</summary>", file=summary_file)
                 print("", file=summary_file)
-                print(
-                    '<div style="max-height: 24em; overflow-y: auto; '
-                    'border: 1px solid #d0d7de; padding: 8px; '
-                    'font-family: monospace; font-size: 12px; white-space: pre-wrap;">',
-                    file=summary_file,
-                )
-                print(html.escape(tail), file=summary_file)
-                print("</div>", file=summary_file)
+                print("```text", file=summary_file)
+                print(tail, file=summary_file)
+                print("```", file=summary_file)
                 print("</details>", file=summary_file)
                 print("", file=summary_file)
 


### PR DESCRIPTION
## Summary
- on failure now , we append the last (100 lines, collapsible, all stages) of the relevant stage log  ( `build` / `run` / `compare` ) to the GHA job summary.
- stage is inferred from timings  ( `fieldcompare_time` → compare , else `solver_time` → run, else build ).
- Closes #792.
## Test plan
- [x] local quickstart pass — summary shows timing table only
- [x] local failed run — summary shows ( `## Failed test logs` ) with compare log tail
- [x] added changelog entry in `changelog-entries/ 830.md`