### PR TITLE
Port two-scale-heat-conduction to latest micro-manager

### DIFF
--- a/two-scale-heat-conduction/micro-dumux/micro-manager-config.json
+++ b/two-scale-heat-conduction/micro-dumux/micro-manager-config.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "micro_sim",
+    "micro_file_names": ["micro_sim"],
     "coupling_params": {
             "participant_name": "Micro-Manager",
             "precice_config_file_name": "../precice-config.xml",

--- a/two-scale-heat-conduction/micro-nutils/micro-manager-config.json
+++ b/two-scale-heat-conduction/micro-nutils/micro-manager-config.json
@@ -1,5 +1,5 @@
 {
-    "micro_file_name": "micro",
+    "micro_file_names": ["micro"],
     "coupling_params": {
             "participant_name": "Micro-Manager",
             "precice_config_file_name": "../precice-config.xml",


### PR DESCRIPTION
Trying to integrate the two-scale-heat-conduction tutorial into the system tests, I noticed that it does not work anymore, with the following error:

```
(0) 06/28/2026 07:08:48 PM - micro_manager.micro_manager - INFO - Micro Manager version: 0.10.1.post14+git.2bf393d1
(0) 06/28/2026 07:08:48 PM - micro_manager.micro_manager - INFO - Reading JSON configuration file: /runs/two-scale-heat-conduction_macro-dumux-micro-dumux_2026-06-28-210801/micro-dumux/micro-manager-config.json
(0) 06/28/2026 07:08:48 PM - micro_manager.micro_manager - INFO - 'micro_file_name' must be specified!
Traceback (most recent call last):
  File "/home/precice/venv/bin/micro-manager-precice", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/precice/venv/lib/python3.12/site-packages/micro_manager/__init__.py", line 114, in main
    manager = MicroManagerCoupling(config_file_path, log_file=args.log_file)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/precice/venv/lib/python3.12/site-packages/micro_manager/micro_manager.py", line 64, in __init__
    self._config.read_json_micro_manager()
  File "/home/precice/venv/lib/python3.12/site-packages/micro_manager/config.py", line 653, in read_json_micro_manager
    self._read_json_base(self._config_file_name)
  File "/home/precice/venv/lib/python3.12/site-packages/micro_manager/config.py", line 533, in _read_json_base
    file_names = self.json["micro_file_names"].get_or_raise(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/precice/venv/lib/python3.12/site-packages/micro_manager/config.py", line 202, in get_or_raise
    raise e
  File "/home/precice/venv/lib/python3.12/site-packages/micro_manager/config.py", line 194, in get_or_raise
    current_element = current_element[key]
                      ~~~~~~~~~~~~~~~^^^^^
KeyError: 'micro_file_names'
```

I understand that this is related to https://github.com/precice/micro-manager/pull/286 (@Snapex2409, @IshaanDesai). Since the micro-manager is still in the `0.x` version, I understand that there is no aim for backwards compatibility at the moment. At the same time, there is no release of this configuration change yet. Is one planned soon? Or would you prefer supporting both `micro_file_name` and `micro_file_names`?