### PR TITLE
Remove the .venv and __pycache__ directories at the end of Python-related tests

### DIFF
--- a/elastic-tube-1d/metadata.yaml
+++ b/elastic-tube-1d/metadata.yaml
@@ -28,7 +28,7 @@ cases:
   fluid-python:
     participant: Fluid
     directory: ./fluid-python
-    run: ./run.sh
+    run: ./run.sh && rm -rf .venv
     component: python-bindings
 
   fluid-rust:
@@ -58,7 +58,7 @@ cases:
   solid-python:
     participant: Solid
     directory: ./solid-python
-    run: ./run.sh
+    run: ./run.sh && rm -rf .venv
     component: python-bindings
   
   solid-rust:

--- a/elastic-tube-1d/metadata.yaml
+++ b/elastic-tube-1d/metadata.yaml
@@ -28,7 +28,7 @@ cases:
   fluid-python:
     participant: Fluid
     directory: ./fluid-python
-    run: ./run.sh && rm -rf .venv
+    run: ./run.sh
     component: python-bindings
 
   fluid-rust:
@@ -58,7 +58,7 @@ cases:
   solid-python:
     participant: Solid
     directory: ./solid-python
-    run: ./run.sh && rm -rf .venv
+    run: ./run.sh
     component: python-bindings
   
   solid-rust:

--- a/tools/tests/component-templates/fenics-adapter.yaml
+++ b/tools/tests/component-templates/fenics-adapter.yaml
@@ -13,5 +13,6 @@ volumes:
 command: >
   /bin/bash -c "id && 
   cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
-  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1" &&
-  && rm -rf .venv __pycache__
+  {{ run }} &&
+  rm -rf .venv __pycache__
+  | tee system-tests_{{ case_folder }}.log 2>&1"

--- a/tools/tests/component-templates/fenics-adapter.yaml
+++ b/tools/tests/component-templates/fenics-adapter.yaml
@@ -13,4 +13,5 @@ volumes:
 command: >
   /bin/bash -c "id && 
   cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
-  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1"
+  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1" &&
+  && rm -rf .venv __pycache__

--- a/tools/tests/component-templates/fenicsx-adapter.yaml
+++ b/tools/tests/component-templates/fenicsx-adapter.yaml
@@ -13,5 +13,6 @@ volumes:
 command: >
   /bin/bash -c "id && 
   cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
-  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1" &&
-  && rm -rf .venv __pycache__
+  {{ run }} &&
+  rm -rf .venv __pycache__
+  | tee system-tests_{{ case_folder }}.log 2>&1"

--- a/tools/tests/component-templates/fenicsx-adapter.yaml
+++ b/tools/tests/component-templates/fenicsx-adapter.yaml
@@ -13,4 +13,5 @@ volumes:
 command: >
   /bin/bash -c "id && 
   cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
-  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1"
+  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1" &&
+  && rm -rf .venv __pycache__

--- a/tools/tests/component-templates/micro-manager.yaml
+++ b/tools/tests/component-templates/micro-manager.yaml
@@ -13,4 +13,5 @@ volumes:
 command: >
   /bin/bash -c "id &&
   cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
-  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1"
+  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1" &&
+  && rm -rf .venv __pycache__

--- a/tools/tests/component-templates/micro-manager.yaml
+++ b/tools/tests/component-templates/micro-manager.yaml
@@ -13,5 +13,6 @@ volumes:
 command: >
   /bin/bash -c "id &&
   cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
-  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1" &&
-  && rm -rf .venv __pycache__
+  {{ run }} &&
+  rm -rf .venv __pycache__
+  | tee system-tests_{{ case_folder }}.log 2>&1"

--- a/tools/tests/component-templates/nutils-adapter.yaml
+++ b/tools/tests/component-templates/nutils-adapter.yaml
@@ -13,5 +13,6 @@ volumes:
 command: >
   /bin/bash -c "id && 
   cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
-  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1" &&
-  && rm -rf .venv __pycache__
+  {{ run }} &&
+  rm -rf .venv __pycache__
+  | tee system-tests_{{ case_folder }}.log 2>&1"

--- a/tools/tests/component-templates/nutils-adapter.yaml
+++ b/tools/tests/component-templates/nutils-adapter.yaml
@@ -13,4 +13,5 @@ volumes:
 command: >
   /bin/bash -c "id && 
   cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
-  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1"
+  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1" &&
+  && rm -rf .venv __pycache__

--- a/tools/tests/component-templates/python-bindings.yaml
+++ b/tools/tests/component-templates/python-bindings.yaml
@@ -13,5 +13,6 @@ volumes:
 command: >
   /bin/bash -c "id && 
   cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
-  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1" &&
-  && rm -rf .venv __pycache__
+  {{ run }} &&
+  rm -rf .venv __pycache__
+  | tee system-tests_{{ case_folder }}.log 2>&1"

--- a/tools/tests/component-templates/python-bindings.yaml
+++ b/tools/tests/component-templates/python-bindings.yaml
@@ -13,4 +13,5 @@ volumes:
 command: >
   /bin/bash -c "id && 
   cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
-  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1"
+  {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1" &&
+  && rm -rf .venv __pycache__

--- a/tools/tests/component-templates/su2-adapter.yaml
+++ b/tools/tests/component-templates/su2-adapter.yaml
@@ -13,5 +13,6 @@ volumes:
 command: >
   /bin/bash -c "id && 
   cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
-  SU2_RUN="/home/precice/SU2_RUN/bin" PYTHONPATH="/home/precice/SU2_RUN/bin:$PYTHONPATH" {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1" &&
-  && rm -rf .venv __pycache__
+  SU2_RUN="/home/precice/SU2_RUN/bin" PYTHONPATH="/home/precice/SU2_RUN/bin:$PYTHONPATH" {{ run }} &&
+  rm -rf .venv __pycache__
+  | tee system-tests_{{ case_folder }}.log 2>&1"

--- a/tools/tests/component-templates/su2-adapter.yaml
+++ b/tools/tests/component-templates/su2-adapter.yaml
@@ -13,4 +13,5 @@ volumes:
 command: >
   /bin/bash -c "id && 
   cd '/runs/{{ tutorial_folder }}/{{ case_folder }}' &&
-  SU2_RUN="/home/precice/SU2_RUN/bin" PYTHONPATH="/home/precice/SU2_RUN/bin:$PYTHONPATH" {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1"
+  SU2_RUN="/home/precice/SU2_RUN/bin" PYTHONPATH="/home/precice/SU2_RUN/bin:$PYTHONPATH" {{ run }} | tee system-tests_{{ case_folder }}.log 2>&1" &&
+  && rm -rf .venv __pycache__

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -719,4 +719,4 @@ test_suites:
 
   selected:
     tutorials:
-      - *two-scale-heat-conduction_macro-nutils_micro-nutils
+      - *elastic-tube-1d_fluid-python_solid-python


### PR DESCRIPTION
With so many Python-based tutorials currently running in the `release` test suite, and with each of them creating a `.venv`, on one the one hand the uploaded artifacts are getting unnecessarily large, on the the other hand the working directory is getting too large during a single run, hitting resource limits.

This PR adds a step in the related components to remove the `.venv` and `__pycache__` directories at the end.