### PR TITLE
Fix the Julia bindings tests

### DIFF
--- a/tests/dockerfiles/ubuntu_2404/Dockerfile
+++ b/tests/dockerfiles/ubuntu_2404/Dockerfile
@@ -118,7 +118,8 @@ ARG JULIA_BINDINGS_REF
 USER precice
 WORKDIR /home/precice
 
-RUN curl -fsSL https://install.julialang.org | sh -s -- --default-channel=lts --yes
+RUN curl -fsSL https://install.julialang.org | sh -s -- --yes
+ENV PATH="/home/precice/.juliaup/bin:$PATH"
 ### end of julia_bindings stage ###
 
 

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -639,7 +639,7 @@ test_suites:
         case_combination:
           - capacitor-julia
           - coil-julia
-        timeout: 900
+        timeout: 1200
         reference_result: ./resonant-circuit/reference-results/capacitor-julia_coil-julia.tar.gz
 
   resonant-circuit_capacitor-python_coil-python:


### PR DESCRIPTION
The Julia bindings tests have been failing again.

In https://github.com/precice/tutorials/commit/8e1c8b9d5300a9c0f32cb00e75499a451b265b37, I switched from the jill installer to the official one, which worked in a local container, at least up to the point of finding Julia (resolving the reported error). That was not enough.

On top, this PR:

- Switches from the LTS (currently 1.10) to the stable (currently 1.12.7) channel. With the LTS, Julia could not find `libprecice`.
- Adds the Julia installation path to `PATH`. The official installer modifies the `~/.bashrc` to do the same, but the `~/.bashrc` is not loaded in non-interactive runs (or I assume that's why it worked in an interactive docker run, but not on the system tests).
- Increases the timeout from 900s to 1200s. Most of this time is spent in installing Julia packages.

Already tested in https://github.com/precice/tutorials/actions/runs/34400554133