### PR TITLE
Introduce case-specific run.sh scripts in deal.II tutorials

### DIFF
--- a/multiple-perpendicular-flaps/solid-downstream-dealii/run.sh
+++ b/multiple-perpendicular-flaps/solid-downstream-dealii/run.sh
@@ -1,1 +1,9 @@
-../../tools/run-dealii.sh
+#!/usr/bin/env bash
+set -e -u
+
+. ../../tools/log.sh
+exec > >(tee --append "$LOGFILE") 2>&1
+
+../../tools/run-dealii.sh "$@"
+
+close_log

--- a/multiple-perpendicular-flaps/solid-upstream-dealii/run.sh
+++ b/multiple-perpendicular-flaps/solid-upstream-dealii/run.sh
@@ -1,1 +1,9 @@
-../../tools/run-dealii.sh
+#!/usr/bin/env bash
+set -e -u
+
+. ../../tools/log.sh
+exec > >(tee --append "$LOGFILE") 2>&1
+
+../../tools/run-dealii.sh "$@"
+
+close_log

--- a/perpendicular-flap/solid-dealii/run.sh
+++ b/perpendicular-flap/solid-dealii/run.sh
@@ -1,1 +1,9 @@
-../../tools/run-dealii.sh
+#!/usr/bin/env bash
+set -e -u
+
+. ../../tools/log.sh
+exec > >(tee --append "$LOGFILE") 2>&1
+
+../../tools/run-dealii.sh "$@"
+
+close_log

--- a/turek-hron-fsi3/solid-dealii/run.sh
+++ b/turek-hron-fsi3/solid-dealii/run.sh
@@ -1,1 +1,9 @@
-../../tools/run-dealii.sh
+#!/usr/bin/env bash
+set -e -u
+
+. ../../tools/log.sh
+exec > >(tee --append "$LOGFILE") 2>&1
+
+../../tools/run-dealii.sh "$@"
+
+close_log


### PR DESCRIPTION
Closes #826 by replacing the symlinks to `run-dealii.sh` with case-specific `run.sh` scripts that call that.

The case-specific scripts also implement the usual logging we have in other tutorials.

The GitHub interface shows the changes in a strange way. All symlinks have been replaced by a `run.sh` file with the following content:

```bash
#!/usr/bin/env bash
set -e -u

. ../../tools/log.sh
exec > >(tee --append "$LOGFILE") 2>&1

../../tools/run-dealii.sh "$@"

close_log
```

and I have checked locally that they run normally.