### PR TITLE
Split manual and scheduled system tests workflows

### DIFF
--- a/.github/workflows/system-tests-latest-components.yml
+++ b/.github/workflows/system-tests-latest-components.yml
@@ -1,78 +1,13 @@
-name: System tests (manual/nightly)
+name: System tests (nightly)
 
 on:
   schedule:
     - cron: "0 2 * * *"
       timezone: "Europe/Berlin"
-  workflow_dispatch:
-    inputs:
-      suites:
-        description: 'Test suites to execute (comma-separated,no-spaces)'
-        default: 'release'
-        required: true
-        type: string
-      system_tests_branch:
-        description: 'Use the system tests from'
-        default: 'develop'
-        type: string
-      ref-tutorials:
-        description: 'tutorials ref (default: latest develop)'
-        type: string
-      ref-precice:
-        description: 'precice ref'
-        type: string
-      ref-python-bindings:
-        description: 'python-bindings ref'
-        type: string
-      ref-calculix-adapter:
-        description: 'calculix-adapter ref'
-        type: string
-      ref-dealii-adapter:
-        description: 'dealii-adapter ref'
-        type: string
-      ref-dumux-adapter:
-        description: 'dumux-adapter ref'
-        type: string
-      ref-dune-adapter:
-        description: 'dune-adapter ref'
-        type: string
-      ref-fenics-adapter:
-        description: 'fenics-adapter ref'
-        type: string
-      ref-fenicsx-adapter:
-        description: 'fenicsx-adapter ref'
-        type: string
-      ref-fmi-runner:
-        description: 'fmi-runner ref'
-        type: string
-      ref-micro-manager:
-        description: 'micro-manager ref'
-        type: string
-      ref-openfoam-adapter:
-        description: 'openfoam-adapter ref'
-        type: string
-      ref-su2-adapter:
-        description: 'su2-adapter ref'
-        type: string
 
 jobs:
   run-system-tests:
     name: Trigger system tests
-    uses: precice/tutorials/.github/workflows/system-tests.yml@develop
+    uses: ./.github/workflows/system-tests.yml
     with:
-      suites: ${{ inputs.suites || 'release' }}
-      build_args: "TUTORIALS_REF:${{ inputs.ref-tutorials }},\
-        PRECICE_REF:${{ inputs.ref-precice }},\
-        PYTHON_BINDINGS_REF:${{ inputs.ref-python-bindings }},\
-        CALCULIX_ADAPTER_REF:${{ inputs.ref-calculix-adapter }},\
-        DEALII_ADAPTER_REF:${{ inputs.ref-dealii-adapter }},\
-        DUMUX_ADAPTER_REF:${{ inputs.ref-dumux-adapter }},\
-        DUNE_ADAPTER_REF:${{ inputs.ref-dune-adapter }},\
-        FENICS_ADAPTER_REF:${{ inputs.ref-fenics-adapter }},\
-        FENICSX_ADAPTER_REF:${{ inputs.ref-fenicsx-adapter }},\
-        FMI_RUNNER_REF:${{ inputs.ref-fmi-runner }},\
-        MICRO_MANAGER_REF:${{ inputs.ref-micro-manager }},\
-        OPENFOAM_ADAPTER_REF:${{ inputs.ref-openfoam-adapter }},\
-        SU2_ADAPTER_REF:${{ inputs.ref-su2-adapter }}"
-      system_tests_branch: ${{ inputs.system_tests_branch || 'develop' }}
-      log_level: "INFO"
+      suites: ${{ 'release' }}

--- a/.github/workflows/system-tests-manual.yml
+++ b/.github/workflows/system-tests-manual.yml
@@ -1,0 +1,75 @@
+name: System tests (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      suites:
+        description: 'Test suites to execute (comma-separated,no-spaces)'
+        default: 'release'
+        required: true
+        type: string
+      system_tests_branch:
+        description: 'Use the system tests from'
+        default: 'develop'
+        type: string
+      ref-tutorials:
+        description: 'tutorials ref (default: latest develop)'
+        type: string
+      ref-precice:
+        description: 'precice ref'
+        type: string
+      ref-python-bindings:
+        description: 'python-bindings ref'
+        type: string
+      ref-calculix-adapter:
+        description: 'calculix-adapter ref'
+        type: string
+      ref-dealii-adapter:
+        description: 'dealii-adapter ref'
+        type: string
+      ref-dumux-adapter:
+        description: 'dumux-adapter ref'
+        type: string
+      ref-dune-adapter:
+        description: 'dune-adapter ref'
+        type: string
+      ref-fenics-adapter:
+        description: 'fenics-adapter ref'
+        type: string
+      ref-fenicsx-adapter:
+        description: 'fenicsx-adapter ref'
+        type: string
+      ref-fmi-runner:
+        description: 'fmi-runner ref'
+        type: string
+      ref-micro-manager:
+        description: 'micro-manager ref'
+        type: string
+      ref-openfoam-adapter:
+        description: 'openfoam-adapter ref'
+        type: string
+      ref-su2-adapter:
+        description: 'su2-adapter ref'
+        type: string
+
+jobs:
+  run-system-tests:
+    name: Trigger system tests
+    uses: ./.github/workflows/system-tests.yml
+    with:
+      suites: ${{ inputs.suites || 'release' }}
+      build_args: "TUTORIALS_REF:${{ inputs.ref-tutorials }},\
+        PRECICE_REF:${{ inputs.ref-precice }},\
+        PYTHON_BINDINGS_REF:${{ inputs.ref-python-bindings }},\
+        CALCULIX_ADAPTER_REF:${{ inputs.ref-calculix-adapter }},\
+        DEALII_ADAPTER_REF:${{ inputs.ref-dealii-adapter }},\
+        DUMUX_ADAPTER_REF:${{ inputs.ref-dumux-adapter }},\
+        DUNE_ADAPTER_REF:${{ inputs.ref-dune-adapter }},\
+        FENICS_ADAPTER_REF:${{ inputs.ref-fenics-adapter }},\
+        FENICSX_ADAPTER_REF:${{ inputs.ref-fenicsx-adapter }},\
+        FMI_RUNNER_REF:${{ inputs.ref-fmi-runner }},\
+        MICRO_MANAGER_REF:${{ inputs.ref-micro-manager }},\
+        OPENFOAM_ADAPTER_REF:${{ inputs.ref-openfoam-adapter }},\
+        SU2_ADAPTER_REF:${{ inputs.ref-su2-adapter }}"
+      system_tests_branch: ${{ inputs.system_tests_branch || 'develop' }}
+      log_level: "INFO"

--- a/.github/workflows/system-tests-nightly.yml
+++ b/.github/workflows/system-tests-nightly.yml
@@ -10,4 +10,4 @@ jobs:
     name: Trigger system tests
     uses: ./.github/workflows/system-tests.yml
     with:
-      suites: ${{ 'release' }}
+      suites: 'release'

--- a/.github/workflows/system-tests-pr.yml
+++ b/.github/workflows/system-tests-pr.yml
@@ -8,7 +8,7 @@ jobs:
   run-system-tests:
     name: Trigger system tests
     if: ${{ github.event.label.name == 'trigger-system-tests' }}
-    uses: precice/tutorials/.github/workflows/system-tests.yml@develop
+    uses: ./.github/workflows/system-tests.yml
     with:
       suites: release
       build_args: "TUTORIALS_REF:${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/system-tests-weekly.yml
+++ b/.github/workflows/system-tests-weekly.yml
@@ -1,4 +1,4 @@
-name: System tests (extra cases)
+name: System tests (weekly - extra)
 
 on:
   schedule:
@@ -8,6 +8,6 @@ on:
 jobs:
   run-system-tests:
     name: Trigger system tests
-    uses: precice/tutorials/.github/workflows/system-tests.yml@develop
+    uses: ./.github/workflows/system-tests.yml
     with:
       suites: 'extra'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # preCICE tutorials
 
 [![System tests (nightly)](https://github.com/precice/tutorials/actions/workflows/system-tests-nightly.yml/badge.svg)](https://github.com/precice/tutorials/actions/workflows/system-tests-nightly.yml)
+[![System tests (weekly - extra)](https://github.com/precice/tutorials/actions/workflows/system-tests-weekly.yml/badge.svg)](https://github.com/precice/tutorials/actions/workflows/system-tests-weekly.yml)
 
 > [!IMPORTANT]  
 > This repository is aimed for development purposes and the default branch is `develop`. If you want to use the tutorials, switch to the [`master` branch](https://github.com/precice/tutorials/tree/master) or download the latest [release](https://github.com/precice/tutorials/releases).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # preCICE tutorials
 
-[![System tests (latest components)](https://github.com/precice/tutorials/actions/workflows/system-tests-latest-components.yml/badge.svg)](https://github.com/precice/tutorials/actions/workflows/system-tests-latest-components.yml)
+[![System tests (nightly)](https://github.com/precice/tutorials/actions/workflows/system-tests-nightly.yml/badge.svg)](https://github.com/precice/tutorials/actions/workflows/system-tests-nightly.yml)
 
 > [!IMPORTANT]  
 > This repository is aimed for development purposes and the default branch is `develop`. If you want to use the tutorials, switch to the [`master` branch](https://github.com/precice/tutorials/tree/master) or download the latest [release](https://github.com/precice/tutorials/releases).

--- a/changelog-entries/875.md
+++ b/changelog-entries/875.md
@@ -1,0 +1,1 @@
+- Split the `system-tests-latest-components.yml` into `system-tests-manual.yml` and `system-tests-nightly.yml`. Renamed `system-tests-extra.yml` to `system-tests-weekly.yml`. [#875](https://github.com/precice/tutorials/pull/875)

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -12,11 +12,11 @@ The tutorials repository hosts cases that need multiple components from the preC
 
 ## Running
 
-The main workflow for the user is executing the `systemtests.py` script, which is the same that the [GitHub Actions workflow](https://github.com/precice/tutorials/actions/workflows/system-tests-latest-components.yml) executes. Depending on the options given to the script, it reads in the respective metadata files and generates `docker-compose.yaml` files that can start a fully-defined coupled simulation. For arguments that are not provided, default values from `components.yaml` are used.
+The main workflow for the user is executing the `systemtests.py` script, which is the same that the [GitHub Actions workflow](https://github.com/precice/tutorials/actions/workflows/system-tests.yml) executes. Depending on the options given to the script, it reads in the respective metadata files and generates `docker-compose.yaml` files that can start a fully-defined coupled simulation. For arguments that are not provided, default values from `components.yaml` are used.
 
-### Manual and nightly runs on GitHub
+### Manual and scheduled runs on GitHub
 
-The [System tests (manual/nightly)](https://github.com/precice/tutorials/actions/workflows/system-tests-latest-components.yml) workflow executes the `release` test suite nightly and can also be triggered manually.
+The [System tests (manual)](https://github.com/precice/tutorials/actions/workflows/system-tests-manual.yml) workflow can execute any test suite (default: `release`) with any versions of the involved components (default: latest development branches).
 
 On the workflow page, click `Run workflow`. The default values will execute the `release` test suite using the latest `develop` branches of every component. If you want to override the version of some component, specify it in the respective field. Commit hashes, branches, and tags are all accepted. Branches and tags will get automatically resolved to their current commit on GitHub before starting any test, and all tests will use the same version of any common component.
 
@@ -31,6 +31,8 @@ The available test suites are found in [`tests.yaml`](https://github.com/precice
 
 The `Use workflow from` is a default option of GitHub Actions that concerns the GHA workflow file itself.
 
+The [System tests (nightly)](https://github.com/precice/tutorials/actions/workflows/system-tests-nightly.yml) executes the `release` test suite every night. The [System tests (weekly)](https://github.com/precice/tutorials/actions/workflows/system-tests-nightly.yml) executes the `extra` test suite once per week.
+
 ### Running from a pull request
 
 Several repositories include a workflow that allows triggering the system tests by adding the `trigger-system-tests` label to the pull request. The event is triggered only at the moment of adding the label, so you need to remove the label and add it again if needed.
@@ -42,13 +44,13 @@ See the [system tests workflow in the OpenFOAM adapter](https://github.com/preci
 The [GitHub CLI](https://cli.github.com/) allows triggering workflows of a GitHub project. For example:
 
 ```bash
-gh workflow run system-tests-latest-components.yml -f suites=release
+gh workflow run system-tests-manual.yml -f suites=release
 ```
 
 More arguments are available, for example:
 
 ```bash
-gh workflow run system-tests-latest-components.yml -f suites=release -f build_args="PLATFORM:ubuntu2404,PRECICE_REF:develop" -f log_level="DEBUG" --ref=develop
+gh workflow run system-tests-manual.yml -f suites=release -f build_args="PLATFORM:ubuntu2404,PRECICE_REF:develop" -f log_level="DEBUG" --ref=develop
 ```
 
 The `build_args` override the defaults set in `tools/tests/components.yaml`.
@@ -214,7 +216,7 @@ To add a new component, a few changes are needed:
 
 1. In the `components.yaml`, add a new component, defining all the parameters that it might need.
     - Add these parameters into the `reference_versions.yaml`.
-    - Add fields for these parameters into the `system-tests-latest-components.yml` workflow.
+    - Add fields for these parameters into the `system-tests-manual.yml` workflow.
 2. In the `dockerfiles/<platform>/Dockerfile`, define a new stage for building your new component. Use the parameters you defined above.
     - Defining a `<component>_PR` variable will let you integrate the system tests into the respective component repository.
 3. In the `component_templates.yaml`, define a component template. These are Jinja templates that are used by Docker Compose, and the main detail is how to run a simulation using that component.
@@ -258,7 +260,9 @@ Metadata and workflow/script files:
 
 - `.github/workflows/`
   - `system-tests.yml`: workflow for running the tests, triggered by other workflows (e.g., other repositories)
-  - `system-tests-latest-components.yml`: manual triggering front-end for `system-tests.yml`
+  - `system-tests-manual.yml`: manual triggering front-end for `system-tests.yml`
+  - `system-tests-nightly.yml`: scheduled run of `system-tests.yml` (every night)
+  - `system-tests-weekly.yml`: scheduled run of `system-tests.yml` (once per week)
 - `flow-over-a-heated-plate/`
   - `fluid-openfoam/`
     - `run.sh`: describes how to execute the respective case

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -31,7 +31,7 @@ The available test suites are found in [`tests.yaml`](https://github.com/precice
 
 The `Use workflow from` is a default option of GitHub Actions that concerns the GHA workflow file itself.
 
-The [System tests (nightly)](https://github.com/precice/tutorials/actions/workflows/system-tests-nightly.yml) executes the `release` test suite every night. The [System tests (weekly)](https://github.com/precice/tutorials/actions/workflows/system-tests-nightly.yml) executes the `extra` test suite once per week.
+The [System tests (nightly)](https://github.com/precice/tutorials/actions/workflows/system-tests-nightly.yml) executes the `release` test suite every night. The [System tests (weekly)](https://github.com/precice/tutorials/actions/workflows/system-tests-weekly.yml) executes the `extra` test suite once per week.
 
 ### Running from a pull request
 


### PR DESCRIPTION
The [latest components workflow](https://github.com/precice/tutorials/actions/workflows/system-tests-latest-components.yml) is currently being executed both every night and manually.

Since the manual runs often fail (as they are meant to when debugging), status badges such as the one in the [preCICE repository](https://github.com/precice/precice/blob/develop/docs/README.md) are sometimes reporting a failure that does not correspond to the scheduled run. Moreover, looking back at the history (to see when something started failing) is complicated.

This PR:

- splits the `system-tests-latest-components.yml` to `system-tests-manual.yml` and `system-tests-nightly.yml`,
- renames the `system-tests-extra.yml` to `system-tests-weekly.yml` for consistency,
- replaces the triggering of workflows from absolute paths+branch to relative paths, hoping to make debugging of the workflows easier:

```diff
- uses: precice/tutorials/.github/workflows/system-tests.yml@develop
+ uses: ./.github/workflows/system-tests.yml
```

@PranjalManhgaye since I cannot easily test before merging, do you see anything I missed / anything wrong?

## Checklist

- [x] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
