### PR TITLE
Make cleaning and other scripts consistent

### DIFF
--- a/partitioned-burgers-1d/clean-tutorial.sh
+++ b/partitioned-burgers-1d/clean-tutorial.sh
@@ -1,14 +1,1 @@
-#!/usr/bin/env sh
-set -e -u
-
-# shellcheck disable=SC1091
-. ../tools/cleaning-tools.sh
-
-clean_tutorial .
-clean_precice_logs .
-rm -fv ./*.log
-rm -fv ./*.vtu
-
-# Clean up root directory
-rm -f initial_condition.npz
-rm -rf output/
+../tools/clean-tutorial-base.sh

--- a/partitioned-burgers-1d/dirichlet-scipy/clean.sh
+++ b/partitioned-burgers-1d/dirichlet-scipy/clean.sh
@@ -7,3 +7,4 @@ set -e -u
 clean_precice_logs .
 clean_case_logs .
 rm -f dirichlet.npz
+rm -f ../initial_condition.npz

--- a/partitioned-burgers-1d/neumann-scipy/clean.sh
+++ b/partitioned-burgers-1d/neumann-scipy/clean.sh
@@ -7,3 +7,4 @@ set -e -u
 clean_precice_logs .
 clean_case_logs .
 rm -f neumann.npz
+rm -f ../initial_condition.npz

--- a/partitioned-burgers-1d/neumann-surrogate/clean.sh
+++ b/partitioned-burgers-1d/neumann-surrogate/clean.sh
@@ -7,3 +7,4 @@ set -e -u
 clean_precice_logs .
 clean_case_logs .
 rm -f surrogate.npz
+rm -f ../initial_condition.npz

--- a/partitioned-burgers-1d/solver-scipy/clean.sh
+++ b/partitioned-burgers-1d/solver-scipy/clean.sh
@@ -6,3 +6,4 @@ set -e -u
 
 clean_case_logs .
 rm -f full_domain.npz
+rm -f ../initial_condition.npz

--- a/partitioned-heat-conduction-3d/clean-tutorial.sh
+++ b/partitioned-heat-conduction-3d/clean-tutorial.sh
@@ -1,10 +1,1 @@
-#!/usr/bin/env sh
-set -e -u
-
-# shellcheck disable=SC1091
-. ../tools/cleaning-tools.sh
-
-clean_tutorial .
-clean_precice_logs .
-rm -fv ./*.log
-
+../tools/clean-tutorial-base.sh

--- a/partitioned-heat-conduction-direct/clean-tutorial.sh
+++ b/partitioned-heat-conduction-direct/clean-tutorial.sh
@@ -1,12 +1,1 @@
-#!/usr/bin/env sh
-set -e -u
-
-# Determine the tutorial directory (where the symlink is located)
-TUTORIAL_DIR="$(cd "$(dirname "$0")" && pwd)"
-cd "$TUTORIAL_DIR"
-
-# shellcheck disable=SC1091
-. ../tools/cleaning-tools.sh
-
-clean_tutorial .
-
+../tools/clean-tutorial-base.sh

--- a/partitioned-pipe-multiscale/clean-tutorial.sh
+++ b/partitioned-pipe-multiscale/clean-tutorial.sh
@@ -1,11 +1,1 @@
-#!/usr/bin/env sh
-set -e -u
-
-# shellcheck disable=SC1091
-. ../tools/cleaning-tools.sh
-
-clean_tutorial .
-clean_precice_logs .
-rm -fv ./*.log
-rm -fv ./*.vtu
-
+../tools/clean-tutorial-base.sh

--- a/partitioned-pipe-multiscale/set-case.sh
+++ b/partitioned-pipe-multiscale/set-case.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 if [ "$1" = "1d3d" ]; then

--- a/perpendicular-flap-stress/solid-gismo/run.sh
+++ b/perpendicular-flap-stress/solid-gismo/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 . ../../tools/log.sh

--- a/tools/clean-tutorial-base.sh
+++ b/tools/clean-tutorial-base.sh
@@ -12,4 +12,4 @@ clean_tutorial .
 clean_precice_logs .
 rm -fv ./*.log
 rm -fv ./*.vtu
-
+rm -rf output/

--- a/water-hammer/clean-tutorial.sh
+++ b/water-hammer/clean-tutorial.sh
@@ -1,11 +1,1 @@
-#!/usr/bin/env sh
-set -e -u
-
-# shellcheck disable=SC1091
-. ../tools/cleaning-tools.sh
-
-clean_tutorial .
-clean_precice_logs .
-rm -fv ./*.log
-rm -fv ./*.vtu
-
+../tools/clean-tutorial-base.sh

--- a/water-hammer/set-case.sh
+++ b/water-hammer/set-case.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -u
 
 if [ "$1" = "1d3d" ]; then


### PR DESCRIPTION
A few tutorials were using a copy of `clean-tutorial.sh` (instead of a symlink to `tools/clean-tutorial-base.sh`), most of them without a clean reason:

- `partitioned-burgers-1d`
- `partitioned-heat-conduction-3d`
- `partitioned-heat-conduction-direct`
- `partitioned-pipe-multiscale`
- `water-hammer`

Out of these, only the `partitioned-burgers-1d` needed to remove additional files:

- `output/` -> I added that to the base script
- `initial-condition.npz` -> since this is generated by each case's `run.sh`, I added it to the respective `clean.sh`.

This PR converts all of the above to symlinks.

At the same time, this PR changes a few remaining `#!/bin/bash` of other scripts to `#!/usr/bin/env bash`.