### PR TITLE
Update reference results for FEniCSx v0.11

### DIFF
--- a/flow-over-heated-plate/reference-results/fluid-openfoam_solid-fenicsx.tar.gz
+++ b/flow-over-heated-plate/reference-results/fluid-openfoam_solid-fenicsx.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b31adcb4938e92dd05418425329281f48a86575792fc5063a65f4ef03be058ae
-size 1128130
+oid sha256:906e0fa33755c44f1be8f51fe25d6de8758a79de60485da09ac1db4a651fa94a
+size 1129602


### PR DESCRIPTION
[Since Sep 10](https://github.com/precice/tutorials/actions/runs/34433402878), the test case `flow-over-heated-plate_fluid-openfoam_solid-fenicsx` (only) has been failing with isolated regressions in the heat flux (written by FEniCSx) and fewer and smaller regressions in the temperature. These seem to originate from an update from FEniCSx v0.10 to v0.11.

## Details

Example visualizations at dt100:

<img width="1024" height="768" alt="diff_Solid-Mesh-Solid dt100 point_Heat-Flux" src="https://github.com/user-attachments/assets/4bc6ac0c-bee2-4a73-913a-a347ccdb8942" />
<img width="1024" height="768" alt="diff_Solid-Mesh-Fluid dt100 point_Heat-Flux" src="https://github.com/user-attachments/assets/bda82cad-bcf1-417f-9fa2-f7af25643626" />

Complete archive: 
[system_tests_run_34678500632_1_full.zip](https://github.com/user-attachments/files/32139762/system_tests_run_34678500632_1_full.zip)

The [FEniCS PPA](https://launchpad.net/~fenics-packages/+archive/ubuntu/fenics) seems to have been updated from v0.10.0 to v0.11.0 on Sep 4 ([builds](https://launchpad.net/~fenics-packages/+archive/ubuntu/fenics/+builds?build_text=fenics-dolfinx&build_state=built)). This run also seems to be the first one to use FEniCSx v0.11 (the [revious run](https://github.com/precice/tutorials/actions/runs/34307327473) used v0.10).

Comparing the `pip-installed-packages.log`, the only differences are:

```diff
  attrs==26.1.0
  blinker==1.7.0
  cffi==1.16.0
  cryptography==41.0.7
  dbus-python==1.3.2
  decorator==5.1.1
  distro==1.9.0
  distro-info==1.7+build1
- fenics-basix==0.10.0.post0
- fenics-dolfinx==0.10.0.post2
- fenics-ffcx==0.10.1.post0
- fenics-ufl==2025.2.1
+ fenics-basix==0.11.0
+ fenics-dolfinx==0.11.0.post0
+ fenics-ffcx==0.11.0
+ fenics-ufl==2026.1.0
  fenicsxprecice @ git+https://github.com/precice/fenicsx-adapter.git@c1c338be270477ced082785fc8e2606688dde748
  httplib2==0.20.4
  jsonschema==4.26.0
  jsonschema-specifications==2025.9.1
  launchpadlib==1.11.0
  lazr.restfulclient==0.14.6
  lazr.uri==1.0.6
  mpi4py==3.1.5
  nanobind==2.9.2
  numpy==1.26.4
  oauthlib==3.2.2
  petsc4py==3.19.6
  ply==3.11
  precice-adapter-schema==0.4.1
  pusimp==0.1.1
  pycparser==2.21
  PyGObject==3.48.2
  PyJWT==2.7.0
  pyparsing==3.1.1
  pyprecice==3.4.0
- python-apt==2.7.7+ubuntu5.2
+ python-apt==2.7.7+ubuntu5.3
  referencing==0.37.0
  rpds-py==2026.6.3
  SciPy==1.11.4
  setuptools==68.1.2
  six==1.16.0
  slepc4py==3.19.2
  typing_extensions==4.16.0
  unattended-upgrades==0.1
  wadllib==1.3.6
  wheel==0.42.0
```

No related changes have been committed to the preCICE, OpenFOAM adapter, python-bindings, or FEniCSx adapter repositories in this period. Note that the latest builds of the preCICE base image (and thus, the cache update) were in Sep 10 and previously Sep 2. The update of the FEniCS PPA on Sep 4 fits.

It looks like this numerical difference originates from FEniCSx and is not a regression in our packages.

## Checklist

- I added a summary of any user-facing changes (compared to the last release) in the `changelog-entries/<PRnumber>.md`. -> N/A
- If I changed `requirements.txt` files, I regenerated sibling `requirements-reference.txt` files with `python3 tools/releasing/update-requirements-reference.py` (pass a path to update only that directory, or `--all` to refresh everything). -> The updated packages are not in the `requirements.txt`. We should actually update these files to also cover implicit dependencies.
