### PR TITLE
Add a notification step for failed tests

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -98,3 +98,11 @@ jobs:
         name: system_tests_run_${{ github.run_id }}_${{ github.run_attempt }}_full
         path: |
           runs/*
+    - name: Notify maintainers
+      if: ${{ failure() }}
+      uses: precice/notify-action@v1
+      with:
+        homeserver: ${{ vars.MATRIX_BOT_HOMESERVER }}
+        login: ${{ vars.MATRIX_BOT_LOGIN }}
+        password: ${{ secrets.MATRIX_BOT_PASSWORD }}
+        room_id: ${{ vars.MATRIX_BOT_ROOMID }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -21,6 +21,10 @@ on:
           description: 'TRUE or FALSE (FALSE -> Upload only when the workflow fails)'
           default: 'TRUE'
           type: string
+    secrets:
+      MATRIX_BOT_PASSWORD:
+        required: true
+
 jobs:
   run_system_tests:
     runs-on: [self-hosted, linux, x64, precice-tests-vm]


### PR DESCRIPTION
Adds a step to send a Matrix notification in case the system tests fail, similarly to https://github.com/precice/precice/blob/develop/.github/workflows/performance-regression.yml

I would like to further restrict this to scheduled runs only, but this is currently a reusable workflow and all other workflows call it (without further steps). Still, not too many manual tests should fail in the near future.

The needed secrets are already shared with this repository.