### PR TITLE
Add override inputs to system-tests-latest-components.yml

### DIFF
--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - id: print-inputs
         name: Display inputs
-        uses: shayki5/print-workflow-dispatch-inputs@v1
+        uses: VeyronSakai/display-inputs-action@v0.1
         with:
           add_to_summary: 'true'
       - id: ref-precice

--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -69,8 +69,6 @@ jobs:
       - id: print-inputs
         name: Display inputs
         uses: VeyronSakai/display-inputs-action@v0.1
-        with:
-          add_to_summary: 'true'
       - id: ref-precice
         name: Get preCICE ref
         uses: nmbgeek/github-action-get-latest-commit@main

--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -15,6 +15,39 @@ on:
         description: 'Branch to take the system tests from'
         default: 'develop'
         type: string
+      ref-precice:
+        description: 'precice Git ref (override latest)'
+        type: string
+      ref-python-bindings:
+        description: 'python-bindings ref'
+        type: string
+      ref-calculix-adapter:
+        description: 'calculix-adapter ref'
+        type: string
+      ref-dealii-adapter:
+        description: 'dealii-adapter ref'
+        type: string
+      ref-dumux-adapter:
+        description: 'dumux-adapter ref'
+        type: string
+      ref-fenics-adapter:
+        description: 'fenics-adapter ref'
+        type: string
+      ref-fenicsx-adapter:
+        description: 'fenicsx-adapter ref'
+        type: string
+      ref-micro-manager:
+        description: 'micro-manager ref'
+        type: string
+      ref-openfoam-adapter:
+        description: 'openfoam-adapter ref'
+        type: string
+      ref-su2-adapter:
+        description: 'su2-adapter ref'
+        type: string
+      ref-tutorials:
+        description: 'tutorials ref'
+        type: string
 
 jobs:
   gather-refs:
@@ -24,6 +57,7 @@ jobs:
       ref-precice: ${{ steps.ref-precice.outputs.shorthash }}
       ref-python-bindings: ${{ steps.ref-python-bindings.outputs.shorthash }}
       ref-calculix-adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}
+      ref-dealii-adapter: ${{ steps.ref-dealii-adapter.outputs.shorthash }}
       ref-dumux-adapter: ${{ steps.ref-dumux-adapter.outputs.shorthash }}
       ref-fenics-adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}
       ref-fenicsx-adapter: ${{ steps.ref-fenicsx-adapter.outputs.shorthash }}
@@ -52,6 +86,13 @@ jobs:
         with:
           owner: precice
           repo: calculix-adapter
+          branch: develop
+      - id: ref-dealii-adapter
+        name: Get deal.II adapter ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: dealii-adapter
           branch: develop
       - id: ref-dumux-adapter
         name: Get DuMux adapter ref
@@ -108,6 +149,7 @@ jobs:
           printf 'preCICE: ${{ steps.ref-precice.outputs.shorthash }}\n ${{ steps.ref-precice.outputs.description }}\n----------\n'
           printf 'Python bindings: ${{ steps.ref-python-bindings.outputs.shorthash }}\n ${{ steps.ref-python-bindings.outputs.description }}\n----------\n'
           printf 'CalculiX adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}\n ${{ steps.ref-calculix-adapter.outputs.description }}\n----------\n'
+          printf 'deal.II adapter: ${{ steps.ref-dealii-adapter.outputs.shorthash }}\n ${{ steps.ref-dealii-adapter.outputs.description }}\n----------\n'
           printf 'DuMux adapter: ${{ steps.ref-dumux-adapter.outputs.shorthash }}\n ${{ steps.ref-dumux-adapter.outputs.description }}\n----------\n'
           printf 'FEniCS adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}\n ${{ steps.ref-fenics-adapter.outputs.description }}\n----------\n'
           printf 'FEniCSx adapter: ${{ steps.ref-fenicsx-adapter.outputs.shorthash }}\n ${{ steps.ref-fenicsx-adapter.outputs.description }}\n----------\n'
@@ -115,6 +157,12 @@ jobs:
           printf 'OpenFOAM adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }} ${{ steps.ref-openfoam-adapter.outputs.description }}\n----------\n'
           printf 'SU2 adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}\n ${{ steps.ref-su2-adapter.outputs.description }}\n----------\n'
           printf 'Tutorials: ${{ steps.ref-tutorials.outputs.shorthash }} ${{ steps.ref-tutorials.outputs.description }}\n----------\n'
+      - id: inputs
+        run: |
+          {
+            echo "## Workflow inputs (will override the above reported latest components):"
+            echo "{{ inputs }}"
+          } >> "$GITHUB_STEP_SUMMARY"
       - id: summary
         name: Prepare Markdown summary
         run: |
@@ -137,6 +185,12 @@ jobs:
             echo "Description:"
             echo "\`\`\`"
             echo "${{ steps.ref-calculix-adapter.outputs.description }}"
+            echo "\`\`\`"
+            echo "### deal.II adapter"
+            echo "Reference: [\`${{ steps.ref-dealii-adapter.outputs.shorthash }}\`](https://github.com/precice/dealii-adapter/commit/${{ steps.ref-dealii-adapter.outputs.shorthash }})"
+            echo "Description:"
+            echo "\`\`\`"
+            echo "${{ steps.ref-dealii-adapter.outputs.description }}"
             echo "\`\`\`"
             echo "### DuMux adapter"
             echo "Reference: [\`${{ steps.ref-dumux-adapter.outputs.shorthash }}\`](https://github.com/precice/dumux-adapter/commit/${{ steps.ref-dumux-adapter.outputs.shorthash }})"
@@ -189,15 +243,16 @@ jobs:
     with:
       suites: ${{ inputs.suites || 'release' }}
       build_args: "PLATFORM:ubuntu_2404,\
-        PRECICE_REF:${{ needs.gather-refs.outputs.ref-precice }},\
-        PYTHON_BINDINGS_REF:${{ needs.gather-refs.outputs.ref-python-bindings }},\
-        CALCULIX_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-calculix-adapter }},\
-        DUMUX_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-dumux-adapter }},\
-        FENICS_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-fenics-adapter }},\
-        FENICSX_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-fenicsx-adapter }},\
-        MICRO_MANAGER_REF:${{ needs.gather-refs.outputs.ref-micro-manager }},\
-        OPENFOAM_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-openfoam-adapter }},\
-        SU2_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-su2-adapter }},\
-        TUTORIALS_REF:${{ needs.gather-refs.outputs.ref-tutorials }}"
+        PRECICE_REF:${{ inputs.ref-precice || needs.gather-refs.outputs.ref-precice }},\
+        PYTHON_BINDINGS_REF:${{ inputs.ref-python-bindings || needs.gather-refs.outputs.ref-python-bindings }},\
+        CALCULIX_ADAPTER_REF:${{ inputs.ref-calculix-adapter || needs.gather-refs.outputs.ref-calculix-adapter }},\
+        DEALII_ADAPTER_REF:${{ inputs.ref-dealii-adapter || needs.gather-refs.outputs.ref-dealii-adapter }},\
+        DUMUX_ADAPTER_REF:${{ inputs.ref-dumux-adapter || needs.gather-refs.outputs.ref-dumux-adapter }},\
+        FENICS_ADAPTER_REF:${{ inputs.ref-fenics-adapter || needs.gather-refs.outputs.ref-fenics-adapter }},\
+        FENICSX_ADAPTER_REF:${{ inputs.ref-fenicsx-adapter || needs.gather-refs.outputs.ref-fenicsx-adapter }},\
+        MICRO_MANAGER_REF:${{ inputs.ref-micro-manager || needs.gather-refs.outputs.ref-micro-manager }},\
+        OPENFOAM_ADAPTER_REF:${{ inputs.ref-openfoam-adapter || needs.gather-refs.outputs.ref-openfoam-adapter }},\
+        SU2_ADAPTER_REF:${{ inputs.ref-su2-adapter || needs.gather-refs.outputs.ref-su2-adapter }},\
+        TUTORIALS_REF:${{ inputs.ref-tutorials || needs.gather-refs.outputs.ref-tutorials }}"
       system_tests_branch: ${{ inputs.system_tests_branch || 'develop' }}
       log_level: "INFO"

--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -66,6 +66,11 @@ jobs:
       ref-su2-adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}
       ref-tutorials: ${{ steps.ref-tutorials.outputs.shorthash }}
     steps:
+      - id: print-inputs
+        name: Display inputs
+        uses: shayki5/print-workflow-dispatch-inputs@v1
+        with:
+          add_to_summary: 'true'
       - id: ref-precice
         name: Get preCICE ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -157,10 +162,6 @@ jobs:
           printf 'OpenFOAM adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }} ${{ steps.ref-openfoam-adapter.outputs.description }}\n----------\n'
           printf 'SU2 adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}\n ${{ steps.ref-su2-adapter.outputs.description }}\n----------\n'
           printf 'Tutorials: ${{ steps.ref-tutorials.outputs.shorthash }} ${{ steps.ref-tutorials.outputs.description }}\n----------\n'
-      - id: inputs
-        uses: shayki5/print-workflow-dispatch-inputs@v1
-        with:
-          add_to_summary: 'true'
       - id: summary
         name: Prepare Markdown summary
         run: |

--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -50,6 +50,13 @@ on:
         type: string
 
 jobs:
+  report-inputs:
+    name: Report workflow inputs
+    runs-on: ubuntu-latest
+    steps:
+      - id: report-inputs
+        name: Report inputs
+        uses: VeyronSakai/display-inputs-action@v0.1
   gather-refs:
     name: Map Git branches to latest refs
     runs-on: ubuntu-latest
@@ -66,9 +73,6 @@ jobs:
       ref-su2-adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}
       ref-tutorials: ${{ steps.ref-tutorials.outputs.shorthash }}
     steps:
-      - id: print-inputs
-        name: Display inputs
-        uses: VeyronSakai/display-inputs-action@v0.1
       - id: ref-precice
         name: Get preCICE ref
         uses: nmbgeek/github-action-get-latest-commit@main

--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -158,11 +158,9 @@ jobs:
           printf 'SU2 adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}\n ${{ steps.ref-su2-adapter.outputs.description }}\n----------\n'
           printf 'Tutorials: ${{ steps.ref-tutorials.outputs.shorthash }} ${{ steps.ref-tutorials.outputs.description }}\n----------\n'
       - id: inputs
-        run: |
-          {
-            echo "## Workflow inputs (will override the above reported latest components):"
-            echo "{{ inputs }}"
-          } >> "$GITHUB_STEP_SUMMARY"
+        uses: shayki5/print-workflow-dispatch-inputs@v1
+        with:
+          add_to_summary: 'true'
       - id: summary
         name: Prepare Markdown summary
         run: |


### PR DESCRIPTION
Adds manual overrides to the system tests latest components inputs, to make the workflow more intuitive.

It also adds the deal.II ref argument, which was missing from https://github.com/precice/tutorials/pull/646.

Partially replaces #647. I will split it into a manual and a reusable workflow in a follow-up.