### PR TITLE
Migrade fieldcompare base image to own

### DIFF
--- a/tools/tests/docker-compose.field_compare.template.yaml
+++ b/tools/tests/docker-compose.field_compare.template.yaml
@@ -6,6 +6,8 @@ services:
     volumes:
       - {{ run_directory }}:/runs
     command:
+      - fieldcompare
+      - dir
       - /runs/{{ tutorial_folder }}/{{ precice_output_folder }}
       - /runs/{{ tutorial_folder }}/{{ reference_output_folder }}
       - "-rtol {{ tolerance }} --ignore-missing-reference-files --exclude-files reference-results-metadata.txt --ignore-unsupported-file-formats --diff"

--- a/tools/tests/docker-compose.field_compare.template.yaml
+++ b/tools/tests/docker-compose.field_compare.template.yaml
@@ -1,6 +1,8 @@
 services:
   field-compare:
-    build: https://github.com/dglaeser/fieldcompare-action.git # use the docker container provided by fieldcompare
+    build: 
+      context: {{ dockerfile_context }}
+      target: fieldcompare
     volumes:
       - {{ run_directory }}:/runs
     command:

--- a/tools/tests/docker-compose.field_compare.template.yaml
+++ b/tools/tests/docker-compose.field_compare.template.yaml
@@ -5,8 +5,8 @@ services:
       target: fieldcompare
     volumes:
       - {{ run_directory }}:/runs
-    command:
-      - fieldcompare dir
-      - /runs/{{ tutorial_folder }}/{{ precice_output_folder }}
-      - /runs/{{ tutorial_folder }}/{{ reference_output_folder }}
-      - "-rtol {{ tolerance }} --ignore-missing-reference-files --exclude-files reference-results-metadata.txt --ignore-unsupported-file-formats --diff"
+    command: >
+      /bin/bash -c "fieldcompare dir \
+      -rtol {{ tolerance }} --ignore-missing-reference-files --exclude-files reference-results-metadata.txt --ignore-unsupported-file-formats --diff \
+      /runs/{{ tutorial_folder }}/{{ precice_output_folder }} \
+      /runs/{{ tutorial_folder }}/{{ reference_output_folder }}"

--- a/tools/tests/docker-compose.field_compare.template.yaml
+++ b/tools/tests/docker-compose.field_compare.template.yaml
@@ -6,8 +6,7 @@ services:
     volumes:
       - {{ run_directory }}:/runs
     command:
-      - fieldcompare
-      - dir
+      - fieldcompare dir
       - /runs/{{ tutorial_folder }}/{{ precice_output_folder }}
       - /runs/{{ tutorial_folder }}/{{ reference_output_folder }}
       - "-rtol {{ tolerance }} --ignore-missing-reference-files --exclude-files reference-results-metadata.txt --ignore-unsupported-file-formats --diff"

--- a/tools/tests/docker-compose.field_compare.template.yaml
+++ b/tools/tests/docker-compose.field_compare.template.yaml
@@ -7,6 +7,7 @@ services:
       - {{ run_directory }}:/runs
     command: >
       /bin/bash -c "fieldcompare dir \
-      -rtol {{ tolerance }} --ignore-missing-reference-files --exclude-files reference-results-metadata.txt --ignore-unsupported-file-formats --diff \
+      --ignore-missing-reference-files --exclude-files reference-results-metadata.txt --ignore-unsupported-file-formats --diff \
+      -rtol {{ tolerance }} \
       /runs/{{ tutorial_folder }}/{{ precice_output_folder }} \
       /runs/{{ tutorial_folder }}/{{ reference_output_folder }}"

--- a/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -629,4 +629,3 @@ RUN git clone https://github.com/precice/openfoam-adapter.git &&\
 
 FROM python:3.14 AS fieldcompare
 RUN pip install fieldcompare[all]==0.5.0
-ENTRYPOINT ["fieldcompare", "dir"]

--- a/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -629,4 +629,4 @@ RUN git clone https://github.com/precice/openfoam-adapter.git &&\
 
 FROM python:3.14 AS fieldcompare
 RUN pip install fieldcompare[all]==0.5.0
-ENTRYPOINT ["fieldcompare", "dir", "$1", "$2", "$3"]
+ENTRYPOINT ["fieldcompare", "dir"]

--- a/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tools/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -569,7 +569,7 @@ RUN cd /home/precice/aste && \
 WORKDIR /home/precice
 
 
-FROM solids4foam/solids4foam:v2.3-openfoam-v2412-latest as solids4foam
+FROM solids4foam/solids4foam:v2.3-openfoam-v2412-latest AS solids4foam
 
 ARG PRECICE_UID=1000
 ARG PRECICE_GID=1000
@@ -626,3 +626,7 @@ RUN git clone https://github.com/precice/openfoam-adapter.git &&\
     if [ -n "${OPENFOAM_ADAPTER_PR}" ]; then git fetch origin pull/${OPENFOAM_ADAPTER_PR}/head; fi && \
     git checkout ${OPENFOAM_ADAPTER_REF} && \
     /usr/bin/openfoam2412 ./Allwmake -j $(nproc)
+
+FROM python:3.14 AS fieldcompare
+RUN pip install fieldcompare[all]==0.5.0
+ENTRYPOINT ["fieldcompare", "dir", "$1", "$2", "$3"]

--- a/tools/tests/systemtests/Systemtest.py
+++ b/tools/tests/systemtests/Systemtest.py
@@ -399,6 +399,13 @@ class Systemtest:
             'precice_output_folder': PRECICE_REL_OUTPUT_DIR,
             'reference_output_folder': PRECICE_REL_REFERENCE_DIR + "/" + self.reference_result.path.name.replace(".tar.gz", ""),
             'tolerance': self.tolerance,
+            # The dockerfile_context value inside the templates is only
+            # used as a build context path and does not need to be
+            # absolute – it will be resolved relative to the system test
+            # directory.
+            'dockerfile_context': (
+                Path("..") / "tools" / "tests" / "dockerfiles" / Path(self.params_to_use.get("PLATFORM"))
+            ),
         }
         jinja_env = Environment(loader=FileSystemLoader(PRECICE_TESTS_DIR))
         template = jinja_env.get_template(


### PR DESCRIPTION
Drops the dependency to https://github.com/dglaeser/fieldcompare-action (from where we only extracted the Dockerfile) by incorporating the respective Dockerfile into the Dockerfile of the tests.

Tested in https://github.com/precice/tutorials/actions/runs/31596594294