### PR TITLE
Modify Python requirements.txt in tests

### DIFF
--- a/changelog-entries/857.md
+++ b/changelog-entries/857.md
@@ -1,0 +1,1 @@
+- Fixed the version selection of Python-based tutorials in the system tests [#857](https://github.com/precice/tutorials/pull/857)

--- a/channel-transport/transport-nutils/requirements.txt
+++ b/channel-transport/transport-nutils/requirements.txt
@@ -1,6 +1,5 @@
 setuptools # required by nutils
 nutils~=7.3
 numpy >1, <2
-# remeshing support will be released with preCICE version 3.2
-pyprecice @ git+https://github.com/precice/python-bindings.git@develop
+pyprecice >=3.2 # Remeshing support is available since preCICE version 3.2
 setuptools

--- a/tools/tests/docker-compose.template.yaml
+++ b/tools/tests/docker-compose.template.yaml
@@ -15,8 +15,11 @@ services:
       sed -i 's|</log>|<sink type=\"file\" output=\"precice-debug.log\" filter=\"%Severity% >= debug and %Rank% = 0\" enabled=\"true\" /></log>|g' precice-config.xml &&
       sed -i 's%</participant>%<export:vtu directory=\"../{{precice_output_folder}}\" /> </participant>%g' precice-config.xml &&
       sed -i 's|m2n:sockets |m2n:sockets network=\"eth0\" |g' precice-config.xml &&
-      cat precice-config.xml"
-
+      echo -e '\ngit+https://github.com/precice/micro-manager.git@{{build_arguments.MICRO_MANAGER_REF}}' | tee -a $(grep -r --include requirements.txt 'micro-manager-precice' -l .) > /dev/null &&
+      echo -e '\ngit+https://github.com/precice/fenicsx-adapter.git@{{build_arguments.FENICSX_ADAPTER_REF}}' | tee -a $(grep -r --include requirements.txt 'fenicsxprecice' -l .) > /dev/null &&
+      echo -e '\ngit+https://github.com/precice/fenics-adapter.git@{{build_arguments.FENICS_ADAPTER_REF}}' | tee -a $(grep -r --include requirements.txt 'fenicsprecice' -l .) > /dev/null &&
+      echo -e '\ngit+https://github.com/precice/python-bindings.git@{{build_arguments.PYTHON_BINDINGS_REF}}' | tee -a $(grep -r --include requirements.txt 'pyprecice' -l .) > /dev/null"
+    # TODO: fmiprecice does not have a _REF yet
 
   {% for service in services %}
   {{ service }}:

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -37,7 +37,6 @@ test_suites:
           - fluid-openfoam
           - transport-nutils
         max_time: 0.1
-        timeout: 600
         reference_result: ./channel-transport/reference-results/fluid-openfoam_transport-nutils.tar.gz
       - &channel-transport_fluid-openfoam_transport-openfoam
         path: channel-transport

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -37,6 +37,7 @@ test_suites:
           - fluid-openfoam
           - transport-nutils
         max_time: 0.1
+        timeout: 600
         reference_result: ./channel-transport/reference-results/fluid-openfoam_transport-nutils.tar.gz
       - &channel-transport_fluid-openfoam_transport-openfoam
         path: channel-transport

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -521,8 +521,8 @@ test_suites:
         case_combination:
           - macro-nutils
           - micro-nutils
-        max_time: 0.05
-        timeout: 600
+        max_time: 0.01
+        timeout: 1200
         skip_compare: true # Values too close to zero
         reference_result: ./two-scale-heat-conduction/reference-results/macro-nutils_micro-nutils.tar.gz
 

--- a/two-scale-heat-conduction/metadata.yaml
+++ b/two-scale-heat-conduction/metadata.yaml
@@ -28,5 +28,5 @@ cases:
   micro-nutils:
     participant: Micro-Manager
     directory: ./micro-nutils
-    run: source /home/precice/venv/bin/activate && ./run.sh -s
-    component: nutils-adapter
+    run: ./run.sh -s
+    component: micro-manager


### PR DESCRIPTION
This PR fixes #584, allowing the Python-based tests to pick the correct, to-be-tested dependency versions in tests.

It replaces #745, which follows a different approach: In that PR, the aim is to install everything in a common venv, which runs into version conflicts and required changes in every component template and Docker build stage. The conflict manifests itself on the various Nutils-based tutorials, each depending on a different Nutils version, but it would also result in testing different setups than a user.

This PR takes into account that:

- now almost every tutorial has a `requirements.txt`
- our `requirements.txt` files seem to have rather loosely-restricted versions
- adding a concrete version from Git at the bottom of the `requirements.txt` seems to be preferred over the latest one from PyPI. I cannot find any documentation on this (most relevant: [PEP 440](https://peps.python.org/pep-0440/) and PIP [VCS support](https://pip.pypa.io/en/stable/topics/vcs-support/) and [dependency resolution](https://pip.pypa.io/en/stable/topics/dependency-resolution/)), but I observe it consistently in my tests.

The approach I use is to add an a line with the corresponding `_REF` (e.g., `git+https://github.com/precice/python-bindings.git@PYTHON_BINDINGS_REF`) at the bottom of each `requirements.txt` file in the tutorial folder (to also include `solver-python` etc) that mentions the respective package (e.g., `pyprecice`). It looks like I don't need to remove the original line. This leads to, for example:

```
setuptools # required by nutils
nutils~=7.3
numpy >1, <2
pyprecice~=3.0
micro-manager-precice

git+https://github.com/precice/micro-manager.git@3ee74f81f0670c92433c5225520c989d4e931325

git+https://github.com/precice/python-bindings.git@f40889ab2d8d85560ef60cdaf7af2b6d694255b4
```

I am applying this step in the `prepare:` Docker Compose service template, which is where we also modify the `precice-config.xml`. This keeps the change minimal and applies it only once per tutorial. A downside is that every test builds the respective PIP packages (which does not seem to take long).

It substitutes the value passed as a Jinja2 template argument. I initially tried implementing it using the available environment variables, but this is simpler and does not require passing the build arguments as environment variables (which could also be misused at runtime).

I have tested the changes on the [release test suite](https://github.com/precice/tutorials/actions/runs/28747583001) and previously in various attempts of [this GHA test run](https://github.com/precice/tutorials/actions/runs/28684559204) (see attempts [36](https://github.com/precice/tutorials/actions/runs/28684559204/attempts/36) + [43](https://github.com/precice/tutorials/actions/runs/28684559204/attempts/43)). I needed to increase the timeout of the previously untested `two-scale-heat-conduction_macro-nutils_micro-nutils` case and change its component in the metadata from `nutils-adapter` to `micro-manager`.

What remains open (but I will deal with in a separate PR) is:

- the FMI Runner does not yet have a component, so it also does not have an `FMI_RUNNER_REF`. The changes of this PR currently have no effect in the respective tests.
- the Nutils component is rather useless, since what it installs is always replaced. This is also the case in many cases that use the python-bindings (with the strange exception of the DuMux adapter component, which depends on the Micro-Manager, which depends on the Python bindings).
