### PR TITLE
Fix flow-over-heated-plate/solid-dunefem for newer ufl versions

### DIFF
--- a/changelog-entries/864.md
+++ b/changelog-entries/864.md
@@ -1,0 +1,1 @@
+- Fix flow-over-heated-plate/solid-dunefem for newer ufl versions and raise the minimum dune-fem requirement [#864](https://github.com/precice/tutorials/pull/864)

--- a/flow-over-heated-plate/solid-dunefem/requirements.txt
+++ b/flow-over-heated-plate/solid-dunefem/requirements.txt
@@ -1,2 +1,2 @@
-dune-fem>=2.8
+dune-fem>=2.11   # Known to work with 2.11.0.5, 2.12.0.2
 pyprecice~=3.0

--- a/flow-over-heated-plate/solid-dunefem/solid.py
+++ b/flow-over-heated-plate/solid-dunefem/solid.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     space = solutionSpace(mesh, order=1)
     u = ufl.TrialFunction(space)
     v = ufl.TestFunction(space)
-    x = ufl.SpatialCoordinate(ufl.triangle)
+    x = ufl.SpatialCoordinate(space)
     n = ufl.FacetNormal(space)
 
     u0 = uflFunction(mesh, name="u0", order=space.order,


### PR DESCRIPTION
Fixes https://github.com/precice/tutorials/issues/863 by replacing:

```diff
- x = ufl.SpatialCoordinate(ufl.triangle)
+ x = ufl.SpatialCoordinate(space)
```

following the [dune-fem demo](https://gitlab.dune-project.org/dune-fem/dune-fem/-/blob/master/pydemo/testthreading.py).

I am not sure why this was originally a `ufl.triange` (#274, FYI @NiklasKotarsky @uekerman), but the case seems to work and produce the expected results.

This PR also bumps the minimum dune-fem version to 2.11, since older versions do not build anymore (see https://github.com/precice/tutorials/issues/863#issue-4826476718). I have tested with the latest revisions of both 2.11 and 2.12 and added a comment in the `requirements.txt`.

## Checklist

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
