### PR TITLE
Add a test suite for the python bindings

### DIFF
--- a/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -108,7 +108,7 @@ WORKDIR /home/precice
 
 # Builds the precice python bindings for python3
 # Installs also matplotlib as it is needed for the elastic-tube 1d fluid-python participant.
-RUN git clone https://github.com/precice/python-bindings.git precice && \
+RUN git clone https://github.com/precice/python-bindings.git python-bindings && \
     cd python-bindings && \
     if [ -n "${PYTHON_BINDINGS_PR}" ]; then git fetch origin pull/${PYTHON_BINDINGS_PR}/head; fi && \
     git checkout ${PYTHON_BINDINGS_REF} && \

--- a/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -100,15 +100,21 @@ ENV CMAKE_PREFIX_PATH="/home/precice/.local"
 
 
 FROM precice AS python_bindings
+ARG PYTHON_BINDINGS_PR
 ARG PYTHON_BINDINGS_REF
 
 USER precice
 WORKDIR /home/precice
+
 # Builds the precice python bindings for python3
 # Installs also matplotlib as it is needed for the elastic-tube 1d fluid-python participant.
-RUN python3 -m venv /home/precice/venv && \
+RUN git clone https://github.com/precice/python-bindings.git precice && \
+    cd python-bindings && \
+    if [ -n "${PYTHON_BINDINGS_PR}" ]; then git fetch origin pull/${PYTHON_BINDINGS_PR}/head; fi && \
+    git checkout ${PYTHON_BINDINGS_REF} && \
+    python3 -m venv /home/precice/venv && \
     . /home/precice/venv/bin/activate && \
-    pip3 install git+https://github.com/precice/python-bindings.git@${PYTHON_BINDINGS_REF} && \
+    pip3 install . && \
     pip3 install matplotlib 
 ### end of python_bindings stage ###
 

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -894,6 +894,7 @@ test_suites:
   python-bindings:
     tutorials:
       - *elastic-tube-1d_fluid-cpp_solid-cpp
+      - *oscillator_mass-left-fmi_mass-right-fmi
       - *partitioned-heat-conduction_dirichlet-fenicsx_neumann-fenicsx
       - *partitioned-heat-conduction_dirichlet-nutils_neumann-nutils
       - *perpendicular-flap_fluid-su2_solid-fenics

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -891,6 +891,14 @@ test_suites:
       - *partitioned-heat-conduction-mixedbc_left-openfoam_right-openfoam
       - *partitioned-heat-conduction-robin_left-openfoam_right-openfoam
 
+  python-bindings:
+    tutorials:
+      - *elastic-tube-1d_fluid-cpp_solid-cpp
+      - *partitioned-heat-conduction_dirichlet-fenicsx_neumann-fenicsx
+      - *partitioned-heat-conduction_dirichlet-nutils_neumann-nutils
+      - *perpendicular-flap_fluid-su2_solid-fenics
+      - *two-scale-heat-conduction_macro-dumux_micro-dumux
+
   solids4foam:
     tutorials:
       - *perpendicular-flap_fluid-openfoam_solid-solids4foam

--- a/tools/tests/tests.yaml
+++ b/tools/tests/tests.yaml
@@ -893,12 +893,12 @@ test_suites:
 
   python-bindings:
     tutorials:
-      - *elastic-tube-1d_fluid-cpp_solid-cpp
+      - *elastic-tube-1d_fluid-python_solid-python
       - *oscillator_mass-left-fmi_mass-right-fmi
       - *partitioned-heat-conduction_dirichlet-fenicsx_neumann-fenicsx
       - *partitioned-heat-conduction_dirichlet-nutils_neumann-nutils
       - *perpendicular-flap_fluid-su2_solid-fenics
-      - *two-scale-heat-conduction_macro-dumux_micro-dumux
+      - *two-scale-heat-conduction_macro-nutils_micro-nutils
 
   solids4foam:
     tutorials:


### PR DESCRIPTION
Adds a system tests test suite for the Python bindings, covering:

- the elastic-tube-1d
- Nutils (from the `partitioned-heat-conduction`)
- FEniCS
- FEniCSx
- FMI Runner
- SU2
- Micro-Manager

@IshaanDesai do I miss anything?