### PR TITLE
Remove note to closed issue in heatexchanger tutorial

### DIFF
--- a/heat-exchanger/README.md
+++ b/heat-exchanger/README.md
@@ -43,10 +43,6 @@ preCICE configuration (image generated using the [precice-config-visualizer](htt
 
 ## Running the Simulation
 
-{% note %}
-Since the already prepared case contains mesh files of approx. 50MB in size, we currently host these files outside of the tutorials repository and are downloaded automatically the first time. You can [help us improve this](https://github.com/precice/tutorials/issues/6)!
-{% endnote %}
-
 In order to run the coupled simulation, you can simply step into the participant directories and execute`./run.sh` (or `./run.sh -parallel` for running a fluid participant in parallel). The simulation will need several minutes or up to an hour on a laptop to end (t=500). Before repeating the simulation, you can use the `clean-tutorial.sh` script to clean-up any previous results and log files.
 
 ## Post-processing


### PR DESCRIPTION
Removes this note:

<img width="1202" height="261" alt="image" src="https://github.com/user-attachments/assets/865fc876-1881-4bf1-a412-287e71877e09" />

As the issue was closed due to the simplified heat exchanger tutorial.

https://github.com/precice/tutorials/issues/6

## Checklist

- [ ] I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`.
- [ ] If I changed `requirements.txt` files, I regenerated sibling `requirements-reference.txt` files with `python3 tools/releasing/update-requirements-reference.py` (pass a path to update only that directory, or `--all` to refresh everything).