### PR TITLE
Pin the Julia version

### DIFF
--- a/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -123,7 +123,7 @@ USER precice
 WORKDIR /home/precice
 
 RUN pipx install jill && \
-    jill install --confirm
+    jill install 1.12.6 --confirm
 ### end of julia_bindings stage ###
 
 


### PR DESCRIPTION
https://github.com/precice/tutorials/pull/886 added Julia to the system tests using [jill](https://github.com/abelsiqueira/jill). Two weeks ago, with the release of Julia 1.12.7, the Julia-based tests started [failing](https://github.com/precice/tutorials/actions/runs/32254325780) (could not install Julia, see also https://github.com/JuliaLang/julia/issues/62876).

This PR pins the Julia version to the latest one currently working, to avoid similar issues in the future. In any case, here we are mainly interested in detecting regressions introduced by the Julia bindings, not by the dependencies.

Testing in https://github.com/precice/tutorials/actions/runs/32947618905 -> The Julia installation works, but the test fails later for unrelated reasons (see https://github.com/precice/tutorials/pull/907#issuecomment-5421833465)