### PR TITLE
Add an absolute tolerance to fieldcompare

### DIFF
--- a/quickstart/fluid-openfoam/0/U
+++ b/quickstart/fluid-openfoam/0/U
@@ -35,7 +35,7 @@ boundaryField
     inlet
     {
         type            fixedValue;
-        value           uniform (1 0 0);
+        value           uniform (1.0001 0 0);
     }
 
     outlet

--- a/quickstart/fluid-openfoam/0/U
+++ b/quickstart/fluid-openfoam/0/U
@@ -35,7 +35,7 @@ boundaryField
     inlet
     {
         type            fixedValue;
-        value           uniform (1.0001 0 0);
+        value           uniform (1 0 0);
     }
 
     outlet

--- a/tests/docker-compose.field_compare.template.yaml
+++ b/tests/docker-compose.field_compare.template.yaml
@@ -8,6 +8,7 @@ services:
     command: >
       /bin/bash -c "fieldcompare dir \
       --ignore-missing-reference-files --exclude-files .reference-results-metadata.md --ignore-unsupported-file-formats --diff \
+      -atol 1e-12*max \
       -rtol {{ tolerance }} \
       /runs/{{ tutorial_folder }}/{{ precice_output_folder }} \
       /runs/{{ tutorial_folder }}/{{ reference_output_folder }}"

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -165,6 +165,7 @@ test_suites:
           - fluid-openfoam
           - solid-fenics
         max_time_windows: 1
+        skip_compare: true # See https://github.com/precice/tutorials/issues/853
         reference_result: ./elastic-tube-3d/reference-results/fluid-openfoam_solid-fenics.tar.gz
 
   flow-around-controlled-moving-cylinder_controller-fmi_fluid-openfoam_solid-python:

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -165,7 +165,6 @@ test_suites:
           - fluid-openfoam
           - solid-fenics
         max_time_windows: 1
-        skip_compare: true
         reference_result: ./elastic-tube-3d/reference-results/fluid-openfoam_solid-fenics.tar.gz
 
   flow-around-controlled-moving-cylinder_controller-fmi_fluid-openfoam_solid-python:

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -165,7 +165,6 @@ test_suites:
           - fluid-openfoam
           - solid-fenics
         max_time_windows: 1
-        tolerance: 1e-2    # Some values are too close to zero
         skip_compare: true
         reference_result: ./elastic-tube-3d/reference-results/fluid-openfoam_solid-fenics.tar.gz
 


### PR DESCRIPTION
fieldcompare uses an absolute and a relative difference [source](https://gitlab.com/dglaeser/fieldcompare/-/blob/main/README.md), see also [joss paper](https://doi.org/10.21105/joss.04905):

$$
\vert a - b \vert \leq max(\rho \cdot max(\vert a \vert, \vert b \vert), \epsilon)
$$

Both an `atol` ($$\epsilon$$) and an `rtol` ($$\rho$$) can be specified, and many examples specify both.

As a remedy for artifacts too close to zero, fieldcompare provides the following syntax: `-atol 1e-12*max`

This PR adds such a tolerance to all tests, and removes the higher relative tolerance from elastic-tube-3d_fluid-openfoam_solid-fenics.

Note that another issue (#853) still affects the same test case, so the `skip_compare` cannot be removed. I added a link to that issue as a reminder.

Related to #393.

Testing in https://github.com/precice/tutorials/actions/runs/34692600890 (release)

Testing if regressions are still caught in https://github.com/precice/tutorials/actions/runs/34696650484 (modified the inlet velocity in the Quickstart)
