### PR TITLE
Add a solids4foam solid participant to perpendicular-flap-stress

### DIFF
--- a/changelog-entries/913.md
+++ b/changelog-entries/913.md
@@ -1,0 +1,1 @@
+- Added a solids4foam solid participant to the `perpendicular-flap-stress` tutorial, reading `Stress` via the solids4foam `solidTraction` boundary condition.

--- a/perpendicular-flap-stress/README.md
+++ b/perpendicular-flap-stress/README.md
@@ -31,6 +31,8 @@ Solid participant:
 
 * G+Smo (perpendicular-flap-vertex-gismo). This solver includes both linear and nonlinear versions of the Newmark time integrator for time-dependent structural problems. The linear version iterates using a constant stiffness matrix. The nonlinear version iterates using an updated Jacobian matrix to account for material or geometric nonlinearity. By default, the solver runs in linear mode. To switch to nonlinear mode, add `--nonlinear` as option in `run.sh`. For more information, have a look at the [G+Smo adapter documentation](https://precice.org/adapter-gismo.html).
 
+* solids4foam (OpenFOAM). A linear-elastic, small-strain solid model, using the same flap geometry and material properties as the [perpendicular flap tutorial](https://precice.org/tutorials-perpendicular-flap.html). The `interface` patch uses the solids4foam `solidTraction` boundary condition, reading the coupled traction from the `solidTraction` field that the adapter fills. This requires solids4foam v2.2 or later and an OpenFOAM-preCICE adapter with support for reading `Stress` in solid participants. For more information, have a look at the [solids4foam documentation](https://solids4foam.github.io/).
+
 ## Running the simulation
 
 Open two separate terminals and start the desired fluid and solid participants by calling the respective run scripts `run.sh` located in the participants' directories. For example:
@@ -53,7 +55,7 @@ On the OpenFOAM side, you can open the `.foam` file with ParaView, or create VTK
 
 On the G+Smo side, you can open the `.pvd` file located in the `solid-gismo/output` folder using ParaView. If you prefer not to plot the simulation, simply edit the `run.sh` script and remove the  `--plot` option.
 
-As we defined a watchpoint on the 'Solid' participant at the flap tip (see `precice-config.xml`), we can plot it with gnuplot using the script `plot-displacement.sh.` You need to specify the directory of the selected solid participant as a command line argument, so that the script can pick-up the desired watchpoint file, e.g. `plot-displacement.sh solid-gismo`. The resulting graph shows the x displacement of the flap tip. You can modify the script to plot the force instead.
+As we defined a watchpoint on the 'Solid' participant at the flap tip (see `precice-config.xml`), we can plot it with gnuplot using the script `plot-displacement.sh.` You need to specify the directory of the selected solid participant as a command line argument, so that the script can pick-up the desired watchpoint file, e.g. `plot-displacement.sh solid-gismo` or `plot-displacement.sh solid-solids4foam`. The resulting graph shows the x displacement of the flap tip. You can modify the script to plot the force instead.
 
 ![Flap watchpoint](images/tutorials-perpendicular-flap-stress-displacement-watchpoint.png)
 

--- a/perpendicular-flap-stress/solid-solids4foam/0/D
+++ b/perpendicular-flap-stress/solid-solids4foam/0/D
@@ -1,0 +1,34 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volVectorField;
+    location    "0";
+    object      D;
+}
+
+dimensions      [0 1 0 0 0 0 0];
+
+internalField   uniform (0 0 0);
+
+boundaryField
+{
+    interface
+    {
+        type            solidTraction;
+        tractionField   solidTraction;
+        pressure        uniform 0;
+        value           uniform (0 0 0);
+    }
+    bottom
+    {
+        type            fixedDisplacement;
+        value           uniform (0 0 0);
+    }
+    frontAndBack
+    {
+        type            empty;
+    }
+}
+
+

--- a/perpendicular-flap-stress/solid-solids4foam/0/solidTraction
+++ b/perpendicular-flap-stress/solid-solids4foam/0/solidTraction
@@ -1,0 +1,32 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       volVectorField;
+    location    "0";
+    object      solidTraction;
+}
+
+dimensions      [1 -1 -2 0 0 0 0];
+
+internalField   uniform (0 0 0);
+
+boundaryField
+{
+    interface
+    {
+        type            calculated;
+        value           uniform (0 0 0);
+    }
+    bottom
+    {
+        type            calculated;
+        value           uniform (0 0 0);
+    }
+    frontAndBack
+    {
+        type            empty;
+    }
+}
+
+

--- a/perpendicular-flap-stress/solid-solids4foam/clean.sh
+++ b/perpendicular-flap-stress/solid-solids4foam/clean.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -e -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+. ../../tools/cleaning-tools.sh
+
+clean_openfoam .

--- a/perpendicular-flap-stress/solid-solids4foam/constant/dynamicMeshDict
+++ b/perpendicular-flap-stress/solid-solids4foam/constant/dynamicMeshDict
@@ -1,0 +1,10 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      dynamicMeshDict;
+}
+
+dynamicFvMesh   staticFvMesh;
+

--- a/perpendicular-flap-stress/solid-solids4foam/constant/g
+++ b/perpendicular-flap-stress/solid-solids4foam/constant/g
@@ -1,0 +1,12 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       uniformDimensionedVectorField;
+    location    "constant";
+    object      g;
+}
+
+dimensions      [0 1 -2 0 0 0 0];
+value           ( 0 0 0 );
+

--- a/perpendicular-flap-stress/solid-solids4foam/constant/mechanicalProperties
+++ b/perpendicular-flap-stress/solid-solids4foam/constant/mechanicalProperties
@@ -1,0 +1,21 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      mechanicalProperties;
+}
+
+planeStress no;
+
+mechanical
+(
+    rubber
+    {
+        type        linearElastic;
+        rho         rho [1 -3 0 0 0 0 0] 3000;
+        E           E [1 -1 -2 0 0 0 0] 4e6;
+        nu          nu [0 0 0 0 0 0 0] 0.3;
+    }
+);
+

--- a/perpendicular-flap-stress/solid-solids4foam/constant/physicsProperties
+++ b/perpendicular-flap-stress/solid-solids4foam/constant/physicsProperties
@@ -1,0 +1,12 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "constant";
+    object      physicsProperties;
+}
+
+type    solid;
+
+

--- a/perpendicular-flap-stress/solid-solids4foam/constant/solidProperties
+++ b/perpendicular-flap-stress/solid-solids4foam/constant/solidProperties
@@ -1,0 +1,25 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      solidProperties;
+}
+
+solidModel    linearGeometryTotalDisplacement;
+
+linearGeometryTotalDisplacementCoeffs
+{
+    // Maximum number of momentum correctors
+    nCorrectors     1000;
+
+    // Solution tolerance for displacement
+    solutionTolerance 1e-08;
+
+    // Alternative solution tolerance for displacement
+    alternativeTolerance 1e-08;
+
+    // Write frequency for the residuals
+    infoFrequency   100;
+}
+

--- a/perpendicular-flap-stress/solid-solids4foam/constant/solidProperties
+++ b/perpendicular-flap-stress/solid-solids4foam/constant/solidProperties
@@ -10,16 +10,38 @@ solidModel    linearGeometryTotalDisplacement;
 
 linearGeometryTotalDisplacementCoeffs
 {
-    // Maximum number of momentum correctors
-    nCorrectors     1000;
+    solutionAlgorithm PETScSNES;
 
-    // Solution tolerance for displacement
-    solutionTolerance 1e-08;
+    highOrderCoeffs
+    {
+        highOrderJacobian false;
+        highOrderResidual true;
 
-    // Alternative solution tolerance for displacement
-    alternativeTolerance 1e-08;
+        displacement
+        {
+            // Polynomial order of displacement field
+            polynomialOrder 3;
 
-    // Write frequency for the residuals
-    infoFrequency   100;
+            // Extra cells in minimum size stencil
+            faceStencilExtraCells 15;
+
+            // Weight function for least square systems
+            weightFunctionCoeffs
+            {
+                type radiallySymmetricExponential;
+                k 6;
+            }
+            calcConditionNumber false;
+        }
+    }
+
+    stabilisation
+    {
+        momentum
+        {
+            type        alpha;
+            scaleFactor 1.0;
+        }
+    }
 }
 

--- a/perpendicular-flap-stress/solid-solids4foam/run.sh
+++ b/perpendicular-flap-stress/solid-solids4foam/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+. ../../tools/log.sh
+exec > >(tee --append "$LOGFILE") 2>&1
+
+blockMesh
+
+../../tools/run-openfoam.sh "$@"
+. ../../tools/openfoam-remove-empty-dirs.sh && openfoam_remove_empty_dirs
+
+close_log

--- a/perpendicular-flap-stress/solid-solids4foam/system/blockMeshDict
+++ b/perpendicular-flap-stress/solid-solids4foam/system/blockMeshDict
@@ -1,0 +1,55 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      blockMeshDict;
+}
+
+scale 0.01;
+
+vertices
+(
+    (-5 0 0)
+    (5 0 0)
+    (5 100 0)
+    (-5 100 0)
+
+    (-5 0 100)
+    (5 0 100)
+    (5 100 100)
+    (-5 100 100)
+);
+
+blocks
+(
+    hex (0 1 2 3 4 5 6 7) (6 15 1) simpleGrading (1 1 1)
+);
+
+edges
+(
+);
+
+patches
+(
+    patch interface
+    (
+        (4 7 3 0)
+        (7 6 2 3)
+        (1 2 6 5)
+    )
+    patch bottom
+    (
+        (0 1 5 4)
+    )
+    empty frontAndBack
+    (
+        (3 2 1 0)
+        (4 5 6 7)
+    )
+);
+
+mergePatchPairs
+(
+);
+

--- a/perpendicular-flap-stress/solid-solids4foam/system/controlDict
+++ b/perpendicular-flap-stress/solid-solids4foam/system/controlDict
@@ -1,0 +1,49 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      controlDict;
+}
+
+application     solids4Foam;
+
+startFrom       startTime;
+
+startTime       0;
+
+stopAt          endTime;
+
+endTime         5;
+
+deltaT          0.01;
+
+writeControl    adjustableRunTime;
+
+writeInterval   0.1;
+
+purgeWrite      0;
+
+writeFormat     ascii;
+
+writePrecision  6;
+
+writeCompression off;
+
+timeFormat      general;
+
+timePrecision   6;
+
+libs ("libpreciceAdapterFunctionObject.so");
+functions
+{
+    preCICE_Adapter
+    {
+        type preciceAdapterFunctionObject;
+        errors strict; // Available since OpenFOAM v2012
+    }
+}
+
+
+

--- a/perpendicular-flap-stress/solid-solids4foam/system/decomposeParDict
+++ b/perpendicular-flap-stress/solid-solids4foam/system/decomposeParDict
@@ -1,0 +1,18 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      decomposeParDict;
+}
+
+numberOfSubdomains 4;
+
+method          simple;
+
+simpleCoeffs
+{
+    n               (1 4 1);
+    delta           0.001;
+}
+

--- a/perpendicular-flap-stress/solid-solids4foam/system/fvSchemes
+++ b/perpendicular-flap-stress/solid-solids4foam/system/fvSchemes
@@ -28,24 +28,16 @@ divSchemes
 
 laplacianSchemes
 {
-    default            none;
-    laplacian(DD,D)    Gauss linear corrected;
-    laplacian(DDD,DD)  Gauss linear corrected;
+    default            Gauss linear corrected;
 }
 
 snGradSchemes
 {
-    default            none;
-    snGrad(D)          corrected;
-    snGrad(DD)         corrected;
+    default            corrected;
 }
 
 interpolationSchemes
 {
-    default            none;
-    interpolate(impK)  linear;
-    interpolate(grad(D)) linear;
-    interpolate(grad(DD)) linear;
-    interpolate(sigma) linear;
+    default            linear;
 }
 

--- a/perpendicular-flap-stress/solid-solids4foam/system/fvSchemes
+++ b/perpendicular-flap-stress/solid-solids4foam/system/fvSchemes
@@ -1,0 +1,51 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    object      fvSchemes;
+}
+
+d2dt2Schemes
+{
+    default            backward;
+}
+
+ddtSchemes
+{
+    default            backward;
+}
+
+gradSchemes
+{
+    default            leastSquaresS4f 0;
+}
+
+divSchemes
+{
+    default            Gauss linear;
+}
+
+laplacianSchemes
+{
+    default            none;
+    laplacian(DD,D)    Gauss linear corrected;
+    laplacian(DDD,DD)  Gauss linear corrected;
+}
+
+snGradSchemes
+{
+    default            none;
+    snGrad(D)          corrected;
+    snGrad(DD)         corrected;
+}
+
+interpolationSchemes
+{
+    default            none;
+    interpolate(impK)  linear;
+    interpolate(grad(D)) linear;
+    interpolate(grad(DD)) linear;
+    interpolate(sigma) linear;
+}
+

--- a/perpendicular-flap-stress/solid-solids4foam/system/fvSolution
+++ b/perpendicular-flap-stress/solid-solids4foam/system/fvSolution
@@ -1,0 +1,38 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSolution;
+}
+
+solvers
+{
+    "D|DD"
+    {
+        solver          PCG;
+        preconditioner  FDIC;
+        tolerance       1e-09;
+        relTol          0.1;
+    }
+}
+
+relaxationFactors
+{
+    // Under-relaxating the D equation by 0.99-0.9999 can improve convergence in
+    // some cases, in particular when there are solidContact boundaries
+    equations
+    {
+        //D   0.999;
+    }
+
+    // Under-relaxating the D field by 0.1-0.9 can improve convergence in some
+    // cases
+    fields
+    {
+        //D      0.9;
+    }
+}
+
+

--- a/perpendicular-flap-stress/solid-solids4foam/system/fvSolution
+++ b/perpendicular-flap-stress/solid-solids4foam/system/fvSolution
@@ -9,30 +9,31 @@ FoamFile
 
 solvers
 {
-    "D|DD"
+    D
     {
-        solver          PCG;
-        preconditioner  FDIC;
-        tolerance       1e-09;
-        relTol          0.1;
+        solver    petsc;
+
+        options
+        {
+            snes_type newtonls;
+            snes_linesearch_type basic;
+            snes_max_it "100";
+            snes_monitor;
+            snes_converged_reason;
+
+            snes_mf;
+            snes_mf_operator;
+
+            ksp_type lgmres;
+            ksp_gmres_restart "200";
+            ksp_converged_reason;
+            ksp_rtol "1e-3";
+
+            pc_type bjacobi;
+            sub_pc_type lu;
+
+            snes_lag_preconditioner_persists true;
+            snes_lag_preconditioner "-2";
+        }
     }
 }
-
-relaxationFactors
-{
-    // Under-relaxating the D equation by 0.99-0.9999 can improve convergence in
-    // some cases, in particular when there are solidContact boundaries
-    equations
-    {
-        //D   0.999;
-    }
-
-    // Under-relaxating the D field by 0.1-0.9 can improve convergence in some
-    // cases
-    fields
-    {
-        //D      0.9;
-    }
-}
-
-

--- a/perpendicular-flap-stress/solid-solids4foam/system/preciceDict
+++ b/perpendicular-flap-stress/solid-solids4foam/system/preciceDict
@@ -1,0 +1,46 @@
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      preciceDict;
+}
+
+preciceConfig "../precice-config.xml";
+
+participant Solid;
+
+modules (FSI);
+
+interfaces
+{
+    Interface1
+    {
+        mesh              Solid-Mesh;
+        patches           (interface);
+        locations         faceCenters;
+
+        readData
+        (
+            Stress
+        );
+
+        writeData
+        (
+            Displacement
+        );
+    };
+};
+
+FSI
+{
+    solverType solid;
+
+    // Name of displacement fields
+    namePointDisplacement pointD;
+    nameCellDisplacement D;
+
+    // Name of the stress (traction) field on the solid
+    nameStress solidTraction;
+}

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -528,6 +528,16 @@ test_suites:
         max_time: 0.1
         reference_result: ./perpendicular-flap/reference-results/fluid-su2_solid-fenics.tar.gz
 
+  perpendicular-flap-stress:
+    tutorials:
+      - &perpendicular-flap-stress_fluid-openfoam_solid-solids4foam
+        path: perpendicular-flap-stress
+        case_combination:
+          - fluid-openfoam
+          - solid-solids4foam
+        max_time: 0.1
+        reference_result: ./perpendicular-flap-stress/reference-results/fluid-openfoam_solid-solids4foam.tar.gz
+
   quickstart:
     tutorials:
       - &quickstart_openfoam_cpp
@@ -927,6 +937,7 @@ test_suites:
   solids4foam:
     tutorials:
       - *perpendicular-flap_fluid-openfoam_solid-solids4foam
+      - *perpendicular-flap-stress_fluid-openfoam_solid-solids4foam
 
   su2-adapter:
     tutorials:


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft: blocked on precice/openfoam-adapter#417** ("Support reading Stress in solid participants"). This case cannot run until that adapter change is released, and the reference-results tarball cannot be generated until it reaches the system-test images. Marking ready for review once #417 is merged.

## Summary

Adds a **solids4foam** solid participant to the `perpendicular-flap-stress` tutorial, following the approach of #872/#909 (`perpendicular-flap/solid-solids4foam`) and #912 (`breaking-dam-2d`).

This is the first tutorial case exercising **`Stress` reading** in the OpenFOAM adapter. The interface patch uses the solids4foam `solidTraction` boundary condition, whose `tractionField` option consumes the `solidTraction` volVectorField that the adapter fills:

```c++
// 0/D
interface
{
    type            solidTraction;
    tractionField   solidTraction;
    pressure        uniform 0;
    value           uniform (0 0 0);
}
```

```c++
// system/preciceDict
readData ( Stress );

FSI
{
    solverType    solid;
    nameStress    solidTraction;
}
```

The case is otherwise identical to `perpendicular-flap/solid-solids4foam`: same flap geometry, same linear-elastic material (E = 4e6, nu = 0.3, rho = 3000), same `linearGeometryTotalDisplacement` solid model.

## Results

`perpendicular-flap-stress` is the same physical scenario as `perpendicular-flap` — the two `fluid-openfoam/system/blockMeshDict` files are byte-identical, and only the exchanged data differs (`Stress` with consistent mapping vs `Force` with conservative mapping). That makes the existing `perpendicular-flap/solid-solids4foam` case a direct reference.

Flap-tip x-displacement over the full 5 s run (500 time windows):

| t [s] | perpendicular-flap (Force) | this case (Stress) |
|---|---|---|
| 0.10 | +1.836160e-02 | +1.837240e-02 |
| 0.50 | +1.598337e-01 | +1.593658e-01 |
| 1.00 | +7.382926e-02 | +7.132269e-02 |
| 2.00 | +1.562350e-01 | +1.564509e-01 |
| 5.00 | +1.392887e-01 | +1.383371e-01 |

Peak tip amplitude over the run: **0.165038 (this case) vs 0.166294 (Force path), i.e. 0.76%**. The remaining difference is the expected consequence of the different mapping constraints. The run reports "The momentum equation converged in all time-steps" and completes in under a minute (serial solid).

Tested with OpenFOAM v2606, preCICE 3.4.1, solids4foam (development) and the OpenFOAM adapter from precice/openfoam-adapter#417.

## Notes

* Requires solids4foam v2.2 or later and an OpenFOAM-preCICE adapter with support for reading `Stress` in solid participants.
* The reference-results tarball for `fluid-openfoam_solid-solids4foam` still needs to be generated; the `tests/tests.yaml` entry already points at the expected path.
* This PR and the `elastic-tube-3d` one both add an entry to the `solids4foam` test suite in `tests/tests.yaml`, so whichever merges second will need a trivial rebase there.
* The changelog entry will be renamed to the PR number.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBFTMffUN7qDigrDQrPVb2