### PR TITLE
Add a watchpoint to the breaking-dam-2d tutorial

### DIFF
--- a/breaking-dam-2d/plot-displacement.sh
+++ b/breaking-dam-2d/plot-displacement.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+if [ "${1:-}" = "" ]; then
+    echo "No target directory specified. Please specify the directory of the solid participant containing the watchpoint, e.g. ./plot-displacement.sh solid-fenics."
+    exit 1
+fi
+
+FILE="$1/precice-Solid-watchpoint-Flap-Tip.log"
+
+if [ ! -f "$FILE" ]; then
+    echo "Unable to locate the watchpoint file (precice-Solid-watchpoint-Flap-Tip.log) in the specified solid directory '${1}'. Make sure the specified directory matches the solid participant you used for the calculations."
+    exit 1
+fi
+ 
+gnuplot -p << EOF                                                               
+	set grid                                                                        
+	set title 'x-displacement of the flap tip'                                        
+	set xlabel 'time [s]'                                                           
+	set ylabel 'x-displacement [m]'                                                 
+	plot "$1/precice-Solid-watchpoint-Flap-Tip.log" using 1:4 with lines title "$1"
+EOF

--- a/breaking-dam-2d/precice-config.xml
+++ b/breaking-dam-2d/precice-config.xml
@@ -47,6 +47,7 @@
     <provide-mesh name="Solid-Mesh" />
     <read-data name="Force" mesh="Solid-Mesh" />
     <write-data name="Displacement" mesh="Solid-Mesh" />
+    <watch-point mesh="Solid-Mesh" name="Flap-Tip" coordinate="0.0;1.0" />
   </participant>
 
   <m2n:sockets acceptor="Fluid" connector="Solid" exchange-directory=".." />


### PR DESCRIPTION
This PR adds a watchpoint in the configuration and the respective script for the breaking-dam-2d (same as the one for `perpendicular-flap`).

The result is the following with OpenFOAM v2512 and CalculiX v2.20, but it might need to be updated for OpenFOAM v2606 (see https://github.com/precice/openfoam-adapter/pull/411):

<img width="640" height="480" alt="tutorials-breaking-dam-2d-watchpoint" src="https://github.com/user-attachments/assets/cae46fb7-d57e-4eec-b622-ed9052819c4b" />

Since this is currently very different than the one observed in OpenFOAM v2606, I am not adding it to the `images/` or `README.md`.

Further cleanup of all these plotting scripts is needed (see, e.g., https://github.com/precice/tutorials/issues/426).