### PR TITLE
Schedule running the extra system tests cases

### DIFF
--- a/.github/workflows/system-tests-extra.yml
+++ b/.github/workflows/system-tests-extra.yml
@@ -1,0 +1,13 @@
+name: System tests (extra cases)
+
+on:
+  schedule:
+    - cron: "0 3 * * WED"
+      timezone: "Europe/Berlin"
+
+jobs:
+  run-system-tests:
+    name: Trigger system tests
+    uses: precice/tutorials/.github/workflows/system-tests.yml@develop
+    with:
+      suites: 'extra'

--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -2,7 +2,7 @@ name: System tests (manual/nightly)
 
 on:
   schedule:
-    - cron: "0 4 * * *"
+    - cron: "0 2 * * *"
       timezone: "Europe/Berlin"
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
While most [tests](https://github.com/precice/tutorials/blob/develop/tools/tests/tests.yaml) are included in the `release` test suite, some take much longer to run, for which reason they are in the `extra` test suite. Most of these are also not adding much value compared to other cases, since they would mostly be affected by changes in their configuration. Still, we need to test them.

This PR adds a short workflow that triggers these extra test cases once per week. The day is arbitrary, but having a test fail in the middle of the week would be nicer than in the beginning/end of the week.

It also adjusts the execution of the `release` test suite to start 2h earlier, as the job always seems to finally start in the late morning. I understand that there is a lot of competition on triggering scheduled events on GHA, even though we are using our own runner.

This leads to:

- Every night at 2:00 (or asap): `release` test suite
- Every Wednesday night at 3:00 (or asap): `extra` test suite
- If `release` is not done by the time `extra` starts, it will just wait.

Testing the `extra` test suite in https://github.com/precice/tutorials/actions/runs/28859073065/job/85592833771