### PR TITLE
Add alternative configurations of the geometric multiscale tutorials to the system tests

### DIFF
--- a/partitioned-pipe-multiscale/metadata.yaml
+++ b/partitioned-pipe-multiscale/metadata.yaml
@@ -3,32 +3,30 @@ path: partitioned-pipe-multiscale # relative to git repo
 url: https://precice.org/tutorials-partitioned-pipe-multiscale.html
 
 participants:
-  - Fluid1DLeft
-  # - Fluid1DRight
-  # - Fluid3DLeft
-  - Fluid3DRight
+  - Left
+  - Right
 
 cases:
   fluid1d-left-nutils:
-    participant: Fluid1DLeft
+    participant: Left
     directory: ./fluid1d-left-nutils
     run: ./run.sh
     component: nutils-adapter
 
-  # fluid1d-right-nutils:
-  #   participant: Fluid1DRight
-  #   directory: ./fluid1d-right-nutils
-  #   run: ./run.sh
-  #   component: nutils-adapter
+  fluid3d-left-openfoam:
+    participant: Left
+    directory: ./fluid3d-left-openfoam
+    run: ./run.sh
+    component: openfoam-adapter
 
-  # fluid3d-left-openfoam:
-  #   participant: Fluid3DLeft
-  #   directory: ./fluid3d-left-openfoam
-  #   run: ./run.sh
-  #   component: openfoam-adapter
+  fluid1d-right-nutils:
+    participant: Right
+    directory: ./fluid1d-right-nutils
+    run: ./run.sh
+    component: nutils-adapter
 
   fluid3d-right-openfoam:
-    participant: Fluid3DRight
+    participant: Right
     directory: ./fluid3d-right-openfoam
     run: ./run.sh
     component: openfoam-adapter

--- a/partitioned-pipe-multiscale/reference-results/fluid1d-left-nutils_fluid3d-right-openfoam.tar.gz
+++ b/partitioned-pipe-multiscale/reference-results/fluid1d-left-nutils_fluid3d-right-openfoam.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bc40404e24756a6a6e913356965a67bbe84a1e7596fae90fead5fd4069677deb
-size 18619
+oid sha256:d5a7079c53ecc2ea88ba2cb9b86c75c78988bfd5112e11d2258990bdc4de012b
+size 19038

--- a/partitioned-pipe-multiscale/reference-results/fluid3d-left-openfoam_fluid1d-right-nutils.tar.gz
+++ b/partitioned-pipe-multiscale/reference-results/fluid3d-left-openfoam_fluid1d-right-nutils.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e1bc3d3b51e0e44b0d348f234f3d2037b718dc30664eab22bdc39f13d430469
+size 65829

--- a/partitioned-pipe-multiscale/reference-results/reference_results.metadata
+++ b/partitioned-pipe-multiscale/reference-results/reference_results.metadata
@@ -11,7 +11,8 @@ We also include some information on the machine used to generate them
 
 | name | time | sha256 |
 |------|------|-------|
-| fluid1d-left-nutils_fluid3d-right-openfoam.tar.gz | 2026-05-28 14:01:56 | bc40404e24756a6a6e913356965a67bbe84a1e7596fae90fead5fd4069677deb |
+| fluid1d-left-nutils_fluid3d-right-openfoam.tar.gz | 2026-07-06 19:59:34 | d5a7079c53ecc2ea88ba2cb9b86c75c78988bfd5112e11d2258990bdc4de012b |
+| fluid3d-left-openfoam_fluid1d-right-nutils.tar.gz | 2026-07-06 19:59:34 | 3e1bc3d3b51e0e44b0d348f234f3d2037b718dc30664eab22bdc39f13d430469 |
 
 ## List of arguments used to generate the files
 
@@ -24,15 +25,17 @@ We also include some information on the machine used to generate them
 | OPENFOAM_EXECUTABLE | openfoam2512 |
 | SU2_VERSION | 7.5.1 |
 | FENICS_ADAPTER_REF | v2.3.0 |
+| FENICSX_ADAPTER_REF | v1.0.1 |
+| FMI_RUNNER_REF | v0.2.1 |
 | CALCULIX_ADAPTER_REF | v2.20.1 |
 | DEALII_ADAPTER_REF | a421d92 |
 | DUMUX_ADAPTER_REF | 3f3f54f |
 | MICRO_MANAGER_REF | v0.10.1 |
 | OPENFOAM_ADAPTER_REF | 2c3062c |
-| PRECICE_REF | v3.4.1 |
-| PYTHON_BINDINGS_REF | v3.4.0 |
+| PRECICE_REF | b770460f2447b94da430086085d6b424e7c073e9 |
+| PYTHON_BINDINGS_REF | 1a469788eec0a3de1a00691bdf5e5b0b25a2ae97 |
 | SU2_ADAPTER_REF | 5abe79b |
-| TUTORIALS_REF | 816ffe9 |
+| TUTORIALS_REF | 36294ae3063177c50717d9acd7e5fdae14e07bf5 |
 | PRECICE_PRESET | production-audit |
 | PRECICE_UID | 1003 |
 | PRECICE_GID | 1003 |
@@ -40,7 +43,7 @@ We also include some information on the machine used to generate them
 
 ### uname -a
 
-Linux precice-tests 5.15.0-179-generic #189-Ubuntu SMP Tue May 5 18:20:56 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux
+Linux precice-tests 5.15.0-185-generic #195-Ubuntu SMP Fri Jun 19 17:11:50 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux
 
 
 ### lscpu

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -679,6 +679,7 @@ test_suites:
       - *volume-coupled-diffusion_source-fenics_drain-fenics
       - *volume-coupled-flow_fluid-openfoam_source-nutils
       - *water-hammer_fluid1d-left-nutils_fluid3d-right-openfoam
+      - *water-hammer_fluid3d-left-openfoam_fluid1d-right-nutils
       - *wolf-sheep-soil-creep_soil-creep-landlab_wolf-sheep-grass-mesa
     external:
       - *partitioned-heat-conduction-mixedbc_left-openfoam_right-openfoam
@@ -784,6 +785,7 @@ test_suites:
       - *two-scale-heat-conduction_macro-nutils_micro-nutils
       - *volume-coupled-flow_fluid-openfoam_source-nutils
       - *water-hammer_fluid1d-left-nutils_fluid3d-right-openfoam
+      - *water-hammer_fluid3d-left-openfoam_fluid1d-right-nutils
 
   openfoam-adapter:
     tutorials:
@@ -819,6 +821,7 @@ test_suites:
       - *quickstart_openfoam_cpp
       - *volume-coupled-flow_fluid-openfoam_source-nutils
       - *water-hammer_fluid1d-left-nutils_fluid3d-right-openfoam
+      - *water-hammer_fluid3d-left-openfoam_fluid1d-right-nutils
     external:
       - *partitioned-heat-conduction-mixedbc_left-openfoam_right-openfoam
       - *partitioned-heat-conduction-robin_left-openfoam_right-openfoam

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -401,7 +401,14 @@ test_suites:
         run-before: ./set-case.sh 1d3d
         max_time: 0.05
         reference_result: ./partitioned-pipe-multiscale/reference-results/fluid1d-left-nutils_fluid3d-right-openfoam.tar.gz
-      # More case combinations are possible, but they requite calling set-case.sh
+      - &partitioned-pipe-multiscale_fluid3d-left-openfoam_fluid1d-right-nutils
+        path: partitioned-pipe-multiscale
+        case_combination:
+          - fluid3d-left-openfoam
+          - fluid1d-right-nutils
+        run-before: ./set-case.sh 3d1d
+        max_time: 0.05
+        reference_result: ./partitioned-pipe-multiscale/reference-results/fluid3d-left-openfoam_fluid1d-right-nutils.tar.gz
 
   partitioned-pipe-two-phase:
     tutorials:
@@ -556,7 +563,14 @@ test_suites:
         run-before: ./set-case.sh 1d3d
         max_time: 0.05
         reference_result: ./water-hammer/reference-results/fluid1d-left-nutils_fluid3d-right-openfoam.tar.gz
-      # More case combinations are possible, but they requite calling set-case.sh
+      - &water-hammer_fluid3d-left-openfoam_fluid1d-right-nutils
+        path: water-hammer
+        case_combination:
+          - fluid3d-left-openfoam
+          - fluid1d-right-nutils
+        run-before: ./set-case.sh 3d1d
+        max_time: 0.05
+        reference_result: ./water-hammer/reference-results/fluid3d-left-openfoam_fluid1d-right-nutils.tar.gz
 
   wolf-sheep-soil-creep:
     tutorials:
@@ -650,6 +664,7 @@ test_suites:
       - *partitioned-pipe_fluid1-openfoam-pimplefoam_fluid2-openfoam-pimplefoam
       - *partitioned-pipe_fluid1-openfoam-sonicliquidfoam_fluid2-openfoam-sonicliquidfoam
       - *partitioned-pipe-multiscale_fluid1d-left-nutils_fluid3d-right-openfoam
+      - *partitioned-pipe-multiscale_fluid3d-left-openfoam_fluid1d-right-nutils
       - *partitioned-pipe-two-phase_fluid1-openfoam_fluid2-openfoam
       - *perpendicular-flap_fluid-fake_solid-fake
       - *perpendicular-flap_fluid-openfoam_solid-calculix
@@ -763,6 +778,7 @@ test_suites:
       - *partitioned-heat-conduction_dirichlet-nutils_neumann-nutils
       - *partitioned-heat-conduction-direct_dirichlet-nutils_neumann-nutils
       - *partitioned-pipe-multiscale_fluid1d-left-nutils_fluid3d-right-openfoam
+      - *partitioned-pipe-multiscale_fluid3d-left-openfoam_fluid1d-right-nutils
       - *perpendicular-flap_fluid-nutils_solid-calculix
       - *turek-hron-fsi3_fluid-nutils_solid-nutils
       - *two-scale-heat-conduction_macro-nutils_micro-nutils
@@ -793,6 +809,7 @@ test_suites:
       - *partitioned-pipe_fluid1-openfoam-pimplefoam_fluid2-openfoam-pimplefoam
       - *partitioned-pipe_fluid1-openfoam-sonicliquidfoam_fluid2-openfoam-sonicliquidfoam
       - *partitioned-pipe-multiscale_fluid1d-left-nutils_fluid3d-right-openfoam
+      - *partitioned-pipe-multiscale_fluid3d-left-openfoam_fluid1d-right-nutils
       - *partitioned-pipe-two-phase_fluid1-openfoam_fluid2-openfoam
       - *perpendicular-flap_fluid-openfoam_solid-calculix
       - *perpendicular-flap_fluid-openfoam_solid-dealii

--- a/water-hammer/metadata.yaml
+++ b/water-hammer/metadata.yaml
@@ -3,32 +3,30 @@ path: water-hammer # relative to git repo
 url: https://precice.org/tutorials-water-hammer.html
 
 participants:
-  - Fluid1DLeft
-  # - Fluid1DRight
-  # - Fluid3DLeft
-  - Fluid3DRight
+  - Left
+  - Right
 
 cases:
   fluid1d-left-nutils:
-    participant: Fluid1DLeft
+    participant: Left
     directory: ./fluid1d-left-nutils
     run: ./run.sh
     component: nutils-adapter
 
-  # fluid1d-right-nutils:
-  #   participant: Fluid1DRight
-  #   directory: ./fluid1d-right-nutils
-  #   run: ./run.sh
-  #   component: nutils-adapter
+  fluid3d-left-openfoam:
+    participant: Left
+    directory: ./fluid3d-left-openfoam
+    run: ./run.sh
+    component: openfoam-adapter
 
-  # fluid3d-left-openfoam:
-  #   participant: Fluid3DLeft
-  #   directory: ./fluid3d-left-openfoam
-  #   run: ./run.sh
-  #   component: openfoam-adapter
+  fluid1d-right-nutils:
+    participant: Right
+    directory: ./fluid1d-right-nutils
+    run: ./run.sh
+    component: nutils-adapter
 
   fluid3d-right-openfoam:
-    participant: Fluid3DRight
+    participant: Right
     directory: ./fluid3d-right-openfoam
     run: ./run.sh
     component: openfoam-adapter

--- a/water-hammer/reference-results/fluid1d-left-nutils_fluid3d-right-openfoam.tar.gz
+++ b/water-hammer/reference-results/fluid1d-left-nutils_fluid3d-right-openfoam.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3c96d4bcd10a6447e39b2918c94753cd9f1994cba89abf713b21869fc78c7dd
-size 159892
+oid sha256:e957dca70ad86b2dd38c0f3a16cac61199751d50c4c6716da58b417a34725e29
+size 160306

--- a/water-hammer/reference-results/fluid3d-left-openfoam_fluid1d-right-nutils.tar.gz
+++ b/water-hammer/reference-results/fluid3d-left-openfoam_fluid1d-right-nutils.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fff2e33eb48e1c50d18fd6d3a57d7b8b151de8bdf0f9787c1495733032b78cb
+size 31094

--- a/water-hammer/reference-results/reference_results.metadata
+++ b/water-hammer/reference-results/reference_results.metadata
@@ -11,7 +11,8 @@ We also include some information on the machine used to generate them
 
 | name | time | sha256 |
 |------|------|-------|
-| fluid1d-left-nutils_fluid3d-right-openfoam.tar.gz | 2026-05-31 00:21:36 | b3c96d4bcd10a6447e39b2918c94753cd9f1994cba89abf713b21869fc78c7dd |
+| fluid1d-left-nutils_fluid3d-right-openfoam.tar.gz | 2026-07-06 19:59:34 | e957dca70ad86b2dd38c0f3a16cac61199751d50c4c6716da58b417a34725e29 |
+| fluid3d-left-openfoam_fluid1d-right-nutils.tar.gz | 2026-07-06 19:59:34 | 9fff2e33eb48e1c50d18fd6d3a57d7b8b151de8bdf0f9787c1495733032b78cb |
 
 ## List of arguments used to generate the files
 
@@ -24,15 +25,17 @@ We also include some information on the machine used to generate them
 | OPENFOAM_EXECUTABLE | openfoam2512 |
 | SU2_VERSION | 7.5.1 |
 | FENICS_ADAPTER_REF | v2.3.0 |
+| FENICSX_ADAPTER_REF | v1.0.1 |
+| FMI_RUNNER_REF | v0.2.1 |
 | CALCULIX_ADAPTER_REF | v2.20.1 |
 | DEALII_ADAPTER_REF | a421d92 |
 | DUMUX_ADAPTER_REF | 3f3f54f |
 | MICRO_MANAGER_REF | v0.10.1 |
 | OPENFOAM_ADAPTER_REF | 2c3062c |
-| PRECICE_REF | v3.4.1 |
-| PYTHON_BINDINGS_REF | v3.4.0 |
+| PRECICE_REF | b770460f2447b94da430086085d6b424e7c073e9 |
+| PYTHON_BINDINGS_REF | 1a469788eec0a3de1a00691bdf5e5b0b25a2ae97 |
 | SU2_ADAPTER_REF | 5abe79b |
-| TUTORIALS_REF | more-tests |
+| TUTORIALS_REF | 36294ae3063177c50717d9acd7e5fdae14e07bf5 |
 | PRECICE_PRESET | production-audit |
 | PRECICE_UID | 1003 |
 | PRECICE_GID | 1003 |
@@ -40,7 +43,7 @@ We also include some information on the machine used to generate them
 
 ### uname -a
 
-Linux precice-tests 5.15.0-179-generic #189-Ubuntu SMP Tue May 5 18:20:56 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux
+Linux precice-tests 5.15.0-185-generic #195-Ubuntu SMP Fri Jun 19 17:11:50 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux
 
 
 ### lscpu


### PR DESCRIPTION
Having https://github.com/precice/tutorials/issues/827 merged, we can now add the alternative variants of the `partitioned-pipe-multiscale` and of the `water-hammer` cases to the system tests.

While there are four possible combinations (`1d1d`, `1d3d`, `3d1d`, `3d3d`), the `1d3d` and `3d1d` are enough to cover the interesting cases.

Related to https://github.com/precice/tutorials/issues/448

TODO: Generate reference results and test.