### PR TITLE
Add dune-fem to the system tests

### DIFF
--- a/flow-over-heated-plate/metadata.yaml
+++ b/flow-over-heated-plate/metadata.yaml
@@ -19,11 +19,11 @@ cases:
     run: ./run.sh
     component: su2-adapter
 
-  # solid-dunefem:
-  #   partitipant: Solid
-  #   directory: ./solid-dunefem
-  #   run: ./run.sh
-  #   component: ?
+  solid-dunefem:
+    partitipant: Solid
+    directory: ./solid-dunefem
+    run: ./run.sh
+    component: python-bindings
 
   solid-fenics:
     participant: Solid

--- a/flow-over-heated-plate/metadata.yaml
+++ b/flow-over-heated-plate/metadata.yaml
@@ -20,7 +20,7 @@ cases:
     component: su2-adapter
 
   solid-dunefem:
-    partitipant: Solid
+    participant: Solid
     directory: ./solid-dunefem
     run: ./run.sh
     component: python-bindings

--- a/flow-over-heated-plate/reference-results/fluid-openfoam_solid-dunefem.tar.gz
+++ b/flow-over-heated-plate/reference-results/fluid-openfoam_solid-dunefem.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9a23ae8e12bd212ecdc793a97b329235b4421f139aff07c0f391dac44623c07
+size 218060

--- a/flow-over-heated-plate/reference-results/reference_results.metadata
+++ b/flow-over-heated-plate/reference-results/reference_results.metadata
@@ -11,7 +11,7 @@ We also include some information on the machine used to generate them
 
 | name | time | sha256 |
 |------|------|-------|
-| fluid-openfoam_solid-fenicsx.tar.gz | 2026-06-12 17:50:05 | b31adcb4938e92dd05418425329281f48a86575792fc5063a65f4ef03be058ae |
+| fluid-openfoam_solid-dunefem.tar.gz | 2026-07-07 11:23:40 | c9a23ae8e12bd212ecdc793a97b329235b4421f139aff07c0f391dac44623c07 |
 
 ## List of arguments used to generate the files
 
@@ -25,15 +25,16 @@ We also include some information on the machine used to generate them
 | SU2_VERSION | 7.5.1 |
 | FENICS_ADAPTER_REF | v2.3.0 |
 | FENICSX_ADAPTER_REF | v1.0.1 |
+| FMI_RUNNER_REF | v0.2.1 |
 | CALCULIX_ADAPTER_REF | v2.20.1 |
 | DEALII_ADAPTER_REF | a421d92 |
 | DUMUX_ADAPTER_REF | 3f3f54f |
 | MICRO_MANAGER_REF | v0.10.1 |
 | OPENFOAM_ADAPTER_REF | 2c3062c |
-| PRECICE_REF | v3.4.1 |
-| PYTHON_BINDINGS_REF | v3.4.0 |
+| PRECICE_REF | b770460f2447b94da430086085d6b424e7c073e9 |
+| PYTHON_BINDINGS_REF | 1a469788eec0a3de1a00691bdf5e5b0b25a2ae97 |
 | SU2_ADAPTER_REF | 5abe79b |
-| TUTORIALS_REF | c1c5b4a3b044b5401d06f933204ff41e3252cedc |
+| TUTORIALS_REF | 067d7e4eee971c20e289ee6c538a4e3dfac4a3fb |
 | PRECICE_PRESET | production-audit |
 | PRECICE_UID | 1003 |
 | PRECICE_GID | 1003 |
@@ -41,7 +42,7 @@ We also include some information on the machine used to generate them
 
 ### uname -a
 
-Linux precice-tests 5.15.0-179-generic #189-Ubuntu SMP Tue May 5 18:20:56 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux
+Linux precice-tests 5.15.0-185-generic #195-Ubuntu SMP Fri Jun 19 17:11:50 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux
 
 
 ### lscpu

--- a/tools/tests/reference_versions.yaml
+++ b/tools/tests/reference_versions.yaml
@@ -23,7 +23,7 @@ OPENFOAM_ADAPTER_REF: "2c3062c" # develop, May 27, 2026
 PRECICE_REF: "v3.4.1"
 PYTHON_BINDINGS_REF: "v3.4.0"
 SU2_ADAPTER_REF: "5abe79b"      # develop, May 27, 2026
-TUTORIALS_REF: "develop"
+TUTORIALS_REF: "dune-tests"
 
 # Additional settings
 PRECICE_PRESET: "production-audit"

--- a/tools/tests/reference_versions.yaml
+++ b/tools/tests/reference_versions.yaml
@@ -23,7 +23,7 @@ OPENFOAM_ADAPTER_REF: "2c3062c" # develop, May 27, 2026
 PRECICE_REF: "v3.4.1"
 PYTHON_BINDINGS_REF: "v3.4.0"
 SU2_ADAPTER_REF: "5abe79b"      # develop, May 27, 2026
-TUTORIALS_REF: "dune-tests"
+TUTORIALS_REF: "develop"
 
 # Additional settings
 PRECICE_PRESET: "production-audit"

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -868,4 +868,4 @@ test_suites:
 
   selected:
     tutorials:
-      - *flow-over-heated-plate_fluid-openfoam_solid-dunefem
+      - *elastic-tube-1d_fluid-python_solid-python

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -140,6 +140,13 @@ test_suites:
 
   flow-over-heated-plate:
     tutorials:
+      - &flow-over-heated-plate_fluid-openfoam_solid-dunefem
+        path: flow-over-heated-plate
+        case_combination:
+         - fluid-openfoam
+         - solid-dunefem
+        timeout: 1200
+        reference_result: ./flow-over-heated-plate/reference-results/fluid-openfoam_solid-dunefem.tar.gz
       - &flow-over-heated-plate_fluid-openfoam_solid-fenics
         path: flow-over-heated-plate
         case_combination:
@@ -705,6 +712,7 @@ test_suites:
   extra:
     tutorials:
       - *channel-transport_fluid-nutils_transport-nutils
+      - *flow-over-heated-plate_fluid-openfoam_solid-dunefem
       - *partitioned-heat-conduction_dirichlet-nutils_neumann-nutils
       - *perpendicular-flap_fluid-nutils_solid-calculix
       - *perpendicular-flap_fluid-openfoam_solid-nutils
@@ -860,4 +868,4 @@ test_suites:
 
   selected:
     tutorials:
-      - *elastic-tube-1d_fluid-python_solid-python
+      - *flow-over-heated-plate_fluid-openfoam_solid-dunefem


### PR DESCRIPTION
This PR adds the flow-over-heated-plate/solid-dunefem case to the system tests.

This is based on the python-bindings component and install dunefem from PIP.

Generated reference results in https://github.com/precice/tutorials/actions/runs/28855678288

Related to https://github.com/precice/tutorials/issues/448 and https://github.com/precice/tutorials/pull/864
