### PR TITLE
Improve system tests precice-config.xml modifications

### DIFF
--- a/heat-exchanger/precice-config.xml
+++ b/heat-exchanger/precice-config.xml
@@ -97,7 +97,7 @@
       from="Solid-to-Fluid-Outer" />
   </participant>
 
-  <m2n:sockets connector="Fluid-Inner" acceptor="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Solid" connector="Fluid-Inner" exchange-directory=".." />
 
   <coupling-scheme:parallel-explicit>
     <time-window-size value="1" />
@@ -129,7 +129,7 @@
       initialize="yes" />
   </coupling-scheme:parallel-explicit>
 
-  <m2n:sockets connector="Fluid-Outer" acceptor="Solid" exchange-directory=".." />
+  <m2n:sockets acceptor="Solid" connector="Fluid-Outer" exchange-directory=".." />
 
   <coupling-scheme:parallel-explicit>
     <time-window-size value="1" />

--- a/tests/docker-compose.template.yaml
+++ b/tests/docker-compose.template.yaml
@@ -14,7 +14,7 @@ services:
       cd '/runs/{{ tutorial_folder }}' && 
       sed -i 's|</log>|<sink type=\"file\" output=\"precice-debug.log\" filter=\"%Severity% >= debug and %Rank% = 0\" enabled=\"true\" /></log>|g' precice-config.xml &&
       sed -i 's%</participant>%<export:vtu directory=\"../{{precice_output_folder}}\" /> </participant>%g' precice-config.xml &&
-      sed -i 's|m2n:sockets |m2n:sockets network=\"eth0\" |g' precice-config.xml &&
+      sed -i 's|m2n:sockets acceptor|m2n:sockets network=\"eth0\" acceptor|g' precice-config.xml &&
       grep -r --include Cargo.toml '\"precice\" = \"3.2\"' -l . | xargs -r sed -i 's|\"precice\" = \"3.2\"|\"precice\" = { git = \"https://github.com/precice/rust-bindings\", rev = \"{{build_arguments.RUST_BINDINGS_REF}}\"}|g' &&
       grep -r --include run.sh 'Pkg.add(\"PreCICE\")' -l . | xargs -r  sed -i 's|Pkg.add(\"PreCICE\")|Pkg.add(url=\"https://github.com/precice/PreCICE.jl.git\",rev=\"{{build_arguments.JULIA_BINDINGS_REF}}\")|g' &&
       echo -e '\ngit+https://github.com/precice/fmi-runner@{{build_arguments.FMI_RUNNER_REF}}' | tee -a $(grep -r --include requirements.txt 'fmiprecice' -l .) > /dev/null &&


### PR DESCRIPTION
Fixes #902 by making the `sed` rule more specific. Running the same `sed` command again will return 0 without any modifications.

To make this work, all tutorials need to start with `<m2n:sockets acceptor` (i.e., define the `acceptor` before they define the `connector`). With the exception of the `heat-exchanger`, all the tutorials were doing this already, so I am also changing that tutorial. This leads to the same config.

Testing in https://github.com/precice/tutorials/actions/runs/31888384335 (passes, `rerun-system-test.sh` works)