### PR TITLE
Fix git ref resolution for default build arguments and adjust logging

### DIFF
--- a/changelog-entries/909.md
+++ b/changelog-entries/909.md
@@ -1,0 +1,1 @@
+- Fixed `Systemtest.py` so default `_REF` build arguments from `components.yaml` are resolved to commit SHAs again after the per-component build-args change. [#909](https://github.com/precice/tutorials/pull/909)

--- a/changelog-entries/909.md
+++ b/changelog-entries/909.md
@@ -1,1 +1,1 @@
-- Fixed `Systemtest.py` so default `_REF` build arguments from `components.yaml` are resolved to commit SHAs again after the per-component build-args change. [#909](https://github.com/precice/tutorials/pull/909)
+- Fixed `Systemtest.py` so default `_REF` build arguments from `components.yaml` are resolved to commit SHAs again after the per-component build-args change. [#910](https://github.com/precice/tutorials/pull/910)

--- a/perpendicular-flap/metadata.yaml
+++ b/perpendicular-flap/metadata.yaml
@@ -11,7 +11,7 @@ cases:
     participant: Fluid
     directory: ./fluid-fake
     run: ./run.sh
-    component: bare
+    component: python-bindings
 
   fluid-nutils:
     participant: Fluid
@@ -53,7 +53,7 @@ cases:
     participant: Solid
     directory: ./solid-fake
     run: ./run.sh
-    component: bare
+    component: python-bindings
 
   solid-fenics:
     participant: Solid

--- a/tests/components.yaml
+++ b/tests/components.yaml
@@ -297,6 +297,9 @@ su2-adapter:
     TUTORIALS_REF:
       repository: https://github.com/precice/tutorials
       default: "develop"
+    PYTHON_BINDINGS_REF:
+      repository: https://github.com/precice/python-bindings
+      default: "develop"
     SU2_VERSION:
       default: "7.5.1"
     SU2_ADAPTER_REF:

--- a/tests/systemtests.py
+++ b/tests/systemtests.py
@@ -62,7 +62,7 @@ def main():
         if gh_actions:
             print("::endgroup::", flush=True)
 
-    logging.info(f"Setting up the tests to run... (might take a couple of minutes)")
+    logging.info(f"Configuring the tests to run... (might take a couple of minutes)")
 
     systemtests_to_run = []
     test_suites_to_execute = []

--- a/tests/systemtests.py
+++ b/tests/systemtests.py
@@ -62,6 +62,8 @@ def main():
         if gh_actions:
             print("::endgroup::", flush=True)
 
+    logging.info(f"Setting up the tests to run... (might take a couple of minutes)")
+
     systemtests_to_run = []
     test_suites_to_execute = []
     available_tutorials = Tutorials.from_path(PRECICE_TUTORIAL_DIR)

--- a/tests/systemtests/Systemtest.py
+++ b/tests/systemtests/Systemtest.py
@@ -290,7 +290,9 @@ class Systemtest:
         Previously, this function was also checking if all required parameters were provided, and was raising exceptions for parameters not provided and not having a default value. This check made adding optional parameters with empty defaults (e.g., the TUTORIALS_PR) complicated, and it was removed.
         """
         provided_arguments = self.arguments.arguments
+        explicit_cli_keys = frozenset(provided_arguments.keys())
         self.build_arguments_by_component = {}
+        resolved_ref_cache: Dict[Tuple[str, str], str] = {}
 
         for case in self.case_combination.cases:
             component = case.component
@@ -299,30 +301,39 @@ class Systemtest:
 
             component_args: Dict[str, str] = {}
             for param in component.parameters:
-                if param.key not in provided_arguments:
+                if param.key in explicit_cli_keys:
+                    value = provided_arguments[param.key]
+                elif (
+                    param.key in provided_arguments
+                    and len(provided_arguments[param.key]) == 40
+                ):
+                    value = provided_arguments[param.key]
+                else:
                     logging.info(
                         f"No argument provided for needed parameter {param.key} "
                         f"on component {component.name}. "
                         f"Substituting with {param.default}.")
                     value = param.default
-                else:
-                    value = provided_arguments[param.key]
 
-                if param.key.endswith("_REF") and param.key in provided_arguments:
+                if param.key.endswith("_REF") and param.repository and value:
                     logging.debug(
                         f"The parameter {param.key} on component {component.name} "
                         f"points to the repository {param.repository}.")
-                    # If a commit has already been resolved and added to the build
-                    # arguments, it will be propagated to the next test in the test suite.
-                    # To avoid resolving the same commit again, simply check if the key
-                    # has the same length as the output of _resolve_branch_ref_to_commit.
-                    # The whole process assumes that all components use the same refs.
-                    if value and len(value) == 40:
+                    # If a commit has already been resolved, it will be propagated to
+                    # the next test in the test suite. To avoid resolving the same
+                    # commit again, check if the value has the same length as the
+                    # output of _resolve_branch_ref_to_commit.
+                    cache_key = (str(param.repository), value)
+                    if len(value) == 40:
                         logging.debug(
                             f"Git ref {value} is 40 characters long and probably already a commit.")
-                    elif value and len(value) != 40:
+                    elif cache_key in resolved_ref_cache:
+                        value = resolved_ref_cache[cache_key]
+                    else:
                         value = self._resolve_branch_ref_to_commit(
                             param.repository, value)
+                        resolved_ref_cache[cache_key] = value
+                    if param.key in explicit_cli_keys:
                         provided_arguments[param.key] = value
 
                 component_args[param.key] = value

--- a/tests/systemtests/Systemtest.py
+++ b/tests/systemtests/Systemtest.py
@@ -294,7 +294,7 @@ class Systemtest:
         self.build_arguments_by_component = {}
         resolved_ref_cache: Dict[Tuple[str, str], str] = {}
 
-        logging.info(
+        logging.debug(
             f"Substituting default build arguments and resolving git refs for {self}.")
 
         for case in self.case_combination.cases:

--- a/tests/systemtests/Systemtest.py
+++ b/tests/systemtests/Systemtest.py
@@ -294,11 +294,15 @@ class Systemtest:
         self.build_arguments_by_component = {}
         resolved_ref_cache: Dict[Tuple[str, str], str] = {}
 
+        logging.info(
+            f"Substituting default build arguments and resolving git refs for {self}.")
+
         for case in self.case_combination.cases:
             component = case.component
             if component.name in self.build_arguments_by_component:
                 continue
 
+            logging.debug(f"Resolving build arguments for component {component.name}.")
             component_args: Dict[str, str] = {}
             for param in component.parameters:
                 if param.key in explicit_cli_keys:
@@ -309,7 +313,7 @@ class Systemtest:
                 ):
                     value = provided_arguments[param.key]
                 else:
-                    logging.info(
+                    logging.debug(
                         f"No argument provided for needed parameter {param.key} "
                         f"on component {component.name}. "
                         f"Substituting with {param.default}.")
@@ -540,7 +544,7 @@ class Systemtest:
 
             commit = git_remote_refs.split()[0]
             # The output assumes a URL of the form <repository>/commits/<commit>. Works for GitHub and Bitbucket.
-            logging.info(
+            logging.debug(
                 f"Resolved the git ref {ref} of the repository {repository} to {repository}/commits/{commit} .")
             return commit if commit else ref
         except Exception:

--- a/tests/systemtests/sources.py
+++ b/tests/systemtests/sources.py
@@ -79,7 +79,7 @@ def fetch_git_repo(url: str, ref: str, cache_dir: Path, subdir: str | None = Non
     checkout = cache_dir / key
 
     if checkout.exists():
-        logging.info(f"Using cached external git source {url} (ref {ref}) from {checkout}")
+        logging.debug(f"Using cached external git source {url} (ref {ref}) from {checkout}")
         try:
             subprocess.run(
                 ["git", "-C", str(checkout), "fetch", "origin", ref, "--depth", "1"],
@@ -98,7 +98,7 @@ def fetch_git_repo(url: str, ref: str, cache_dir: Path, subdir: str | None = Non
             shutil.rmtree(checkout, ignore_errors=True)
 
     if not checkout.exists():
-        logging.info(f"Fetching external git source {url} (ref {ref}) into {checkout}")
+        logging.debug(f"Fetching external git source {url} (ref {ref}) into {checkout}")
         result = subprocess.run(
             ["git", "clone", "--depth", "1", "--branch", ref, url, str(checkout)],
             capture_output=True,
@@ -130,14 +130,14 @@ def fetch_archive(url: str, cache_dir: Path, subdir: str | None = None) -> Path:
     extract_dir = cache_dir / key
 
     if extract_dir.exists():
-        logging.info(f"Using cached external archive {url} from {extract_dir}")
+        logging.debug(f"Using cached external archive {url} from {extract_dir}")
         _ensure_shell_scripts_executable(extract_dir)
         return extract_dir / subdir if subdir else extract_dir
 
     with tempfile.NamedTemporaryFile(delete=False, suffix=".tar.gz") as tmp:
         tmp_path = Path(tmp.name)
     try:
-        logging.info(f"Fetching external archive {url} into {extract_dir}")
+        logging.debug(f"Fetching external archive {url} into {extract_dir}")
         urllib.request.urlretrieve(url, tmp_path)
 
         extract_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Restore git ref resolution for default `_REF` build arguments from `components.yaml`
- Regression introduced in #907: resolution only ran when args were passed via CLI
- Cache resolved refs by `(repository, ref)`; preserve per-component different refs

Follow-up to nightly failures reported in https://github.com/precice/tutorials/pull/907

## Test plan
- [x] `python3 -m py_compile tests/systemtests/Systemtest.py`
- [x] Local smoke: fluid-fake/solid-fake, rust-bindings, SU2 adapter - refs resolve to 40-char SHAs
- [ ] Nightly system tests pass on GHA