### PR TITLE
Add baseline system-test coverage matrix for #448

### DIFF
--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -155,8 +155,11 @@ Fieldcompare requires reference results in the artifact. If not already unpacked
 ### Adding new tests
 
 Tests and test suites are defined in [`tests.yaml`](https://github.com/precice/tutorials/blob/develop/tools/tests/tests.yaml). By convention, every tutorial defines a test suite with the same name as its directory, and several test cases using combinations of the available participants. These test cases are later referenced by other test suites: these are typically the `release` and the test suites of different tested components.
+For a quick coverage overview while planning additions, see
+`tools/tests/system-tests-coverage-matrix.md` (tracked in
+[#448](https://github.com/precice/tutorials/issues/448)).
 
-The available cases are listed in the `metadata.yaml` of each tutorial. To add a new tutorial case as a test, add it to `metadata.yaml` and then define a test using it. Include that test in the relevant test suites.
+The available cases are listed in the `metadata.yaml` of each tutorial. To add a new tutorial case as a test, add it to `metadata.yaml` and then define a test using it. Include that test in the relevant test suites. To add a new tutorial case as a test, add it to `metadata.yaml` and then define a test using it. Include that test in the relevant test suites.
 
 Use the `max_time` or `max_time_windows` parameters to restrict the runtime of the test to the first few coupling time windows, to save time. Aim for a runtime of less than a minute (assuming cached components), if possible.
 

--- a/tools/tests/system-tests-coverage-matrix.md
+++ b/tools/tests/system-tests-coverage-matrix.md
@@ -1,0 +1,62 @@
+# System Tests Coverage Matrix (Baseline)
+
+Concrete tracking artifact for [#448](https://github.com/precice/tutorials/issues/448).
+This file complements `tools/tests/tests.yaml` and is intentionally easy to maintain.
+
+- Last sync: 2026-07-28
+- Generated from: `tests.yaml`, tutorial `metadata.yaml`, issue `#448`
+
+## Status legend
+
+- `Included`: explicitly covered in `tests.yaml` (typically in `release_test`).
+- `Partial`: test exists, but regression/reference coverage is incomplete.
+- `Missing`: tutorial cases exist, but are not in release coverage yet.
+- `Blocked`: known external blocker (license, unmaintained dependency, etc.).
+- `Needs verification`: listed in issue discussion, but no direct suite evidence recorded here yet.
+
+## Component/feature coverage
+
+| Component / feature | Status | Source of truth | Current evidence | Next step / note |
+| --- | --- | --- | --- | --- |
+| bare (preCICE core only) | Included | `tests.yaml` | `quickstart` (`fluid-openfoam` + `solid-cpp`), `elastic-tube-1d` (`fluid-cpp` + `solid-cpp`) in `release_test` | Keep as baseline |
+| Python bindings | Included | `tests.yaml` | `elastic-tube-1d` (`fluid-python`, `solid-python`) in `release_test` | Keep as baseline |
+| OpenFOAM adapter | Included | `tests.yaml` | `quickstart`, `flow-over-heated-plate`, `perpendicular-flap`, `multiple-perpendicular-flaps` | Track partial external/monolithic variants separately |
+| CalculiX adapter | Included | `tests.yaml` | `perpendicular-flap`, `heat-exchanger-simplified` | Keep as baseline |
+| deal.II adapter | Included | `tests.yaml` | `perpendicular-flap`, `multiple-perpendicular-flaps` | Keep as baseline |
+| FEniCS adapter | Included | `tests.yaml` + issue `#448` notes | `flow-over-heated-plate`, `perpendicular-flap` in `fenics_test`/`release_test` | `elastic-tube-3d` OpenFOAM/FEniCS combo still noted as problematic |
+| DUNE / DUNE-FEM / DuMux adapters | Included | `tests.yaml` | `free-flow-over-porous-media`, `two-scale-heat-conduction` suites | Keep sensitivity/tolerance notes reviewed |
+| Micro-Manager | Included | `tests.yaml` | `two-scale-heat-conduction` in `micro_manager_test` | Keep as baseline |
+| SU2 adapter | Included | `tests.yaml` | `perpendicular-flap` (`fluid-su2` + `solid-fenics`) | Keep as baseline |
+| FEniCSx adapter | Needs verification | issue `#448` | Mentioned as included in issue list | Add explicit suite/case evidence in next update |
+| FMI runner | Needs verification | issue `#448` | Mentioned as included in issue list | Add explicit suite/case evidence in next update |
+| MercuryDPM | Needs verification | issue `#448` | Mentioned as included in issue list | Add explicit suite/case evidence in next update |
+| ASTE | Partial | issue `#448` + [#877](https://github.com/precice/tutorials/issues/877) | `aste-turbine` noted as tested without full regression checks | Add/maintain robust regression references |
+| Julia bindings | Missing | issue `#448` | `resonant-circuit/*-julia` cases listed in issue | Land version override support ([#886](https://github.com/precice/tutorials/pull/886)) |
+| Rust bindings | Missing | tutorial metadata + issue `#448` | `elastic-tube-1d` includes `fluid-rust`, `solid-rust` in metadata | Land version override support ([#885](https://github.com/precice/tutorials/pull/885)) |
+| G+Smo adapter (external) | Missing | issue `#448` | `partitioned-heat-conduction*`, `perpendicular-flap-stress` listed in issue | Add executable-path based integration workflow |
+| MATLAB bindings | Blocked | issue `#448` | listed in issue | Needs licensed runner |
+| code_aster adapter | Blocked | issue `#448` + [code_aster-adapter#29](https://github.com/precice/code_aster-adapter/issues/29) | listed in issue | Unmaintained adapter |
+
+## Regression coverage gaps explicitly called out in #448
+
+| Case group | Status | Source of truth | Note |
+| --- | --- | --- | --- |
+| `aste-turbine` | Partial | issue `#448` | Tested, but full regression checks still incomplete |
+| external heat-conduction OpenFOAM variants | Partial | issue `#448` | Listed as external cases without reference results |
+| monolithic variants (`partitioned-burgers-1d`, `partitioned-pipe-two-phase`) | Partial | issue `#448` | Listed as tested without full regression checks |
+
+## Quick update workflow
+
+Run these before updating this file:
+
+```bash
+python tools/tests/print_test_suites.py
+python tools/tests/print_metadata.py
+```
+
+Then update only:
+
+1. `Status`
+2. `Current evidence`
+3. `Next step / note`
+4. `Last sync` date


### PR DESCRIPTION
This PR adds a baseline system-test coverage matrix for [#448](https://github.com/precice/tutorials/issues/448), as part of my planned GSoC work on improving system-test coverage and developer experience.

The new file `tools/tests/system-tests-coverage-matrix.md` tracks:

- which `components/features` are currently covered by system tests
- known gaps (Missing, Partial, Blocked, Needs verification)
- a simple update workflow for keeping the matrix current
- I also linked this matrix from `tools/tests/README.md` so contributors can use it while planning new test suites.

This is intentionally a documentation-only first step: it makes coverage visible and easier to maintain before adding more `tests/components`.

### Test plan

- Verified the matrix content against current tests.yaml and issue #448 

- Ran markdown/pre-commit checks locally

- Maintainer review of status labels and priority gaps