### PR TITLE
Update CALCULIX_ADAPTER_REF version to v2.20.2

### DIFF
--- a/tools/tests/reference_versions.yaml
+++ b/tools/tests/reference_versions.yaml
@@ -17,7 +17,7 @@ ASTE_REF: "4e32a4f"             # develop, July 12, 2026
 FENICS_ADAPTER_REF: "v2.3.0"
 FENICSX_ADAPTER_REF: "v1.0.1"
 FMI_RUNNER_REF: "v0.2.1"
-CALCULIX_ADAPTER_REF: "f5b117e" # fix-120, Aug  4, 2026 
+CALCULIX_ADAPTER_REF: "v2.20.2"
 DEALII_ADAPTER_REF: "a421d92"   # develop, May 27, 2026
 DUNE_ADAPTER_REF: "778d3bb"     # main,    July 8, 2026
 DUMUX_ADAPTER_REF: "3f3f54f"    # develop, May 27, 2026


### PR DESCRIPTION
Related to https://github.com/precice/calculix-adapter/pull/164 (and requires it).

The reference results have already been updated in #891